### PR TITLE
Add show-replies support to nostr-post

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,9 @@ A detailed profile card showing avatar, name, bio, notes count, followers, etc.
 
 ## 6. Nostr Post
 
-Embed any Nostr post by providing the event ID.
+Embed any Nostr post by providing a note ID, event ID, or raw hex event ID.
+
+Use `show-stats="true"` to display like/reply counts, and `show-replies="true"` to start with the minimal replies list expanded below the post.
 
 **Usage:**
 
@@ -228,7 +230,9 @@ Embed any Nostr post by providing the event ID.
 </head>
 <body>
   <nostr-post
-    eventId="note1t2jvt5vpusrwrxkfu8x8r7q65zzvm32xuur6y7am4zn475r8ucjqmwwhd2"
+    noteid="note1t2jvt5vpusrwrxkfu8x8r7q65zzvm32xuur6y7am4zn475r8ucjqmwwhd2"
+    show-stats="true"
+    show-replies="true"
   ></nostr-post>
 </body>
 ```

--- a/README.md
+++ b/README.md
@@ -218,7 +218,9 @@ A detailed profile card showing avatar, name, bio, notes count, followers, etc.
 
 ## 6. Nostr Post
 
-Embed any Nostr post by providing the event ID.
+Embed any Nostr post by providing a note ID, event ID, or raw hex event ID.
+
+Use `show-stats="true"` to display like/reply counts, and `show-replies="true"` to start with the minimal replies list expanded below the post.
 
 **Usage:**
 
@@ -230,7 +232,9 @@ Embed any Nostr post by providing the event ID.
 </head>
 <body>
   <nostr-post
-    eventId="note1t2jvt5vpusrwrxkfu8x8r7q65zzvm32xuur6y7am4zn475r8ucjqmwwhd2"
+    noteid="note1t2jvt5vpusrwrxkfu8x8r7q65zzvm32xuur6y7am4zn475r8ucjqmwwhd2"
+    show-stats="true"
+    show-replies="true"
   ></nostr-post>
 </body>
 ```

--- a/src/common/__tests__/utils-direct-reply.test.ts
+++ b/src/common/__tests__/utils-direct-reply.test.ts
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect } from 'vitest';
+import { NDKEvent } from '@nostr-dev-kit/ndk';
+import {
+  filterDirectReplies,
+  getDirectReplyParentId,
+  isDirectReplyToEvent,
+} from '../utils';
+
+const ROOT = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const PARENT = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const MENTION = 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+const OTHER = 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+
+function createMockReply(tags: string[][]): NDKEvent {
+  return {
+    tags,
+    id: 'reply-event-id',
+    kind: 1,
+    pubkey: 'reply-author',
+    created_at: 1,
+    content: 'reply',
+    sig: '',
+  } as unknown as NDKEvent;
+}
+
+describe('getDirectReplyParentId', () => {
+  it('returns null when there are no e tags', () => {
+    const reply = createMockReply([]);
+
+    expect(getDirectReplyParentId(reply)).toBeNull();
+  });
+
+  it('uses a single positional e tag as the parent', () => {
+    const reply = createMockReply([['e', PARENT, '']]);
+
+    expect(getDirectReplyParentId(reply)).toBe(PARENT);
+  });
+
+  it('uses a marked reply tag as the parent', () => {
+    const reply = createMockReply([
+      ['e', ROOT, '', 'root'],
+      ['e', PARENT, '', 'reply'],
+    ]);
+
+    expect(getDirectReplyParentId(reply)).toBe(PARENT);
+  });
+
+  it('uses a marked root tag for top-level replies', () => {
+    const reply = createMockReply([['e', ROOT, '', 'root']]);
+
+    expect(getDirectReplyParentId(reply)).toBe(ROOT);
+  });
+
+  it('uses the last positional e tag for legacy multi-e replies', () => {
+    const reply = createMockReply([
+      ['e', ROOT, ''],
+      ['e', MENTION, ''],
+      ['e', PARENT, ''],
+    ]);
+
+    expect(getDirectReplyParentId(reply)).toBe(PARENT);
+  });
+
+  it('uses the last positional e tag when the parent is only cited as a mention', () => {
+    const reply = createMockReply([
+      ['e', ROOT, ''],
+      ['e', MENTION, ''],
+      ['e', OTHER, ''],
+    ]);
+
+    expect(getDirectReplyParentId(reply)).toBe(OTHER);
+  });
+});
+
+describe('isDirectReplyToEvent', () => {
+  it('returns true for a single direct positional reply', () => {
+    const reply = createMockReply([['e', PARENT, '']]);
+
+    expect(isDirectReplyToEvent(reply, PARENT)).toBe(true);
+  });
+
+  it('returns true for a marked nested reply', () => {
+    const reply = createMockReply([
+      ['e', ROOT, '', 'root'],
+      ['e', PARENT, '', 'reply'],
+    ]);
+
+    expect(isDirectReplyToEvent(reply, PARENT)).toBe(true);
+  });
+
+  it('returns true for a top-level reply marked with root only', () => {
+    const reply = createMockReply([['e', ROOT, '', 'root']]);
+
+    expect(isDirectReplyToEvent(reply, ROOT)).toBe(true);
+  });
+
+  it('returns true for a legacy multi-e reply when the parent is last', () => {
+    const reply = createMockReply([
+      ['e', ROOT, ''],
+      ['e', MENTION, ''],
+      ['e', PARENT, ''],
+    ]);
+
+    expect(isDirectReplyToEvent(reply, PARENT)).toBe(true);
+  });
+
+  it('returns false when the parent is only a cited mention', () => {
+    const reply = createMockReply([
+      ['e', ROOT, ''],
+      ['e', PARENT, ''],
+      ['e', OTHER, ''],
+    ]);
+
+    expect(isDirectReplyToEvent(reply, PARENT)).toBe(false);
+  });
+
+  it('returns false for a different parent', () => {
+    const reply = createMockReply([['e', PARENT, '']]);
+
+    expect(isDirectReplyToEvent(reply, OTHER)).toBe(false);
+  });
+
+  it('returns false for an empty parent id', () => {
+    const reply = createMockReply([['e', PARENT, '']]);
+
+    expect(isDirectReplyToEvent(reply, '')).toBe(false);
+  });
+});
+
+describe('filterDirectReplies', () => {
+  it('keeps only direct replies for the parent event', () => {
+    const direct = createMockReply([['e', PARENT, '']]);
+    const nested = createMockReply([
+      ['e', ROOT, '', 'root'],
+      ['e', OTHER, '', 'reply'],
+    ]);
+    const mentionOnly = createMockReply([
+      ['e', ROOT, ''],
+      ['e', PARENT, ''],
+      ['e', OTHER, ''],
+    ]);
+
+    const result = filterDirectReplies([direct, nested, mentionOnly], PARENT);
+
+    expect(result).toEqual([direct]);
+  });
+});

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -88,6 +88,27 @@ export type Stats = {
   replies: number;
 };
 
