### PR TITLE
Fix docs drift in like, zap, and auth documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,19 +64,21 @@ Then import components in your JavaScript/TypeScript:
 import 'nostr-components';
 ```
 
+<!-- Keep this shared auth/docs copy aligned with stories/Introduction.mdx and the active Like/Zap specs. -->
 ### Authentication
 
-All interactive components (Follow, Like, Zap) require user authentication. Components use [window.nostr.js](https://github.com/fiatjaf/window.nostr.js) which supports:
+All interactive components (Follow, Like, Zap) require user authentication. Components lazily load [window.nostr.js](https://github.com/fiatjaf/window.nostr.js) on first interaction, which supports:
 - **NIP-07 Browser Extensions** (Alby, nos2x, etc.)
 - **NIP-46 Remote Signers** (Bunkers)
 
-The script is loaded automatically on first interaction — no setup required. Users without an extension will see a floating widget to connect their Nostr account.
+No host-page setup is required. Users can connect with an existing signer or through the floating `window.nostr.js` widget when prompted.
 
 ---
 
 ## 1. Nostr Zap
 
-A Zap button that allows users to send sats to any Nostr user or a URL associated with a User.
+A Zap button that sends sats to a Nostr user and can optionally scope those zaps to a specific URL for open-web attribution.
+When `url` is provided, the component uses a deterministic `["a", "39735:<pubkey>:<normalized_url>"]` tag so relays can apply URL-specific `#a` filtering when fetching zap receipts.
 What is [Zap](https://www.youtube.com/shorts/PDnrh8pkF3g)? 
 
 **Usage:**
@@ -91,7 +93,7 @@ What is [Zap](https://www.youtube.com/shorts/PDnrh8pkF3g)?
 <body>
   <nostr-zap-button 
     npub="npub1qsvv5ttv6mrlh38q8ydmw3gzwq360mdu8re2vr7rk68sqmhmsh4svhsft3"
-    theme="dark"
+    data-theme="dark"
     url="https://nostr-components.web.app/"
     text="⚡ Zap Me"
   ></nostr-zap-button>
@@ -132,8 +134,8 @@ A simple button that allows users to follow a Nostr profile.
 
 ## 3. Nostr Like
 
-A like button that uses NIP-25 (External Content Reactions) to like any URL on the web.
-When URL is not specified, current URL is taken.
+A like button that uses NIP-25 external content reactions to like or unlike any URL on the web and display the net reaction count.
+If `url` is omitted, the component automatically uses the current page URL.
 
 **Usage:**
 

--- a/src/nostr-like-button/spec/implementation.md
+++ b/src/nostr-like-button/spec/implementation.md
@@ -1,8 +1,8 @@
-# Nostr Like Component - Technical Implementation
+# Nostr Like Button - Technical Implementation
 
 ## Overview
 
-This document contains the technical implementation details for the `nostr-like` component. For component usage and API specifications, see [spec.md](./spec.md).
+This document contains the technical implementation details for the `nostr-like-button` component. For component usage and API specifications, see [spec.md](./spec.md).
 
 ## Architecture
 
@@ -41,6 +41,7 @@ This document contains the technical implementation details for the `nostr-like`
 ### Internal Dependencies
 - NostrBaseComponent: Base class with relay and status management
 - NostrService: Relay connection management
+- Nostr Login Service: Lazy-loads `window.nostr.js`, resolves the current signer, and signs events
 - getComponentStyles(): Utility for CSS injection
 - Common Utils: `formatRelativeTime()`
 - Zap Utils: `getBatchedProfileMetadata()` (reused for profile fetching)
@@ -62,15 +63,15 @@ This document contains the technical implementation details for the `nostr-like`
 ### Like/Unlike Action Flow
 ```typescript
 handleLikeClick():
-  - Check NIP-07 availability → error if not available
-  - Get user's pubkey via NIP-07
+  - Ensure window.nostr.js is initialized → error if no signer is available
+  - Get user's pubkey via the connected signer
   - Check if user has already liked this URL
   - If liked: show confirmation dialog → handleUnlike() if confirmed
   - If not liked: handleLike()
 
 handleLike():
   - Create kind 17 event with content: '+'
-  - Sign with NIP-07
+  - Sign with window.nostr.js
   - Publish to relays
   - Optimistic update: isLiked = true, count++
   - Refresh like count
@@ -78,7 +79,7 @@ handleLike():
 
 handleUnlike():
   - Create kind 17 event with content: '-'
-  - Sign with NIP-07
+  - Sign with window.nostr.js
   - Publish to relays
   - Optimistic update: isLiked = false, count--
   - Refresh like count
@@ -87,7 +88,7 @@ handleUnlike():
 
 ## Utility Functions
 
-### Like-Specific Utilities (`src/nostr-like/like-utils.ts`)
+### Like-Specific Utilities (`src/nostr-like-button/like-utils.ts`)
 
 ```typescript
 fetchLikesForUrl(url, relays):
@@ -112,7 +113,7 @@ hasUserLiked(url, userPubkey, relays):
 
 ### Reused Utilities
 - `formatRelativeTime()` from `src/common/utils.ts`
-- `getBatchedProfileMetadata()` from `src/nostr-zap/zap-utils.ts`
+- `getBatchedProfileMetadata()` from `src/nostr-zap-button/zap-utils.ts`
 
 ## Like Count
 
@@ -160,7 +161,7 @@ hasUserLiked(url, userPubkey, relays):
 ## File Structure
 
 ```
-src/nostr-like/
+src/nostr-like-button/
 ├── nostr-like.ts              # Main component class
 ├── render.ts                  # Rendering logic
 ├── style.ts                   # Component styles

--- a/src/nostr-like-button/spec/spec.md
+++ b/src/nostr-like-button/spec/spec.md
@@ -1,8 +1,8 @@
-# Nostr Like Component Specification
+# Nostr Like Button Specification
 
 ## Overview
 
-- Component: `nostr-like`
+- Component: `nostr-like-button`
 - Purpose: Like/unlike web pages using Nostr reactions
 - Architecture: Extends `NostrBaseComponent`
 - NIP: [NIP-25 External Content Reactions (kind 17)](https://github.com/nostr-protocol/nips/blob/master/25.md#external-content-reactions)
@@ -11,7 +11,7 @@
 
 - Display like button with thumbs-up icon and like count
 - Show net like count (likes minus unlikes) for current or specified URL
-- Click button to like (one-way action initially)
+- Click button to like and optionally unlike later
 - If already liked, show confirmation dialog to unlike
 - Unlike publishes kind 17 event with '-' content
 - Click count to view individual likers/dislikers in modal
@@ -22,8 +22,8 @@
 
 ### Like
 1. User clicks like button
-2. Check for NIP-07 extension (browser signer) // TODO: Onboarding module
-3. Check current user's like status
+2. Ensure `window.nostr.js` is available and a signer is connected
+3. Check the current user's like status
 4. If not liked, create kind 17 reaction event with '+' content
 5. Request user signature
 6. Broadcast to relays
@@ -32,8 +32,8 @@
 
 ### Unlike
 1. User clicks like button (when already liked)
-2. Check for NIP-07 extension (browser signer) // TODO: Onboarding module
-3. Check current user's like status
+2. Ensure `window.nostr.js` is available and a signer is connected
+3. Check the current user's like status
 4. Show confirmation dialog: "You have already liked this. Do you want to unlike it?"
 5. If confirmed, create kind 17 reaction event with '-' content
 6. Request user signature
@@ -187,36 +187,36 @@ No Likes:
 
 Basic (likes current page):
 ```html
-<nostr-like></nostr-like>
+<nostr-like-button></nostr-like-button>
 ```
 
 Specific URL:
 ```html
-<nostr-like url="https://saiy2k.in/2025/04/01/nostr-components/"></nostr-like>
+<nostr-like-button url="https://saiy2k.in/2025/04/01/nostr-components/"></nostr-like-button>
 ```
 
 Custom text:
 ```html
-<nostr-like text="Love it!"></nostr-like>
+<nostr-like-button text="Love it!"></nostr-like-button>
 ```
 
 Dark theme:
 ```html
-<nostr-like data-theme="dark"></nostr-like>
+<nostr-like-button data-theme="dark"></nostr-like-button>
 ```
 
 Custom relays:
 ```html
-<nostr-like relays="wss://relay1.com,wss://relay2.com"></nostr-like>
+<nostr-like-button relays="wss://relay1.com,wss://relay2.com"></nostr-like-button>
 ```
 
 Custom styling:
 ```html
-<nostr-like style="
+<nostr-like-button style="
   --nostrc-icon-width: 24px;
   --nostrc-like-btn-bg: #f0f0f0;
   --nostrc-like-btn-liked-color: #ff0000;
-"></nostr-like>
+"></nostr-like-button>
 ```
 
 ## Likers Dialog
@@ -246,12 +246,13 @@ Each reaction entry shows:
 
 **Features:**
 - One-click liking of any URL
+- Optional unlike flow with confirmation
 - View who liked your content
 - See total like counts
 - All data stored on Nostr relays
 
 **Requirement:**
-Requires a Nostr browser extension (Alby, nos2x, etc.) to sign and publish likes. // TODO:Onboarding
+Requires a connected signer via `window.nostr.js` (for example an extension-backed NIP-07 signer or a NIP-46 remote signer) to sign and publish likes.
 
 ## NIP-25 Event Structure
 
@@ -283,9 +284,8 @@ Requires a Nostr browser extension (Alby, nos2x, etc.) to sign and publish likes
 ## Future Enhancements
 
 - Reaction emoji support (heart, fire, etc.) beyond just like (+) /unlike (-)
-- Anonymous reactions (without NIP-07)
+- Anonymous reactions (without a connected signer)
 - Bulk profile fetching optimization (NIP-45)
 - Pagination for 1000+ likes
 - Real-time updates via subscriptions
-
 

--- a/src/nostr-like-button/spec/testing.md
+++ b/src/nostr-like-button/spec/testing.md
@@ -1,10 +1,10 @@
-# Nostr-like Component – Testing Considerations
+# Nostr Like Button – Testing Considerations
 
 ## Functional Tests
 
-- Test like action with NIP-07
+- Test like action with a connected signer via `window.nostr.js`
 - Test unlike action with confirmation dialog
-- Test without NIP-07 (error state)
+- Test without a connected signer (error state)
 - Test with 0 likes
 - Test with 1 like
 - Test with many likes (100+)

--- a/src/nostr-zap-button/spec/implementation.md
+++ b/src/nostr-zap-button/spec/implementation.md
@@ -1,8 +1,8 @@
-# Nostr Zap Component - Technical Implementation
+# Nostr Zap Button - Technical Implementation
 
 ## Overview
 
-This document contains the technical implementation details for the `nostr-zap` component. For component usage and API specifications, see [spec.md](./spec.md).
+This document contains the technical implementation details for the `nostr-zap-button` component. For component usage and API specifications, see [spec.md](./spec.md).
 
 ## Architecture
 
@@ -54,6 +54,7 @@ This document contains the technical implementation details for the `nostr-zap` 
 - NostrUserComponent: Base class for user-specific components
 - UserResolver: User identity validation and resolution
 - NostrService: Relay connection management
+- Nostr Login Service: Lazy-loads `window.nostr.js` and signs zap requests when a connected signer is available
 - getComponentStyles(): Utility for CSS injection with design tokens
 - Common Utils: `decodeNpub()` and `decodeNip19Entity()` for NIP-19 decoding
 
@@ -97,7 +98,7 @@ All dialogs use the shared `DialogComponent` base class (see `src/base/dialog-co
 - WebLN Integration: Direct wallet connection
 - Copy Functionality: Clipboard API for invoice copying
 - Payment Confirmation: Uses `listenForZapReceipt()` to detect successful payments
-- URL-Based Zaps: Passes URL parameter through `OpenZapModalParams` for NIP-73 compliance
+- URL-Based Zaps: Passes URL parameter through `OpenZapModalParams` for URL-based zap correlation and receipt filtering
 - Success State: Shows "⚡ Thank you!" overlay and hides controls
 
 ### Help Dialog Features
@@ -142,7 +143,7 @@ All dialogs use the shared `DialogComponent` base class (see `src/base/dialog-co
 - `decodeNpub()`: Decodes npub strings to hex pubkeys
 - `decodeNip19Entity()`: General NIP-19 entity decoder
 
-### Zap-Specific Utilities (`src/nostr-zap/zap-utils.ts`)
+### Zap-Specific Utilities (`src/nostr-zap-button/zap-utils.ts`)
 - `fetchTotalZapAmount()`: Fetches total and individual zap data with relay-side URL filtering via `#a`
 - `buildUrlATag()`: Computes the deterministic `a` tag value (`39735:pubkey:url`) for a given recipient pubkey and URL
 - `getProfileMetadata()`: Caches user profile data

--- a/src/nostr-zap-button/spec/spec.md
+++ b/src/nostr-zap-button/spec/spec.md
@@ -88,7 +88,7 @@ Button:
 
 ## Wireframes
 
-![Nostr Zap Component Wireframes](./wireframes.png)
+![Nostr Zap Component Wireframe](./wireframe.png)
 
 ### States
 

--- a/stories/Introduction.mdx
+++ b/stories/Introduction.mdx
@@ -78,19 +78,21 @@ Then import components in your JavaScript/TypeScript:
 import 'nostr-components';
 ```
 
+{/* Keep this shared auth/docs copy aligned with README.md and the active Like/Zap specs. */}
 ### Authentication
 
-All interactive components (Follow, Like, Zap) require user authentication. Components use [window.nostr.js](https://github.com/fiatjaf/window.nostr.js) which supports:
+All interactive components (Follow, Like, Zap) require user authentication. Components lazily load [window.nostr.js](https://github.com/fiatjaf/window.nostr.js) on first interaction, which supports:
 - **NIP-07 Browser Extensions** (Alby, nos2x, etc.)
 - **NIP-46 Remote Signers** (Bunkers)
 
-The script is loaded automatically on first interaction — no setup required. Users without an extension will see a floating widget to connect their Nostr account.
+No host-page setup is required. Users can connect with an existing signer or through the floating `window.nostr.js` widget when prompted.
 
 ---
 
 ## 1. Nostr Zap
 
-A Zap button that allows users to send sats to any Nostr user or a URL associated with a User.
+A Zap button that sends sats to a Nostr user and can optionally scope those zaps to a specific URL for open-web attribution.
+When `url` is provided, the component uses a deterministic `["a", "39735:<pubkey>:<normalized_url>"]` tag so relays can apply URL-specific `#a` filtering when fetching zap receipts.
 What is [Zap](https://www.youtube.com/shorts/PDnrh8pkF3g)? 
 
 **Usage:**
@@ -105,7 +107,7 @@ What is [Zap](https://www.youtube.com/shorts/PDnrh8pkF3g)?
 <body>
   <nostr-zap-button 
     npub="npub1qsvv5ttv6mrlh38q8ydmw3gzwq360mdu8re2vr7rk68sqmhmsh4svhsft3"
-    theme="dark"
+    data-theme="dark"
     url="https://nostr-components.web.app/"
     text="⚡ Zap Me"
   ></nostr-zap-button>
@@ -146,8 +148,8 @@ A simple button that allows users to follow a Nostr profile.
 
 ## 3. Nostr Like
 
-A like button that uses NIP-25 (External Content Reactions) to like any URL on the web.
-When URL is not specified, current URL is taken.
+A like button that uses NIP-25 external content reactions to like or unlike any URL on the web and display the net reaction count.
+If `url` is omitted, the component automatically uses the current page URL.
 
 **Usage:**
 

--- a/stories/nostr-like/NostrLike.stories.tsx
+++ b/stories/nostr-like/NostrLike.stories.tsx
@@ -13,7 +13,9 @@ const meta: Meta = {
   parameters: {
     docs: {
       description: {
-        component: 'A web component that displays a like button for URLs using NIP-25 External Content Reactions (kind 17). Supports URL-based likes with theme customization and shows like counts with clickable likers list.\n\n**Features:**\n- One-way like action (no unlike)\n- Automatic URL detection from current page\n- NIP-07 signing support\n- Progressive profile loading in likers dialog\n\n⚠️ **Scalability Limitation:** The component queries up to 1000 reaction events per URL. For viral content, like counts and likers lists may be incomplete.',
+        // Keep this description aligned with README.md, stories/Introduction.mdx,
+        // and src/nostr-like-button/spec/spec.md.
+        component: 'A web component that displays a like button for URLs using NIP-25 External Content Reactions (kind 17). Supports URL-based likes with theme customization and shows net like counts with a clickable likers list.\n\n**Features:**\n- Like and unlike support with confirmation before unlike\n- Automatic URL detection from the current page\n- Connected signer support via `window.nostr.js` (NIP-07 / NIP-46)\n- Progressive profile loading in the likers dialog\n\n⚠️ **Scalability Limitation:** The component queries up to 1000 reaction events per URL. For viral content, net like counts and likers lists may be incomplete.',
       },
       source: {
         transform: (code, storyContext) =>

--- a/stories/nostr-zap/NostrZap.stories.tsx
+++ b/stories/nostr-zap/NostrZap.stories.tsx
@@ -11,7 +11,9 @@ const meta: Meta = {
   parameters: {
     docs: {
       description: {
-        component: 'A web component that displays a zap button for Nostr profiles. Supports npub, nip05, and pubkey inputs with theme customization, zap amount configuration, and URL-based zaps for content creators.\n\n**Note on URL-based zaps:** Zap receipts don\'t carry `#k` or `#i` tags. URL-specific totals are derived by parsing the zap request stored in the receipt\'s description field.\n\n⚠️ **Scalability Limitation:** The component queries up to 1000 zap receipt events per user. For high-traffic creators, total zap amounts and zappers lists may be incomplete.',
+        // Keep this description aligned with README.md, stories/Introduction.mdx,
+        // and src/nostr-zap-button/spec/spec.md.
+        component: 'A web component that displays a zap button for Nostr profiles. Supports npub, nip05, and pubkey inputs with theme customization, zap amount configuration, and URL-based zaps for content creators.\n\n**URL-based zaps:** When `url` is provided, zap requests include `["a", "39735:<recipient_pubkey>:<normalized_url>"]`. NIP-57 relays copy that tag into zap receipts, enabling relay-side `#a` filtering for URL-specific totals and zappers lists.\n\n⚠️ **Scalability Limitation:** The component queries up to 1000 matching zap receipt events. For high-traffic creators, total zap amounts and zappers lists may be incomplete.',
       },
       source: {
         transform: (code, storyContext) =>


### PR DESCRIPTION
## Summary

This PR aligns the repo-tracked documentation with the current implementation for the active Like, Zap, and authentication flows.

Closes #70 

The main goal is to make sure new contributors and users can understand the current behavior from the docs directly, without having to reverse-engineer it from the source.

## What changed

- Updated the README and Storybook introduction docs to reflect the current auth flow through `window.nostr.js`
- Updated public-facing Like docs to describe the current like/unlike behavior and net count model
- Updated public-facing Zap docs to describe the current URL-based zap flow using deterministic `a` tags and relay-side `#a` filtering
- Replaced outdated example markup using `theme="dark"` with the current `data-theme="dark"` usage in the touched docs
- Synced the Storybook Like and Zap component descriptions with current runtime behavior
- Updated Like and Zap spec / implementation docs to use the current public component names:
  - `nostr-like-button`
  - `nostr-zap-button`
- Corrected stale auth wording in spec docs that still implied an older NIP-07-only flow
- Corrected stale internal path references in the Like/Zap implementation docs
- Fixed the zap spec wireframe image reference
- Added lightweight maintainer-facing comments near duplicated docs copy to make future drift less likely

## Why this matters

Some docs were still describing older behavior, especially around:
- URL-based zap receipt fetching
- signer/auth setup
- Like button capabilities
- current component naming

That made it easy to build the wrong mental model of the repo, especially for new contributors working on open-web Like/Zap features.

## Verification

- Ran `npm test -- --run`
- Ran `npm run build-storybook`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication flow documentation to clarify that interactive components lazy-load on first interaction.
  * Expanded Like button documentation to detail like/unlike behavior with confirmation dialogs and net reaction count display.
  * Clarified Zap button URL-scoping functionality with deterministic tag support for relay filtering.
  * Updated theming attribute syntax from `theme="dark"` to `data-theme="dark"` in documentation examples.
  * Refined component descriptions across setup guides and Storybook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->