### PR TITLE
feat(ui): add keyboard accessibility to nostr-profile-badge

### DIFF
--- a/src/nostr-profile-badge/nostr-profile-badge.ts
+++ b/src/nostr-profile-badge/nostr-profile-badge.ts
@@ -83,12 +83,20 @@ export default class NostrProfileBadge extends NostrUserComponent {
   private attachDelegatedListeners() {
 
     // Click anywhere on the profile badge (except follow button, copy buttons)
-    this.delegateEvent('click', '.nostr-profile-badge-container', (e: Event) => {
-      const target = e.target as HTMLElement;
-      if (!target.closest('.nc-copy-btn, .nostr-follow-button-container, nostr-follow-button')) {
-        this.onProfileClick();
-      }
-    });
+this.delegateEvent('click', '.nostr-profile-badge-container', (e: Event) => {
+  const target = e.target as HTMLElement
+  if (!target.closest('.nc-copy-btn, .nostr-follow-button-container, nostr-follow-button')) {
+    this.onProfileClick()
+  }
+})
+
+// Keyboard accessibility (Enter key)
+this.delegateEvent('keydown', '.nostr-profile-badge-container', (e: KeyboardEvent) => {
+  if (e.key === 'Enter') {
+    this.onProfileClick()
+  }
+});
+
 
     // Copy is handled via attachCopyDelegation() using `.nc-copy-btn`
   }

--- a/src/nostr-profile-badge/nostr-profile-badge.ts
+++ b/src/nostr-profile-badge/nostr-profile-badge.ts
@@ -80,26 +80,46 @@ export default class NostrProfileBadge extends NostrUserComponent {
     }
   }
 
-  private attachDelegatedListeners() {
+ private attachDelegatedListeners() {
 
-    // Click anywhere on the profile badge (except follow button, copy buttons)
-this.delegateEvent('click', '.nostr-profile-badge-container', (e: Event) => {
-  const target = e.target as HTMLElement
-  if (!target.closest('.nc-copy-btn, .nostr-follow-button-container, nostr-follow-button')) {
-    this.onProfileClick()
-  }
-})
+  // Click anywhere on the profile badge (except follow button, copy buttons)
+  this.delegateEvent('click', '.nostr-profile-badge-container', (e: Event) => {
+    const target = e.target as HTMLElement
+    if (
+      !target.closest(
+        '.nc-copy-btn, .nostr-follow-button-container, nostr-follow-button'
+      )
+    ) {
+      this.onProfileClick()
+    }
+  })
 
-// Keyboard accessibility (Enter key)
-this.delegateEvent('keydown', '.nostr-profile-badge-container', (e: KeyboardEvent) => {
-  if (e.key === 'Enter') {
-    this.onProfileClick()
-  }
-});
+  // Keyboard accessibility (Enter + Space)
+  this.delegateEvent(
+    'keydown',
+    '.nostr-profile-badge-container',
+    (e: KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        const target = e.target as HTMLElement
 
+        // Ignore nested interactive elements
+        if (
+          target.closest(
+            '.nc-copy-btn, .nostr-follow-button-container, nostr-follow-button'
+          )
+        ) {
+          return
+        }
 
-    // Copy is handled via attachCopyDelegation() using `.nc-copy-btn`
-  }
+        e.preventDefault()
+        e.stopPropagation()
+        this.onProfileClick()
+      }
+    }
+  )
+
+  // Copy is handled via attachCopyDelegation() using `.nc-copy-btn`
+}
 
   protected renderContent() {
     const overall       = this.computeOverall();

--- a/src/nostr-profile-badge/render.ts
+++ b/src/nostr-profile-badge/render.ts
@@ -70,7 +70,13 @@ function renderError(errorMessage: string): string {
 
 function renderContainer(leftContent: string, rightContent: string): string {
   return `
-    <div class='nostr-profile-badge-container'>
+  <div
+      class="nostr-profile-badge-container"
+      tabindex="0"
+      role="button"
+      aria-label="Open Nostr profile"
+    >
+
       <div class='nostr-profile-badge-left-container'>
         ${leftContent}
       </div>

--- a/src/nostr-profile-badge/render.ts
+++ b/src/nostr-profile-badge/render.ts
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: MIT
 
-import { NDKUser, NDKUserProfile } from '@nostr-dev-kit/ndk';
-import { escapeHtml, maskNPub } from '../common/utils';
-import { DEFAULT_PROFILE_IMAGE } from '../common/constants';
-import { renderNpub } from '../base/text-row/render-npub';
-import { renderNip05 } from '../base/text-row/render-nip05';
-import { renderName } from '../base/text-row/render-name';
+import { NDKUser, NDKUserProfile } from '@nostr-dev-kit/ndk'
+import { escapeHtml, maskNPub } from '../common/utils'
+import { DEFAULT_PROFILE_IMAGE } from '../common/constants'
+import { renderNpub } from '../base/text-row/render-npub'
+import { renderNip05 } from '../base/text-row/render-nip05'
+import { renderName } from '../base/text-row/render-name'
 
 export interface RenderProfileBadgeOptions {
-  isLoading: boolean;
-  isError: boolean;
-  errorMessage?: string;
-  userProfile: NDKUserProfile | null;
-  ndkUser: NDKUser | null;
-  showNpub: boolean;
-  showFollow: boolean;
+  isLoading: boolean
+  isError: boolean
+  errorMessage?: string
+  userProfile: NDKUserProfile | null
+  ndkUser: NDKUser | null
+  showNpub: boolean
+  showFollow: boolean
 }
 
 export function renderProfileBadge({
@@ -26,31 +26,45 @@ export function renderProfileBadge({
   showNpub,
   showFollow
 }: RenderProfileBadgeOptions): string {
-
   if (isLoading) {
-    return renderLoading();
+    return renderLoading()
   }
 
   if (isError || userProfile == null) {
-    return renderError(errorMessage || '');
+    return renderError(errorMessage || '')
   }
 
-  const rawName = userProfile.displayName ||
+  const rawName =
+    userProfile.displayName ||
     userProfile.name ||
     maskNPub(ndkUser?.npub || '')
-  const escapedName = escapeHtml(rawName);
-  const profileImage = escapeHtml(userProfile.picture || DEFAULT_PROFILE_IMAGE);
-  const npub = ndkUser?.npub || '';
-  const nip05 = userProfile?.nip05 || '';
-  const pubkey = escapeHtml(ndkUser?.pubkey || '');
+
+  const escapedName = escapeHtml(rawName)
+  const profileImage = escapeHtml(
+    userProfile.picture || DEFAULT_PROFILE_IMAGE
+  )
+
+  const npub = ndkUser?.npub || ''
+  const nip05 = userProfile.nip05 || ''
+  const pubkey = escapeHtml(ndkUser?.pubkey || '')
 
   return renderContainer(
-    `<img src='${profileImage}' alt='Nostr profile image of ${escapedName}' loading="lazy" decoding="async"/>`,
+    `<img
+      src="${profileImage}"
+      alt="Nostr profile image of ${escapedName}"
+      loading="lazy"
+      decoding="async"
+    />`,
     `${renderName({ name: rawName })}
-     ${userProfile.nip05 ? renderNip05(nip05) : ''}
-     ${showNpub === true ? renderNpub(npub || '') : ''}
-     ${showFollow === true && ndkUser?.pubkey ? `<nostr-follow-button pubkey="${pubkey}"></nostr-follow-button>` : ''}`
-  );
+     ${nip05 ? renderNip05(nip05) : ''}
+     ${showNpub ? renderNpub(npub) : ''}
+     ${
+       showFollow && ndkUser?.pubkey
+         ? `<nostr-follow-button pubkey="${pubkey}"></nostr-follow-button>`
+         : ''
+     }`,
+    rawName
+  )
 }
 
 function renderLoading(): string {
@@ -58,31 +72,33 @@ function renderLoading(): string {
     '<div class="skeleton img-skeleton"></div>',
     `<div class="skeleton" style="width: 120px;"></div>
      <div class="skeleton" style="width: 160px;"></div>`
-  );
+  )
 }
 
 function renderError(errorMessage: string): string {
   return renderContainer(
     '<div class="error-icon">&#9888;</div>',
     escapeHtml(errorMessage)
-  );
+  )
 }
 