+export function isDirectReplyToEvent(reply: NDKEvent, parentEventId: string): boolean {
+  if (!parentEventId) return false;
+
+  const eTags = reply.tags.filter(tag => tag[0] === 'e');
+  if (eTags.length === 0) return false;
+
+  const matchingETags = eTags.filter(tag => tag[1] === parentEventId);
+  if (matchingETags.length === 0) return false;
+
+  return eTags.length === 1 || matchingETags.some(tag => tag[3] === 'reply');
+}
+
+export function filterDirectReplies(
+  replies: Iterable<NDKEvent>,
+  parentEventId: string
+): NDKEvent[] {
+  return Array.from(replies).filter(reply =>
+    isDirectReplyToEvent(reply, parentEventId)
+  );
+}
+
 export async function getPostStats(ndk: NDK, postId: string): Promise<Stats> {
   const reposts = await ndk.fetchEvents({
     kinds: [NDKKind.Repost],
@@ -97,11 +118,6 @@ export async function getPostStats(ndk: NDK, postId: string): Promise<Stats> {
   const isDirectRepost = (repost: NDKEvent): boolean => {
     const pTagCounts = repost.tags.filter(tag => tag[0] === 'p').length;
     return pTagCounts === 1;
-  };
-
-  const isDirectReply = (reply: NDKEvent): boolean => {
-    const eTagsCount = reply.tags.filter(tag => tag[0] === 'e').length;
-    return eTagsCount === 1;
   };
 
   // Only take the count of direct reposts
@@ -154,9 +170,7 @@ export async function getPostStats(ndk: NDK, postId: string): Promise<Stats> {
     '#e': [postId || ''],
   });
 
-  // Only take the direct replies
-  // https://github.com/nostr-protocol/nips/blob/master/10.md#positional-e-tags-deprecated
-  const replyCount = Array.from(replies).filter(isDirectReply).length;
+  const replyCount = filterDirectReplies(replies, postId).length;
 
   return {
     likes: likes.size,
@@ -198,9 +212,22 @@ export function parseBooleanAttribute(attr: string | null): boolean {
 }
 
 export function escapeHtml(text: string): string {
-  const div = document.createElement('div');
-  div.textContent = text;
-  return div.innerHTML;
+  return String(text).replace(/[&<>"']/g, char => {
+    switch (char) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      case '\'':
+        return '&#39;';
+      default:
+        return char;
+    }
+  });
 }
 
 export function isValidUrl(url: string): boolean {

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -88,16 +88,24 @@ export type Stats = {
   replies: number;
 };
 
+export function getDirectReplyParentId(reply: NDKEvent): string | null {
+  const eTags = reply.tags.filter(tag => tag[0] === 'e');
+  if (eTags.length === 0) return null;
+
+  const replyTag = eTags.find(tag => tag[3] === 'reply');
+  if (replyTag?.[1]) return replyTag[1];
+
+  const rootTag = eTags.find(tag => tag[3] === 'root');
+  if (rootTag?.[1]) return rootTag[1];
+
+  if (eTags.length === 1) return eTags[0][1] ?? null;
+
+  return eTags[eTags.length - 1][1] ?? null;
+}
+
 export function isDirectReplyToEvent(reply: NDKEvent, parentEventId: string): boolean {
   if (!parentEventId) return false;
-
-  const eTags = reply.tags.filter(tag => tag[0] === 'e');
-  if (eTags.length === 0) return false;
-
-  const matchingETags = eTags.filter(tag => tag[1] === parentEventId);
-  if (matchingETags.length === 0) return false;
-
-  return eTags.length === 1 || matchingETags.some(tag => tag[3] === 'reply');
+  return getDirectReplyParentId(reply) === parentEventId;
 }
 
 export function filterDirectReplies(

--- a/src/nostr-post/nostr-post.ts
+++ b/src/nostr-post/nostr-post.ts
@@ -1,14 +1,20 @@
 // SPDX-License-Identifier: MIT
 
-import { NDKEvent } from '@nostr-dev-kit/ndk';
+import { NDKEvent, NDKUserProfile } from '@nostr-dev-kit/ndk';
 import Glide from '@glidejs/glide';
-import { getPostStats, Stats } from '../common/utils';
+import {
+  filterDirectReplies,
+  getPostStats,
+  parseBooleanAttribute,
+  Stats,
+} from '../common/utils';
 import { renderPost, RenderPostOptions } from './render';
 import { parseText } from './parse-text';
 import { renderContent, replaceEmbeddedPostPlaceholders } from './render-content';
 import { NostrEventComponent } from '../base/event-component/nostr-event-component';
 import { NCStatus } from '../base/base-component/nostr-base-component';
 import { getPostStyles } from './style';
+import { buildReplyItem, ReplyItem } from './reply-utils';
 
 const EVT_POST = 'nc:post';
 const EVT_AUTHOR = 'nc:author';
@@ -19,13 +25,21 @@ export default class NostrPost extends NostrEventComponent {
   protected stats: Stats | null = null;
   protected statsLoading: boolean = false;
   protected embeddedPosts: Map<string, NDKEvent> = new Map();
+  protected replyItems: ReplyItem[] = [];
+  protected repliesExpanded: boolean = false;
+  protected repliesLoaded: boolean = false;
+  protected repliesLoading: boolean = false;
+  protected repliesError: string | null = null;
   private glideInitialized: boolean = false;
   private cachedParsedContent: string | null = null;
   private cachedHtmlToRender: string | null = null;
+  private statsRequestSeq: number = 0;
+  private repliesRequestSeq: number = 0;
 
   async connectedCallback() {
     super.connectedCallback?.();
     this.attachDelegatedListeners();
+    this.repliesExpanded = this.shouldShowReplies();
     this.render();
   }
 
@@ -33,6 +47,7 @@ export default class NostrPost extends NostrEventComponent {
     return [
       ...super.observedAttributes,
       'show-stats',
+      'show-replies',
     ];
   }
 
@@ -44,6 +59,21 @@ export default class NostrPost extends NostrEventComponent {
     if (oldValue === newValue) return;
     super.attributeChangedCallback?.(name, oldValue, newValue);
     if (name === 'show-stats') {
+      if (this.shouldShowStats() && this.event) {
+        void this.getPostStats();
+      } else {
+        this.resetStatsState();
+        this.render();
+      }
+    }
+
+    if (name === 'show-replies') {
+      this.repliesExpanded = this.shouldShowReplies();
+
+      if (this.event && this.repliesExpanded && !this.repliesLoaded && !this.repliesLoading) {
+        void this.loadReplies();
+      }
+
       this.render();
     }
   }
@@ -55,7 +85,17 @@ export default class NostrPost extends NostrEventComponent {
 
   protected async onEventReady(_event: any) {
     this.invalidateCache();
-    this.getPostStats();
+    this.resetStatsState();
+    this.resetReplyState();
+
+    if (this.shouldShowStats()) {
+      void this.getPostStats();
+    }
+
+    if (this.repliesExpanded) {
+      void this.loadReplies();
+    }
+
     this.render();
   }
 
@@ -65,28 +105,149 @@ export default class NostrPost extends NostrEventComponent {
     this.glideInitialized = false;
   }
 
-  async getPostStats() {
-    try {
-      const shouldShowStats = this.getAttribute('show-stats') === 'true';
+  private resetStatsState() {
+    this.statsRequestSeq++;
+    this.stats = null;
+    this.statsLoading = false;
+  }
 
-      if (this.event && shouldShowStats) {
-        this.statsLoading = true;
-        this.render();
-        
-        const stats = await getPostStats(
-          this.nostrService.getNDK(),
-          this.event.id
-        );
-        if (stats) {
-          this.stats = stats;
-        }
+  private resetReplyState() {
+    this.repliesRequestSeq++;
+    this.replyItems = [];
+    this.repliesLoaded = false;
+    this.repliesLoading = false;
+    this.repliesError = null;
+    this.repliesExpanded = this.shouldShowReplies();
+  }
+
+  private shouldShowStats(): boolean {
+    return parseBooleanAttribute(this.getAttribute('show-stats'));
+  }
+
+  private shouldShowReplies(): boolean {
+    return parseBooleanAttribute(this.getAttribute('show-replies'));
+  }
+
+  async getPostStats() {
+    const shouldShowStats = this.shouldShowStats();
+    const eventId = this.event?.id;
+
+    if (!shouldShowStats || !eventId) {
+      this.resetStatsState();
+      this.render();
+      return;
+    }
+
+    const seq = ++this.statsRequestSeq;
+
+    try {
+      this.stats = null;
+      this.statsLoading = true;
+      this.render();
+      
+      const stats = await getPostStats(
+        this.nostrService.getNDK(),
+        eventId
+      );
+
+      if (seq !== this.statsRequestSeq || this.event?.id !== eventId) {
+        return;
+      }
+
+      if (stats) {
+        this.stats = stats;
       }
     } catch (err) {
+      if (seq !== this.statsRequestSeq || this.event?.id !== eventId) {
+        return;
+      }
+
       const msg = err instanceof Error ? err.message : 'Failed to load post stats';
       console.error('[NostrPostComponent] ' + msg, err);
       this.eventStatus.set(NCStatus.Error, msg);
     } finally {
+      if (seq !== this.statsRequestSeq || this.event?.id !== eventId) {
+        return;
+      }
+
       this.statsLoading = false;
+      this.render();
+    }
+  }
+
+  private async loadReplies() {
+    const eventId = this.event?.id;
+
+    if (!eventId || this.repliesLoading || this.repliesLoaded) {
+      return;
+    }
+
+    const seq = ++this.repliesRequestSeq;
+
+    try {
+      this.repliesLoading = true;
+      this.repliesError = null;
+      this.render();
+
+      const replies = await this.nostrService.getNDK().fetchEvents({
+        kinds: [1],
+        '#e': [eventId],
+      });
+
+      if (seq !== this.repliesRequestSeq || this.event?.id !== eventId) {
+        return;
+      }
+
+      const directReplies = filterDirectReplies(replies, eventId).sort(
+        (a, b) => (a.created_at || 0) - (b.created_at || 0)
+      );
+
+      const uniqueAuthors = new Map<string, typeof directReplies[number]['author']>();
+      for (const reply of directReplies) {
+        uniqueAuthors.set(reply.pubkey, reply.author);
+      }
+
+      const authorProfiles = await Promise.all(
+        Array.from(uniqueAuthors.entries()).map(async ([pubkey, author]) => {
+          try {
+            const profile = await author.fetchProfile();
+            return [pubkey, profile] as const;
+          } catch (error) {
+            console.error(
+              `[NostrPostComponent] Failed to fetch profile for reply author ${pubkey}:`,
+              error
+            );
+            return [pubkey, null] as const;
+          }
+        })
+      );
+
+      if (seq !== this.repliesRequestSeq || this.event?.id !== eventId) {
+        return;
+      }
+
+      const authorProfileMap = new Map<string, NDKUserProfile | null>(authorProfiles);
+
+      this.replyItems = directReplies.map(reply =>
+        buildReplyItem(reply, authorProfileMap.get(reply.pubkey))
+      );
+      this.repliesLoaded = true;
+    } catch (err) {
+      if (seq !== this.repliesRequestSeq || this.event?.id !== eventId) {
+        return;
+      }
+
+      const msg = err instanceof Error ? err.message : 'Failed to load replies';
+      console.error('[NostrPostComponent] ' + msg, err);
+      this.replyItems = [];
+      this.repliesLoaded = false;
+      this.repliesError = msg;
+    } finally {
+      if (seq !== this.repliesRequestSeq || this.event?.id !== eventId) {
+        return;
+      }
+
+      this.repliesLoading = false;
       this.render();
     }
   }
@@ -116,11 +277,22 @@ export default class NostrPost extends NostrEventComponent {
     this.handleNjumpClick(EVT_MENTION, { username }, `p/${username}`);
   }
 
+  private onToggleReplies(e: Event) {
+    e.preventDefault();
+
+    if (this.repliesExpanded) {
+      this.removeAttribute('show-replies');
+      return;
+    }
+
+    this.setAttribute('show-replies', 'true');
+  }
+
   private attachDelegatedListeners() {
     // Click anywhere on the post container (except interactive elements)
     this.delegateEvent('click', '.nostr-post-container', (_e: Event) => {
       const target = _e.target as HTMLElement;
-      if (!target.closest('a, .nostr-mention, video, img, .nc-copy-btn, .post-header-left, .post-header-middle')) {
+      if (!target.closest('a, .nostr-mention, video, img, .nc-copy-btn, .post-header-left, .post-header-middle, .reply-toggle-btn, .post-replies')) {
         this.onPostClick();
       }
     });
@@ -143,6 +315,10 @@ export default class NostrPost extends NostrEventComponent {
         this.onMentionClick(username);
       }
     });
+
+    this.delegateEvent('click', '.reply-toggle-btn', (e: Event) => {
+      this.onToggleReplies(e);
+    });
   }
 
   protected async renderContent() {
@@ -162,7 +338,7 @@ export default class NostrPost extends NostrEventComponent {
     const htmlToRender  = this.cachedHtmlToRender;
     const errorMessage  = this.errorMessage;
 
-    const shouldShowStats = this.getAttribute('show-stats') === 'true';
+    const shouldShowStats = this.shouldShowStats();
 
     const renderOptions: RenderPostOptions = {
       isLoading: isLoading,
@@ -174,6 +350,11 @@ export default class NostrPost extends NostrEventComponent {
       stats: this.stats,
       statsLoading: this.statsLoading,
       htmlToRender,
+      repliesExpanded: this.repliesExpanded,
+      repliesLoaded: this.repliesLoaded,
+      repliesLoading: this.repliesLoading,
+      repliesError: this.repliesError,
+      replyItems: this.replyItems,
     };
 
     this.shadowRoot!.innerHTML = `

--- a/src/nostr-post/nostr-post.ts
+++ b/src/nostr-post/nostr-post.ts
@@ -24,6 +24,7 @@ export default class NostrPost extends NostrEventComponent {
 
   protected stats: Stats | null = null;
   protected statsLoading: boolean = false;
+  protected statsError: string | null = null;
   protected embeddedPosts: Map<string, NDKEvent> = new Map();
   protected replyItems: ReplyItem[] = [];
   protected repliesExpanded: boolean = false;
@@ -109,6 +110,7 @@ export default class NostrPost extends NostrEventComponent {
     this.statsRequestSeq++;
     this.stats = null;
     this.statsLoading = false;
+    this.statsError = null;
   }
 
   private resetReplyState() {
@@ -143,6 +145,7 @@ export default class NostrPost extends NostrEventComponent {
     try {
       this.stats = null;
       this.statsLoading = true;
+      this.statsError = null;
       this.render();
       
       const stats = await getPostStats(
@@ -164,14 +167,13 @@ export default class NostrPost extends NostrEventComponent {
 
       const msg = err instanceof Error ? err.message : 'Failed to load post stats';
       console.error('[NostrPostComponent] ' + msg, err);
-      this.eventStatus.set(NCStatus.Error, msg);
+      this.stats = null;
+      this.statsError = msg;
     } finally {
-      if (seq !== this.statsRequestSeq || this.event?.id !== eventId) {
-        return;
+      if (seq === this.statsRequestSeq && this.event?.id === eventId) {
+        this.statsLoading = false;
+        this.render();
       }
-
-      this.statsLoading = false;
-      this.render();
     }
   }
 
@@ -243,12 +245,10 @@ export default class NostrPost extends NostrEventComponent {
       this.repliesLoaded = false;
       this.repliesError = msg;
     } finally {
-      if (seq !== this.repliesRequestSeq || this.event?.id !== eventId) {
-        return;
+      if (seq === this.repliesRequestSeq && this.event?.id === eventId) {
+        this.repliesLoading = false;
+        this.render();
       }
-
-      this.repliesLoading = false;
-      this.render();
     }
   }
 
@@ -349,6 +349,7 @@ export default class NostrPost extends NostrEventComponent {
       shouldShowStats,
       stats: this.stats,
       statsLoading: this.statsLoading,
+      statsError: this.statsError,
       htmlToRender,
       repliesExpanded: this.repliesExpanded,
       repliesLoaded: this.repliesLoaded,

--- a/src/nostr-post/render.ts
+++ b/src/nostr-post/render.ts
@@ -7,6 +7,7 @@ import { replyIcon, heartIcon } from '../common/icons';
 import { IRenderOptions } from '../base/render-options';
 import { NDKUserProfile } from '@nostr-dev-kit/ndk';
 import { escapeHtml } from '../common/utils';
+import { ReplyItem } from './reply-utils';
 
 export interface RenderPostOptions extends IRenderOptions {
   author: NDKUserProfile | null| undefined;
@@ -18,6 +19,11 @@ export interface RenderPostOptions extends IRenderOptions {
   } | null;
   statsLoading: boolean;
   htmlToRender: string;
+  repliesExpanded: boolean;
+  repliesLoaded: boolean;
+  repliesLoading: boolean;
+  repliesError: string | null;
+  replyItems: ReplyItem[];
 }
 
 export function renderPost(options: RenderPostOptions): string {
@@ -31,6 +37,11 @@ export function renderPost(options: RenderPostOptions): string {
     stats,
     statsLoading,
     htmlToRender,
+    repliesExpanded,
+    repliesLoaded,
+    repliesLoading,
+    repliesError,
+    replyItems,
   } = options;
 
   if (isError) {
@@ -41,7 +52,23 @@ export function renderPost(options: RenderPostOptions): string {
     <div class="nostr-post-container">
       ${renderPostHeader(isLoading, author, date)}
       ${renderPostBody(isLoading, htmlToRender)}
-      ${shouldShowStats ? renderPostFooter(isLoading, stats, statsLoading) : ''}
+      ${renderPostFooter(
+        isLoading,
+        shouldShowStats,
+        stats,
+        statsLoading,
+        repliesExpanded,
+        repliesLoaded,
+        replyItems
+      )}
+      ${renderRepliesSection(
+        isLoading,
+        repliesExpanded,
+        repliesLoaded,
+        repliesLoading,
+        repliesError,
+        replyItems
+      )}
     </div>
   `;
 }
@@ -118,37 +145,136 @@ function renderPostBody(
 
 function renderPostFooter(
   isLoading: boolean,
+  shouldShowStats: boolean,
   stats: { replies: number; likes: number } | null,
-  statsLoading: boolean
+  statsLoading: boolean,
+  repliesExpanded: boolean,
+  repliesLoaded: boolean,
+  replyItems: ReplyItem[]
 ): string {
-  if (isLoading || statsLoading) {
+  if (isLoading) {
     return `
       <div class="post-footer">
-        <div class='stats-container'>
-          <div class="stat">
-            <div style="width: 16px; height: 16px; border-radius: 4px;" class="skeleton"></div>
-            <div style="width: 20px; height: 16px; border-radius: 4px;" class="skeleton"></div>
-          </div>
-          <div class="stat">
-            <div style="width: 16px; height: 16px; border-radius: 4px;" class="skeleton"></div>
-            <div style="width: 20px; height: 16px; border-radius: 4px;" class="skeleton"></div>
-          </div>
+        <div class="stats-container">
+          ${shouldShowStats ? `
+            <div class="stat">
+              <div style="width: 16px; height: 16px; border-radius: 4px;" class="skeleton"></div>
+              <div style="width: 20px; height: 16px; border-radius: 4px;" class="skeleton"></div>
+            </div>
+            <div class="stat">
+              <div style="width: 16px; height: 16px; border-radius: 4px;" class="skeleton"></div>
+              <div style="width: 20px; height: 16px; border-radius: 4px;" class="skeleton"></div>
+            </div>
+          ` : ''}
+          <button class="stat reply-toggle-btn" type="button" disabled aria-expanded="false">
+            <span class="skeleton reply-toggle-skeleton"></span>
+          </button>
         </div>
       </div>
     `;
   }
 
+  const replyCount =
+    stats?.replies ?? (repliesLoaded ? replyItems.length : undefined);
+  const replyCountLabel =
+    !repliesExpanded && replyCount && replyCount > 0
+      ? ` (${replyCount})`
+      : '';
+
   return `
     <div class="post-footer">
-      <div class='stats-container'>
-        <div class="stat">
-          ${replyIcon}
-          <span>${stats?.replies ?? 0}</span>
-        </div>
-        <div class="stat">
-          ${heartIcon}
-          <span>${stats?.likes ?? 0}</span>
-        </div>
+      <div class="stats-container">
+        ${shouldShowStats ? `
+          <div class="stat">
+            ${statsLoading ? '<span class="skeleton reply-count-skeleton"></span>' : `${replyIcon}<span>${stats?.replies ?? 0}</span>`}
+          </div>
+          <div class="stat">
+            ${statsLoading ? '<span class="skeleton like-count-skeleton"></span>' : `${heartIcon}<span>${stats?.likes ?? 0}</span>`}
+          </div>
+        ` : ''}
+        <button
+          class="stat reply-toggle-btn"
+          type="button"
+          aria-expanded="${repliesExpanded}"
+        >
+          <span class="reply-toggle-label">
+            ${repliesExpanded ? 'Hide Replies' : `Show Replies${replyCountLabel}`}
+          </span>
+        </button>
+      </div>
+    </div>
+  `;
+}
+
+function renderRepliesSection(
+  isLoading: boolean,
+  repliesExpanded: boolean,
+  repliesLoaded: boolean,
+  repliesLoading: boolean,
+  repliesError: string | null,
+  replyItems: ReplyItem[]
+): string {
+  if (isLoading || !repliesExpanded) {
+    return '';
+  }
+
+  if (repliesLoading) {
+    return `
+      <div class="post-replies post-replies-loading" aria-live="polite">
+        <div class="post-replies-state-label">Loading replies</div>
+        ${renderReplySkeleton()}
+        ${renderReplySkeleton()}
+      </div>
+    `;
+  }
+
+  if (repliesError) {
+    return `
+      <div class="post-replies post-replies-error" aria-live="polite">
+        <div class="post-replies-state-label">Unable to load replies right now.</div>
+      </div>
+    `;
+  }
+
+  if (repliesLoaded && replyItems.length === 0) {
+    return `
+      <div class="post-replies post-replies-empty" aria-live="polite">
+        <div class="post-replies-state-label">No replies yet.</div>
+      </div>
+    `;
+  }
+
+  return `
+    <div class="post-replies" aria-live="polite">
+      ${replyItems.map(renderReplyItem).join('')}
+    </div>
+  `;
+}
+
+function renderReplyItem(reply: ReplyItem): string {
+  return `
+    <div class="post-reply" data-reply-id="${escapeHtml(reply.id)}">
+      <div class="post-reply-avatar">
+        ${reply.authorImage ? `<img src="${escapeHtml(reply.authorImage)}" alt="${escapeHtml(reply.authorName)}" loading="lazy" />` : ''}
+      </div>
+      <div class="post-reply-main">
+        <div class="post-reply-author">${escapeHtml(reply.authorName)}</div>
+        <div class="post-reply-content">${reply.contentHtml}</div>
+      </div>
+    </div>
+  `;
+}
+
+function renderReplySkeleton(): string {
+  return `
+    <div class="post-reply post-reply-skeleton">
+      <div class="post-reply-avatar">
+        <div class="skeleton reply-avatar-skeleton"></div>
+      </div>
+      <div class="post-reply-main">
+        <div class="skeleton reply-author-skeleton"></div>
+        <div class="skeleton reply-line-skeleton"></div>
+        <div class="skeleton reply-line-skeleton short"></div>
       </div>
     </div>
   `;

--- a/src/nostr-post/render.ts
+++ b/src/nostr-post/render.ts
@@ -54,15 +54,16 @@ export function renderPost(options: RenderPostOptions): string {
     <div class="nostr-post-container">
       ${renderPostHeader(isLoading, author, date)}
       ${renderPostBody(isLoading, htmlToRender)}
-      ${shouldShowStats ? renderPostFooter(
+      ${renderPostFooter(
         isLoading,
+        shouldShowStats,
         stats,
         statsLoading,
         statsError,
         repliesExpanded,
         repliesLoaded,
         replyItems
-      ) : ''}
+      )}
       ${renderRepliesSection(
         isLoading,
         repliesExpanded,
@@ -147,6 +148,7 @@ function renderPostBody(
 
 function renderPostFooter(
   isLoading: boolean,
+  shouldShowStats: boolean,
   stats: { replies: number; likes: number } | null,
   statsLoading: boolean,
   statsError: string | null,
@@ -154,18 +156,20 @@ function renderPostFooter(
   repliesLoaded: boolean,
   replyItems: ReplyItem[]
 ): string {
-  if (isLoading || statsLoading) {
+  if (isLoading) {
     return `
       <div class="post-footer">
         <div class="stats-container">
-          <div class="stat">
-            <div style="width: 16px; height: 16px; border-radius: 4px;" class="skeleton"></div>
-            <div style="width: 20px; height: 16px; border-radius: 4px;" class="skeleton"></div>
-          </div>
-          <div class="stat">
-            <div style="width: 16px; height: 16px; border-radius: 4px;" class="skeleton"></div>
-            <div style="width: 20px; height: 16px; border-radius: 4px;" class="skeleton"></div>
-          </div>
+          ${shouldShowStats ? `
+            <div class="stat">
+              <div style="width: 16px; height: 16px; border-radius: 4px;" class="skeleton"></div>
+              <div style="width: 20px; height: 16px; border-radius: 4px;" class="skeleton"></div>
+            </div>
+            <div class="stat">
+              <div style="width: 16px; height: 16px; border-radius: 4px;" class="skeleton"></div>
+              <div style="width: 20px; height: 16px; border-radius: 4px;" class="skeleton"></div>
+            </div>
+          ` : ''}
           <button class="stat reply-toggle-btn" type="button" disabled aria-expanded="false">
             <span class="skeleton reply-toggle-skeleton"></span>
           </button>
@@ -186,12 +190,14 @@ function renderPostFooter(
   return `
     <div class="post-footer">
       <div class="stats-container">
-        <div class="stat" ${statsError ? 'title="Unable to load stats right now."' : ''}>
-          ${replyIcon}<span>${replyStat}</span>
-        </div>
-        <div class="stat" ${statsError ? 'title="Unable to load stats right now."' : ''}>
-          ${heartIcon}<span>${likeStat}</span>
-        </div>
+        ${shouldShowStats ? `
+          <div class="stat" ${statsError ? 'title="Unable to load stats right now."' : ''}>
+            ${statsLoading ? '<span class="skeleton reply-count-skeleton"></span>' : `${replyIcon}<span>${replyStat}</span>`}
+          </div>
+          <div class="stat" ${statsError ? 'title="Unable to load stats right now."' : ''}>
+            ${statsLoading ? '<span class="skeleton like-count-skeleton"></span>' : `${heartIcon}<span>${likeStat}</span>`}
+          </div>
+        ` : ''}
         <button
           class="stat reply-toggle-btn"
           type="button"

--- a/src/nostr-post/render.ts
+++ b/src/nostr-post/render.ts
@@ -18,6 +18,7 @@ export interface RenderPostOptions extends IRenderOptions {
     likes: number;
   } | null;
   statsLoading: boolean;
+  statsError: string | null;
   htmlToRender: string;
   repliesExpanded: boolean;
   repliesLoaded: boolean;
@@ -36,6 +37,7 @@ export function renderPost(options: RenderPostOptions): string {
     shouldShowStats,
     stats,
     statsLoading,
+    statsError,
     htmlToRender,
     repliesExpanded,
     repliesLoaded,
@@ -52,15 +54,15 @@ export function renderPost(options: RenderPostOptions): string {
     <div class="nostr-post-container">
       ${renderPostHeader(isLoading, author, date)}
       ${renderPostBody(isLoading, htmlToRender)}
-      ${renderPostFooter(
+      ${shouldShowStats ? renderPostFooter(
         isLoading,
-        shouldShowStats,
         stats,
         statsLoading,
+        statsError,
         repliesExpanded,
         repliesLoaded,
         replyItems
-      )}
+      ) : ''}
       ${renderRepliesSection(
         isLoading,
         repliesExpanded,
@@ -145,27 +147,25 @@ function renderPostBody(
 
 function renderPostFooter(
   isLoading: boolean,
-  shouldShowStats: boolean,
   stats: { replies: number; likes: number } | null,
   statsLoading: boolean,
+  statsError: string | null,
   repliesExpanded: boolean,
   repliesLoaded: boolean,
   replyItems: ReplyItem[]
 ): string {
-  if (isLoading) {
+  if (isLoading || statsLoading) {
     return `
       <div class="post-footer">
         <div class="stats-container">
-          ${shouldShowStats ? `
-            <div class="stat">
-              <div style="width: 16px; height: 16px; border-radius: 4px;" class="skeleton"></div>
-              <div style="width: 20px; height: 16px; border-radius: 4px;" class="skeleton"></div>
-            </div>
-            <div class="stat">
-              <div style="width: 16px; height: 16px; border-radius: 4px;" class="skeleton"></div>
-              <div style="width: 20px; height: 16px; border-radius: 4px;" class="skeleton"></div>
-            </div>
-          ` : ''}
+          <div class="stat">
+            <div style="width: 16px; height: 16px; border-radius: 4px;" class="skeleton"></div>
+            <div style="width: 20px; height: 16px; border-radius: 4px;" class="skeleton"></div>
+          </div>
+          <div class="stat">
+            <div style="width: 16px; height: 16px; border-radius: 4px;" class="skeleton"></div>
+            <div style="width: 20px; height: 16px; border-radius: 4px;" class="skeleton"></div>
+          </div>
           <button class="stat reply-toggle-btn" type="button" disabled aria-expanded="false">
             <span class="skeleton reply-toggle-skeleton"></span>
           </button>
@@ -180,18 +180,18 @@ function renderPostFooter(
     !repliesExpanded && replyCount && replyCount > 0
       ? ` (${replyCount})`
       : '';
+  const replyStat = statsError ? '—' : `${stats?.replies ?? 0}`;
+  const likeStat = statsError ? '—' : `${stats?.likes ?? 0}`;
 
   return `
     <div class="post-footer">
       <div class="stats-container">
-        ${shouldShowStats ? `
-          <div class="stat">
-            ${statsLoading ? '<span class="skeleton reply-count-skeleton"></span>' : `${replyIcon}<span>${stats?.replies ?? 0}</span>`}
-          </div>
-          <div class="stat">
-            ${statsLoading ? '<span class="skeleton like-count-skeleton"></span>' : `${heartIcon}<span>${stats?.likes ?? 0}</span>`}
-          </div>
-        ` : ''}
+        <div class="stat" ${statsError ? 'title="Unable to load stats right now."' : ''}>
+          ${replyIcon}<span>${replyStat}</span>
+        </div>
+        <div class="stat" ${statsError ? 'title="Unable to load stats right now."' : ''}>
+          ${heartIcon}<span>${likeStat}</span>
+        </div>
         <button
           class="stat reply-toggle-btn"
           type="button"

--- a/src/nostr-post/reply-utils.ts
+++ b/src/nostr-post/reply-utils.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+
+import { NDKEvent, NDKUserProfile } from '@nostr-dev-kit/ndk';
+import { escapeHtml, isValidUrl } from '../common/utils';
+
+export interface ReplyItem {
+  id: string;
+  authorKey: string;
+  authorName: string;
+  authorImage: string;
+  contentHtml: string;
+}
+
+export function formatReplyText(content: string): string {
+  return escapeHtml(content).replace(/\n/g, '<br />');
+}
+
+export function buildReplyItem(
+  reply: NDKEvent,
+  profile: NDKUserProfile | null | undefined
+): ReplyItem {
+  const fallbackName = reply.author?.npub || reply.pubkey.slice(0, 12);
+
+  return {
+    id: reply.id,
+    authorKey: reply.pubkey,
+    authorName:
+      profile?.displayName ||
+      profile?.name ||
+      profile?.nip05 ||
+      fallbackName,
+    authorImage: isValidUrl(profile?.picture || '') ? profile?.picture || '' : '',
+    contentHtml: formatReplyText(reply.content || ''),
+  };
+}

--- a/src/nostr-post/style.ts
+++ b/src/nostr-post/style.ts
@@ -127,12 +127,143 @@ export function getPostStyles(): string {
     .stats-container {
       display: flex;
       gap: var(--nostrc-spacing-lg);
+      align-items: center;
+      flex-wrap: wrap;
     }
 
     .stat {
       display: flex;
       gap: var(--nostrc-spacing-xs);
+      align-items: center;
       color: var(--nostrc-post-text-secondary);
+    }
+
+    .reply-toggle-btn {
+      appearance: none;
+      border: none;
+      background: transparent;
+      color: var(--nostrc-post-text-secondary);
+      cursor: pointer;
+      font: inherit;
+      font-size: var(--nostrc-font-size-sm);
+      font-weight: var(--nostrc-font-weight-medium);
+      padding: 0;
+      transition:
+        color var(--nostrc-transition-duration) var(--nostrc-transition-timing),
+        opacity var(--nostrc-transition-duration) var(--nostrc-transition-timing);
+    }
+
+    .reply-toggle-btn:hover:not(:disabled) {
+      color: var(--nostrc-post-text-primary);
+    }
+
+    .reply-toggle-btn:disabled {
+      cursor: default;
+      opacity: 0.7;
+    }
+
+    .reply-toggle-btn .reply-toggle-label {
+      text-align: left;
+    }
+
+    .reply-toggle-skeleton {
+      display: inline-block;
+      width: 88px;
+      height: 14px;
+      border-radius: var(--nostrc-border-radius-sm);
+    }
+
+    .reply-count-skeleton,
+    .like-count-skeleton {
+      display: inline-block;
+      width: 48px;
+      height: 16px;
+      border-radius: var(--nostrc-border-radius-sm);
+    }
+
+    .post-replies {
+      display: flex;
+      flex-direction: column;
+      gap: var(--nostrc-spacing-md);
+      padding-top: var(--nostrc-spacing-sm);
+      border-top: var(--nostrc-post-border);
+    }
+
+    .post-replies-empty,
+    .post-replies-error,
+    .post-replies-loading {
+      color: var(--nostrc-post-text-secondary);
+    }
+
+    .post-replies-state-label {
+      font-size: var(--nostrc-font-size-sm);
+      color: var(--nostrc-post-text-secondary);
+    }
+
+    .post-reply {
+      display: grid;
+      grid-template-columns: 32px minmax(0, 1fr);
+      gap: var(--nostrc-spacing-sm);
+      align-items: start;
+    }
+
+    .post-reply-avatar {
+      width: 32px;
+      height: 32px;
+      border-radius: var(--nostrc-border-radius-full);
+      overflow: hidden;
+      background: var(--nostrc-color-background-secondary);
+      flex-shrink: 0;
+    }
+
+    .post-reply-avatar img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+
+    .post-reply-main {
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+      gap: var(--nostrc-spacing-xs);
+    }
+
+    .post-reply-author {
+      font-size: var(--nostrc-font-size-sm);
+      font-weight: var(--nostrc-font-weight-bold);
+      color: var(--nostrc-post-text-primary);
+      word-break: break-word;
+    }
+
+    .post-reply-content {
+      font-size: var(--nostrc-font-size-sm);
+      color: var(--nostrc-post-text-primary);
+      line-height: 1.5;
+      word-break: break-word;
+    }
+
+    .reply-avatar-skeleton {
+      width: 32px;
+      height: 32px;
+      border-radius: var(--nostrc-border-radius-full);
+    }
+
+    .reply-author-skeleton {
+      width: 120px;
+      height: 12px;
+      border-radius: var(--nostrc-border-radius-full);
+    }
+
+    .reply-line-skeleton {
+      width: 100%;
+      height: 10px;
+      border-radius: var(--nostrc-border-radius-full);
+    }
+
+    .reply-line-skeleton.short {
+      width: 72%;
     }
 
     /* === MEDIA STYLING === */

--- a/stories/Introduction.mdx
+++ b/stories/Introduction.mdx
@@ -230,7 +230,9 @@ A detailed profile card showing avatar, name, bio, notes count, followers, etc.
 
 ## 6. Nostr Post
 
-Embed any Nostr post by providing the event ID.
+Embed any Nostr post by providing a note ID, event ID, or raw hex event ID.
+
+Use `show-stats="true"` to display like/reply counts, and `show-replies="true"` to start with the minimal replies list expanded below the post.
 
 **Usage:**
 
@@ -243,7 +245,9 @@ Embed any Nostr post by providing the event ID.
 </head>
 <body>
   <nostr-post
-    eventId="note1t2jvt5vpusrwrxkfu8x8r7q65zzvm32xuur6y7am4zn475r8ucjqmwwhd2"
+    noteid="note1t2jvt5vpusrwrxkfu8x8r7q65zzvm32xuur6y7am4zn475r8ucjqmwwhd2"
+    show-stats="true"
+    show-replies="true"
   ></nostr-post>
 </body>
 ```

--- a/stories/Introduction.mdx
+++ b/stories/Introduction.mdx
@@ -232,7 +232,9 @@ A detailed profile card showing avatar, name, bio, notes count, followers, etc.
 
 ## 6. Nostr Post
 
-Embed any Nostr post by providing the event ID.
+Embed any Nostr post by providing a note ID, event ID, or raw hex event ID.
+
+Use `show-stats="true"` to display like/reply counts, and `show-replies="true"` to start with the minimal replies list expanded below the post.
 
 **Usage:**
 
@@ -245,7 +247,9 @@ Embed any Nostr post by providing the event ID.
 </head>
 <body>
   <nostr-post
-    eventId="note1t2jvt5vpusrwrxkfu8x8r7q65zzvm32xuur6y7am4zn475r8ucjqmwwhd2"
+    noteid="note1t2jvt5vpusrwrxkfu8x8r7q65zzvm32xuur6y7am4zn475r8ucjqmwwhd2"
+    show-stats="true"
+    show-replies="true"
   ></nostr-post>
 </body>
 ```

--- a/stories/nostr-post/NostrPost.stories.tsx
+++ b/stories/nostr-post/NostrPost.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta = {
   parameters: {
     docs: {
       description: {
-        component: 'A web component that displays Nostr posts with content, metadata, and statistics. Supports note IDs, event IDs, and raw hex inputs.',
+        component: 'A web component that displays Nostr posts with content, metadata, optional stats, and a minimal expandable replies view. Supports note IDs, event IDs, and raw hex inputs.',
       },
       source: {
         transform: (code, storyContext) =>
@@ -52,6 +52,11 @@ export const RawHex: Story = {
 export const ShowStats: Story = {
   name: TEST_CASES.showStats.name,
   args: TEST_CASES.showStats.args,
+};
+
+export const ShowReplies: Story = {
+  name: TEST_CASES.showReplies.name,
+  args: TEST_CASES.showReplies.args,
 };
 
 // Content Type Stories

--- a/stories/nostr-post/NostrPost.testing.dynamic.stories.tsx
+++ b/stories/nostr-post/NostrPost.testing.dynamic.stories.tsx
@@ -73,7 +73,7 @@ export const AllAttributes: Story = {
       { type: 'noteid', value: INVALID_TEST_CASES.emptyValues.args.noteid, name: 'Empty Note ID' },
     ],
     widths: [600, 500, 400, 700],
-    booleanAttributes: ['show-stats'],
+    booleanAttributes: ['show-stats', 'show-replies'],
     updateInterval: 8000
   }),
 };

--- a/stories/nostr-post/NostrPost.testing.valid.stories.tsx
+++ b/stories/nostr-post/NostrPost.testing.valid.stories.tsx
@@ -46,6 +46,11 @@ export const ShowStats: Story = {
   args: TEST_CASES.showStats.args,
 };
 
+export const ShowReplies: Story = {
+  name: TEST_CASES.showReplies.name,
+  args: TEST_CASES.showReplies.args,
+};
+
 export const VideoContent: Story = {
   name: TEST_CASES.jackVideoProgramming.name,
   args: TEST_CASES.jackVideoProgramming.args,

--- a/stories/nostr-post/parameters.ts
+++ b/stories/nostr-post/parameters.ts
@@ -20,5 +20,11 @@ export const POST_PARAMETERS: ParameterDefinition[] = [
     description: `Whether need to show the stats of the post or not`,
     defaultValue: 'false',
     control: 'boolean',
+  },
+  {
+    variable: 'show-replies',
+    description: `Whether replies should start expanded below the post`,
+    defaultValue: 'false',
+    control: 'boolean',
   }
 ];

--- a/stories/nostr-post/test-cases-valid.ts
+++ b/stories/nostr-post/test-cases-valid.ts
@@ -39,6 +39,14 @@ export const TEST_CASES = {
       'show-stats': "true",
     },
   },
+  showReplies: {
+    name: 'Show Replies',
+    args: {
+      width: DEFAULT_WIDTH,
+      noteid: POST_DATA.jack_rough_consensus.noteid,
+      'show-replies': "true",
+    },
+  },
 
   // Theme Variations
   oceanGlassTheme: {


### PR DESCRIPTION
Closes #8

## Summary

This PR adds `show-replies` support to `nostr-post` on top of the current `NostrEventComponent` architecture.

Instead of porting the old linked PR directly, this implementation adapts the feature to the current component stack and adds:
- a `show-replies` attribute for `nostr-post`
- an interactive Show/Hide Replies footer control
- lazy reply loading with caching
- minimal reply rendering (avatar, author name, reply text only)
- local reply error handling so the main post UI does not fail if replies fail to load

## What changed

### `nostr-post` reply support
- Added reply state management to `nostr-post`
  - expanded/collapsed state
  - loaded/loading/error state
  - cached reply items
  - stale request guards to avoid leaking old replies between fast post switches
- Added `show-replies` to `observedAttributes`
- Reflected expanded/collapsed UI state back through the `show-replies` attribute
- Replies are fetched lazily on first expand, or immediately if `show-replies="true"` is set initially
- Reply failures are kept local to the replies section instead of switching the whole component into an error state

### Direct reply filtering
- Added shared direct-reply filtering logic in `src/common/utils.ts`
- Reply fetching now filters to direct replies only instead of treating every `#e` reference as a visible reply
- `getPostStats()` now uses the same direct-reply logic so the visible replies list and reply count stay aligned

### Reply rendering
- Added a reply view-model helper in `src/nostr-post/reply-utils.ts`
- Replies are rendered oldest-to-newest
- Reply author profiles are fetched in parallel
- Each reply shows only:
  - avatar
  - author name
  - escaped reply text with line breaks preserved
- No media, embedded notes, stats, or actions are rendered for replies

### Footer UI
- Reworked the footer so reply controls and stats are independent
- `Show Replies` is available even when `show-stats` is not enabled
- Updated the reply toggle to use a footer stat-style control so it visually matches the existing reply/like counts better
- When available, the collapsed toggle shows the reply count

### Docs / Storybook
- Added `show-replies` to post Storybook parameters
- Included it in dynamic Storybook boolean controls
- Added a `Show Replies` story/test case
- Updated the `nostr-post` docs in:
  - `README.md`
  - `stories/Introduction.mdx`
  - `stories/nostr-post/*`

## Verification

Ran:
- `npm run build`
- `npm run build-storybook`

## Notes

- `build` / `build-storybook` complete successfully, but still print pre-existing declaration/type diagnostics from older legacy modules such as `nostr-comment`, `nostr-dm`, and `nostr-live-chat`
- No public API changes beyond adding the `show-replies` attribute to `nostr-post`

## Screenshots
 
<img width="627" height="197" alt="Screenshot 2026-04-01 at 18 43 38" src="https://github.com/user-attachments/assets/c402c40a-447b-4d42-8060-c9dec25e3870" />
<img width="633" height="493" alt="Screenshot 2026-04-01 at 18 43 47" src="https://github.com/user-attachments/assets/44cf85a2-564f-4667-85be-e8c86465e243" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a replies section to the Nostr Post, toggleable with `show-replies` and supported for starting expanded.
  * Updated Nostr post embedding to accept `noteid`, `eventId`, or raw hex event IDs.
* **Documentation**
  * Refreshed Nostr Post docs and examples to use the new identifier options and display controls like `show-stats`.
* **Bug Fixes**
  * Improved reply parent detection for accurate direct-reply counting and more reliable loading.
  * Hardened HTML escaping for user-provided text.
* **Tests**
  * Added coverage for direct-reply utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->