### PR TITLE
feat: add disabled state support to nostr-follow-button

### DIFF
--- a/src/nostr-follow-button/nostr-follow-button.ts
+++ b/src/nostr-follow-button/nostr-follow-button.ts
@@ -47,6 +47,8 @@ export default class NostrFollowButton extends NostrUserComponent {
 
   /** Private functions */
   private async handleFollowClick() {
+    if (this.hasAttribute('disabled')) return;
+
     if (this.computeOverall() !== NCStatus.Ready) return;
     const nip07signer = new NDKNip07Signer();
 
@@ -100,30 +102,51 @@ export default class NostrFollowButton extends NostrUserComponent {
   }
 
   protected renderContent() {
-    const isLoading           = this.computeOverall() == NCStatus.Loading;
-    const isFollowing         = this.followStatus.get() == NCStatus.Loading;
-    const isError             = this.computeOverall() === NCStatus.Error;
-    const errorMessage        = super.renderError(this.errorMessage);
-    const showAvatar          = this.hasAttribute('show-avatar');
-    const customText          = this.getAttribute('text') || 'Follow me on nostr';
+  const isLoading           = this.computeOverall() == NCStatus.Loading;
+  const isFollowing         = this.followStatus.get() == NCStatus.Loading;
+  const isError             = this.computeOverall() === NCStatus.Error;
+  const errorMessage        = super.renderError(this.errorMessage);
+  const showAvatar          = this.hasAttribute('show-avatar');
+  const customText          = this.getAttribute('text') || 'Follow me on nostr';
+  const isDisabled          = this.hasAttribute('disabled');
 
-    const renderOptions: RenderFollowButtonOptions = {
-      isLoading   : isLoading,
-      isError     : isError,
-      errorMessage: errorMessage,
-      isFollowed  : this.isFollowed,
-      isFollowing : isFollowing,
-      showAvatar  : showAvatar,
-      user        : this.user,
-      profile     : this.profile,
-      customText  : customText,
-    };
+  const renderOptions: RenderFollowButtonOptions = {
+    isLoading   : isLoading,
+    isError     : isError,
+    errorMessage: errorMessage,
+    isFollowed  : this.isFollowed,
+    isFollowing : isFollowing,
+    showAvatar  : showAvatar,
+    user        : this.user,
+    profile     : this.profile,
+    customText  : customText,
+  };
 
-    this.shadowRoot!.innerHTML = `
-      ${getFollowButtonStyles()}
-      ${renderFollowButton(renderOptions)}
-    `
+  this.shadowRoot!.innerHTML = `
+    ${getFollowButtonStyles()}
+    ${renderFollowButton(renderOptions)}
+  `;
+
+  // Accessibility + disabled handling
+  const container = this.shadowRoot?.querySelector(
+    '.nostr-follow-button-container'
+  ) as HTMLElement | null;
+
+  if (container) {
+    container.setAttribute('role', 'button');
+    container.setAttribute('aria-pressed', String(this.isFollowed));
+
+    if (isDisabled) {
+      container.setAttribute('aria-disabled', 'true');
+      container.setAttribute('tabindex', '-1');
+    } else {
+      container.removeAttribute('aria-disabled');
+      container.setAttribute('tabindex', '0');
+    }
   }
+}
+
+ 
 }
 
 customElements.define('nostr-follow-button', NostrFollowButton);


### PR DESCRIPTION
Adds support for a `disabled` attribute on `nostr-follow-button`.

When disabled:
- Interaction is blocked
- Keyboard focus is disabled
- Appropriate ARIA attributes are applied

This allows consumers to safely control button state during loading
or when follow actions are not available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the disabled state and refined error messaging when user resolution fails.

* **Accessibility**
  * Added proper ARIA attributes (role, pressed, disabled) and updated keyboard focus behavior for disabled states.

* **Refactor**
  * Switched from delegated to direct click handling and tightened equality checks to improve reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->