-function renderContainer(leftContent: string, rightContent: string): string {
+function renderContainer(
+  leftContent: string,
+  rightContent: string,
+  name?: string
+): string {
   return `
-  <div
+    <div
       class="nostr-profile-badge-container"
       tabindex="0"
-      role="button"
-      aria-label="Open Nostr profile"
+      aria-label="Open Nostr profile${name ? ` of ${escapeHtml(name)}` : ''}"
     >
-
-      <div class='nostr-profile-badge-left-container'>
+      <div class="nostr-profile-badge-left-container">
         ${leftContent}
       </div>
-      <div class='nostr-profile-badge-right-container'>
+      <div class="nostr-profile-badge-right-container">
         ${rightContent}
       </div>
     </div>
-  `;
+  `
 }

--- a/src/nostr-profile-badge/style.ts
+++ b/src/nostr-profile-badge/style.ts
@@ -36,18 +36,25 @@ export function getProfileBadgeStyles(): string {
     }
 
     /* Hover state */
-    :host(.is-clickable:hover) {
-      background: var(--nostrc-profile-badge-hover-bg);
-      color: var(--nostrc-profile-badge-hover-color);
-      border: var(--nostrc-profile-badge-hover-border);
-    }
+:host(.is-clickable:hover) {
+  background: var(--nostrc-profile-badge-hover-bg);
+  color: var(--nostrc-profile-badge-hover-color);
+  border: var(--nostrc-profile-badge-hover-border);
+}
 
-    :host(.is-error) .nostr-profile-badge-container {
-      justify-content: center;
-      align-items: center;
-      color: var(--nostrc-color-error-text);
-      border: var(--nostrc-border-width) solid var(--nostrc-color-error-text);
-    }
+/* Focus-visible state for keyboard navigation */
+.nostr-profile-badge-container:focus-visible {
+  outline: 2px solid var(--nostrc-focus-color, currentColor);
+  outline-offset: 2px;
+}
+
+:host(.is-error) .nostr-profile-badge-container {
+  justify-content: center;
+  align-items: center;
+  color: var(--nostrc-color-error-text);
+  border: var(--nostrc-border-width) solid var(--nostrc-color-error-text);
+}
+
     
     .nostr-profile-badge-left-container {
       width: 48px;


### PR DESCRIPTION
Problem
The nostr-profile-badge component was clickable only via mouse, making it inaccessible to keyboard users.

Solution
Added keyboard interaction and focus support.

Changes
- Added Enter key handler for keyboard activation
- Made badge focusable with tabindex
- Added button role and aria-label

Testing
- npm install --legacy-peer-deps
- npm run dev
- Tab to badge and press Enter


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Profile badges are keyboard accessible — Enter and Space activate a profile.
  * Enhanced accessible labeling for badges for better screen reader support.
  * Clear focus-visible styling so focused badges show a visible outline.

* **New Features**
  * Follow controls support a disabled state and expose appropriate ARIA attributes and keyboard focus behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->