### PR TITLE
Issue #60: Newcomer signer onboarding for Like, Zap, and Follow

### DIFF
--- a/src/base/dialog-component/dialog-component.ts
+++ b/src/base/dialog-component/dialog-component.ts
@@ -168,6 +168,13 @@ export class DialogComponent extends HTMLElement {
   }
 
   /**
+   * Returns the native dialog element created by this component instance.
+   */
+  public getDialogElement(): HTMLDialogElement | null {
+    return this.dialog;
+  }
+
+  /**
    * Show the dialog as modal
    */
   public showModal(): void {

--- a/src/common/auth-onboarding-style.ts
+++ b/src/common/auth-onboarding-style.ts
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: MIT
+
+/**
+ * Onboarding dialog content styles.
+ * Base dialog shell styles come from DialogComponent.
+ */
+export const getAuthOnboardingDialogStyles = (): string => {
+  return `
+    .onboarding-flow {
+      display: grid;
+      gap: 14px;
+    }
+
+    .onboarding-hero {
+      border: 1px solid #efce77;
+      border-radius: 12px;
+      padding: 14px;
+      background: linear-gradient(140deg, #fff6df 0%, #ffe6b3 45%, #f7cd79 100%);
+      color: #3f2a00;
+    }
+
+    .nostr-base-dialog[data-theme='dark'] .onboarding-hero {
+      border-color: #7a5a1b;
+      background: linear-gradient(140deg, #3a2a0c 0%, #523a10 45%, #6e4b14 100%);
+      color: #ffebb8;
+    }
+
+    .onboarding-hero h3 {
+      margin: 0 0 6px;
+      font-size: 1rem;
+      line-height: 1.3;
+    }
+
+    .onboarding-hero p {
+      margin: 0;
+      font-size: 0.92rem;
+      line-height: 1.45;
+    }
+
+    .onboarding-steps {
+      margin: 0;
+      padding-left: 18px;
+      display: grid;
+      gap: 6px;
+      font-size: 0.9rem;
+      color: var(--nostrc-theme-text-primary, #1f2937);
+    }
+
+    .onboarding-steps li {
+      line-height: 1.45;
+    }
+
+    .onboarding-cta-row {
+      display: grid;
+      gap: 10px;
+      grid-template-columns: 1fr;
+    }
+
+    .onboarding-primary-btn,
+    .onboarding-secondary-btn,
+    .onboarding-skip-btn,
+    .onboarding-advanced-apply {
+      border-radius: 10px;
+      font-size: 0.92rem;
+      font-weight: 600;
+      cursor: pointer;
+      min-height: 40px;
+      border: 1px solid transparent;
+      transition: transform 0.18s ease, opacity 0.18s ease, background-color 0.18s ease, color 0.18s ease;
+    }
+
+    .onboarding-primary-btn {
+      background: #d97706;
+      color: #fff;
+      border-color: #b45309;
+    }
+
+    .onboarding-primary-btn:hover {
+      background: #b45309;
+      transform: translateY(-1px);
+    }
+
+    .onboarding-secondary-btn {
+      background: #0f766e;
+      color: #fff;
+      border-color: #115e59;
+    }
+
+    .onboarding-secondary-btn:hover {
+      background: #115e59;
+      transform: translateY(-1px);
+    }
+
+    .onboarding-skip-btn {
+      background: transparent;
+      color: var(--nostrc-theme-text-secondary, #4b5563);
+      border-color: var(--nostrc-theme-border, #c7ced8);
+    }
+
+    .onboarding-skip-btn:hover {
+      background: var(--nostrc-theme-hover-bg, rgba(0, 0, 0, 0.06));
+    }
+
+    .onboarding-primary-btn:disabled,
+    .onboarding-secondary-btn:disabled,
+    .onboarding-advanced-apply:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+      transform: none;
+    }
+
+    .onboarding-links {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      font-size: 0.86rem;
+    }
+
+    .onboarding-links a {
+      color: #0f766e;
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+
+    .nostr-base-dialog[data-theme='dark'] .onboarding-links a {
+      color: #5eead4;
+    }
+
+    .onboarding-advanced {
+      border: 1px solid var(--nostrc-theme-border, #d1d5db);
+      border-radius: 10px;
+      padding: 10px;
+      background: var(--nostrc-theme-hover-bg, rgba(0, 0, 0, 0.03));
+    }
+
+    .onboarding-advanced summary {
+      cursor: pointer;
+      font-weight: 600;
+      margin-bottom: 8px;
+      color: var(--nostrc-theme-text-primary, #111827);
+    }
+
+    .onboarding-advanced p {
+      margin: 0 0 8px;
+      font-size: 0.84rem;
+      line-height: 1.4;
+      color: var(--nostrc-theme-text-secondary, #4b5563);
+    }
+
+    .onboarding-advanced-row {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 8px;
+    }
+
+    .onboarding-advanced-input {
+      min-height: 38px;
+      border-radius: 8px;
+      border: 1px solid var(--nostrc-theme-border, #c7ced8);
+      background: var(--nostrc-theme-bg, #fff);
+      color: var(--nostrc-theme-text-primary, #111827);
+      padding: 0 10px;
+      font-size: 0.85rem;
+    }
+
+    .onboarding-advanced-apply {
+      background: #1d4ed8;
+      color: #fff;
+      border-color: #1e40af;
+    }
+
+    .onboarding-advanced-apply:hover {
+      background: #1e40af;
+      transform: translateY(-1px);
+    }
+
+    .onboarding-status {
+      min-height: 18px;
+      font-size: 0.82rem;
+      color: var(--nostrc-theme-text-secondary, #4b5563);
+    }
+
+    .onboarding-status.error {
+      color: #b91c1c;
+    }
+
+    .onboarding-status.success {
+      color: #065f46;
+    }
+
+    @media (max-width: 480px) {
+      .onboarding-flow {
+        gap: 12px;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .onboarding-primary-btn,
+      .onboarding-secondary-btn,
+      .onboarding-skip-btn,
+      .onboarding-advanced-apply {
+        transition: none;
+      }
+    }
+  `;
+};

--- a/src/common/auth-onboarding.ts
+++ b/src/common/auth-onboarding.ts
@@ -60,7 +60,7 @@ function parseAdvancedInput(value: string): {
   if (trimmed.startsWith('bunker://')) {
     try {
       const parsed = new URL(trimmed);
-      if (!parsed.hostname && !parsed.pathname) {
+      if (!parsed.hostname || !parsed.search) {
         return {
           kind: 'invalid',
           message: 'Bunker token looks incomplete. Include host and query params.',
@@ -141,6 +141,7 @@ export async function showAuthOnboarding(
           <input
             type="password"
             class="onboarding-advanced-input"
+            aria-label="Bunker password or URL"
             placeholder="bunker://..."
             autocomplete="off"
           />

--- a/src/common/auth-onboarding.ts
+++ b/src/common/auth-onboarding.ts
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: MIT
+
+import { nip19 } from 'nostr-tools';
+import type { DialogComponent } from '../base/dialog-component/dialog-component';
+import '../base/dialog-component/dialog-component';
+import { isValidHex } from './utils';
+import { getAuthOnboardingDialogStyles } from './auth-onboarding-style';
+import { getPublicKey } from './nostr-login-service';
+
+type OnboardingAction = 'like' | 'zap' | 'follow';
+type AdvancedInputKind = 'nsec' | 'bunker' | 'invalid';
+
+interface ShowAuthOnboardingOptions {
+  action: OnboardingAction;
+  theme?: 'light' | 'dark';
+}
+
+interface ShowAuthOnboardingResult {
+  connected: boolean;
+  source: 'connect' | 'dismissed';
+}
+
+const ACTION_COPY: Record<
+  OnboardingAction,
+  { actionLabel: string; satsLine: string }
+> = {
+  like: {
+    actionLabel: 'like this page on Nostr',
+    satsLine: 'Creators can add zap buttons and receive sats directly on their websites.',
+  },
+  zap: {
+    actionLabel: 'send a zap tip',
+    satsLine: 'Zaps are instant Bitcoin Lightning tips. Anyone can receive sats on regular websites.',
+  },
+  follow: {
+    actionLabel: 'follow this creator on Nostr',
+    satsLine: 'Building on Nostr means creators can receive sats and own their audience graph.',
+  },
+};
+
+function injectAuthOnboardingStyles(): void {
+  if (document.querySelector('style[data-auth-onboarding-styles]')) return;
+
+  const style = document.createElement('style');
+  style.setAttribute('data-auth-onboarding-styles', 'true');
+  style.textContent = getAuthOnboardingDialogStyles();
+  document.head.appendChild(style);
+}
+
+function parseAdvancedInput(value: string): {
+  kind: AdvancedInputKind;
+  message: string;
+} {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return {
+      kind: 'invalid',
+      message: 'Paste an nsec key or bunker:// token to validate the format.',
+    };
+  }
+
+  if (trimmed.startsWith('bunker://')) {
+    try {
+      const parsed = new URL(trimmed);
+      if (!parsed.hostname && !parsed.pathname) {
+        return {
+          kind: 'invalid',
+          message: 'Bunker token looks incomplete. Include host and query params.',
+        };
+      }
+      return {
+        kind: 'bunker',
+        message: 'Valid bunker token format. Open your remote signer, then press Connect.',
+      };
+    } catch {
+      return {
+        kind: 'invalid',
+        message: 'Invalid bunker:// token format.',
+      };
+    }
+  }
+
+  if (trimmed.startsWith('nsec1')) {
+    try {
+      const decoded = nip19.decode(trimmed);
+      if (decoded.type === 'nsec') {
+        return {
+          kind: 'nsec',
+          message: 'Valid nsec format. Import it into your signer app, then press Connect.',
+        };
+      }
+      return {
+        kind: 'invalid',
+        message: 'This bech32 value is not an nsec key.',
+      };
+    } catch {
+      return {
+        kind: 'invalid',
+        message: 'Invalid nsec format.',
+      };
+    }
+  }
+
+  if (isValidHex(trimmed)) {
+    return {
+      kind: 'nsec',
+      message: 'Valid raw private key format. Import it into your signer app, then press Connect.',
+    };
+  }
+
+  return {
+    kind: 'invalid',
+    message: 'Input is not recognized as nsec or bunker:// format.',
+  };
+}
+
+export async function showAuthOnboarding(
+  options: ShowAuthOnboardingOptions
+): Promise<ShowAuthOnboardingResult> {
+  injectAuthOnboardingStyles();
+
+  if (!customElements.get('dialog-component')) {
+    await customElements.whenDefined('dialog-component');
+  }
+
+  const copy = ACTION_COPY[options.action];
+  const dialogComponent = document.createElement(
+    'dialog-component'
+  ) as DialogComponent;
+  dialogComponent.setAttribute('header', 'Start with Nostr in 30 seconds');
+
+  if (options.theme) {
+    dialogComponent.setAttribute('data-theme', options.theme);
+  }
+
+  dialogComponent.innerHTML = `
+    <div class="onboarding-flow">
+      <section class="onboarding-hero">
+        <h3>You are one click away from Nostr</h3>
+        <p>
+          To ${copy.actionLabel}, connect a signer once. ${copy.satsLine}
+        </p>
+      </section>
+
+      <ol class="onboarding-steps">
+        <li>Connect a signer using browser extension or remote signer.</li>
+        <li>Approve this action from the signer prompt.</li>
+        <li>Explore how to add zap buttons and receive sats on your own site.</li>
+      </ol>
+
+      <div class="onboarding-cta-row">
+        <button type="button" class="onboarding-primary-btn">Connect Nostr</button>
+        <button type="button" class="onboarding-secondary-btn">I need a quick setup guide</button>
+        <button type="button" class="onboarding-skip-btn">Maybe later</button>
+      </div>
+
+      <div class="onboarding-links">
+        <a href="https://nstart.me/" target="_blank" rel="noopener noreferrer">Get started with Nostr</a>
+        <a href="https://getalby.com/" target="_blank" rel="noopener noreferrer">Install a signer extension</a>
+      </div>
+
+      <details class="onboarding-advanced">
+        <summary>Advanced users: nsec or bunker validation</summary>
+        <p>
+          Paste an nsec key or bunker:// token to verify format before connecting with your signer flow.
+        </p>
+        <div class="onboarding-advanced-row">
+          <input
+            type="text"
+            class="onboarding-advanced-input"
+            placeholder="nsec1... or bunker://..."
+            autocomplete="off"
+          />
+          <button type="button" class="onboarding-advanced-apply">Validate input</button>
+        </div>
+      </details>
+
+      <div class="onboarding-status" aria-live="polite"></div>
+    </div>
+  `;
+
+  dialogComponent.showModal();
+
+  const dialogNodes = document.querySelectorAll<HTMLDialogElement>(
+    '.nostr-base-dialog'
+  );
+  const dialog = dialogNodes[dialogNodes.length - 1];
+  if (!dialog) {
+    return { connected: false, source: 'dismissed' };
+  }
+
+  const connectButton = dialog.querySelector<HTMLButtonElement>(
+    '.onboarding-primary-btn'
+  );
+  const setupGuideButton = dialog.querySelector<HTMLButtonElement>(
+    '.onboarding-secondary-btn'
+  );
+  const skipButton = dialog.querySelector<HTMLButtonElement>(
+    '.onboarding-skip-btn'
+  );
+  const advancedInput = dialog.querySelector<HTMLInputElement>(
+    '.onboarding-advanced-input'
+  );
+  const advancedApplyButton = dialog.querySelector<HTMLButtonElement>(
+    '.onboarding-advanced-apply'
+  );
+  const statusNode = dialog.querySelector<HTMLElement>('.onboarding-status');
+
+  const setStatus = (message: string, kind: 'neutral' | 'error' | 'success') => {
+    if (!statusNode) return;
+    statusNode.textContent = message;
+    statusNode.classList.remove('error', 'success');
+    if (kind === 'error') statusNode.classList.add('error');
+    if (kind === 'success') statusNode.classList.add('success');
+  };
+
+  return new Promise<ShowAuthOnboardingResult>((resolve) => {
+    let settled = false;
+
+    const settle = (result: ShowAuthOnboardingResult) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+
+    dialog.addEventListener(
+      'close',
+      () => {
+        settle({ connected: false, source: 'dismissed' });
+      },
+      { once: true }
+    );
+
+    setupGuideButton?.addEventListener('click', () => {
+      window.open('https://nstart.me/', '_blank', 'noopener,noreferrer');
+      setStatus('Setup guide opened in a new tab. Return and press Connect when ready.', 'neutral');
+    });
+
+    skipButton?.addEventListener('click', () => {
+      dialogComponent.close();
+      settle({ connected: false, source: 'dismissed' });
+    });
+
+    advancedApplyButton?.addEventListener('click', () => {
+      const parsed = parseAdvancedInput(advancedInput?.value || '');
+      if (parsed.kind === 'invalid') {
+        setStatus(parsed.message, 'error');
+        return;
+      }
+      setStatus(parsed.message, 'success');
+    });
+
+    connectButton?.addEventListener('click', async () => {
+      connectButton.disabled = true;
+      setStatus('Opening signer connection...', 'neutral');
+
+      try {
+        const pubkey = await getPublicKey();
+        if (pubkey) {
+          setStatus('Connected. Continuing action...', 'success');
+          dialogComponent.close();
+          settle({ connected: true, source: 'connect' });
+          return;
+        }
+
+        setStatus(
+          'Connection is still pending. Complete signer auth, then try Connect again.',
+          'error'
+        );
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Could not start signer connection.';
+        setStatus(message, 'error');
+      } finally {
+        connectButton.disabled = false;
+      }
+    });
+  });
+}

--- a/src/common/auth-onboarding.ts
+++ b/src/common/auth-onboarding.ts
@@ -225,8 +225,7 @@ export async function showAuthOnboarding(
       setStatus('Opening signer connection...', 'neutral');
 
       try {
-        const pubkey = await getPublicKey();
-        if (pubkey) {
+        if (await getPublicKey()) {
           setStatus('Connected. Continuing action...', 'success');
           settle({ connected: true, source: 'connect' });
           dialogComponent.close();

--- a/src/common/auth-onboarding.ts
+++ b/src/common/auth-onboarding.ts
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MIT
 
-import { nip19 } from 'nostr-tools';
 import type { DialogComponent } from '../base/dialog-component/dialog-component';
 import '../base/dialog-component/dialog-component';
-import { isValidHex } from './utils';
 import { getAuthOnboardingDialogStyles } from './auth-onboarding-style';
 import { getPublicKey } from './nostr-login-service';
 
 type OnboardingAction = 'like' | 'zap' | 'follow';
-type AdvancedInputKind = 'nsec' | 'bunker' | 'invalid';
+type AdvancedInputKind = 'bunker' | 'invalid';
 
 interface ShowAuthOnboardingOptions {
   action: OnboardingAction;
@@ -55,7 +53,7 @@ function parseAdvancedInput(value: string): {
   if (!trimmed) {
     return {
       kind: 'invalid',
-      message: 'Paste an nsec key or bunker:// token to validate the format.',
+      message: 'Paste a bunker:// token to validate the format.',
     };
   }
 
@@ -80,37 +78,9 @@ function parseAdvancedInput(value: string): {
     }
   }
 
-  if (trimmed.startsWith('nsec1')) {
-    try {
-      const decoded = nip19.decode(trimmed);
-      if (decoded.type === 'nsec') {
-        return {
-          kind: 'nsec',
-          message: 'Valid nsec format. Import it into your signer app, then press Connect.',
-        };
-      }
-      return {
-        kind: 'invalid',
-        message: 'This bech32 value is not an nsec key.',
-      };
-    } catch {
-      return {
-        kind: 'invalid',
-        message: 'Invalid nsec format.',
-      };
-    }
-  }
-
-  if (isValidHex(trimmed)) {
-    return {
-      kind: 'nsec',
-      message: 'Valid raw private key format. Import it into your signer app, then press Connect.',
-    };
-  }
-
   return {
     kind: 'invalid',
-    message: 'Input is not recognized as nsec or bunker:// format.',
+    message: 'Input is not recognized as bunker:// format.',
   };
 }
 
@@ -160,15 +130,18 @@ export async function showAuthOnboarding(
       </div>
 
       <details class="onboarding-advanced">
-        <summary>Advanced users: nsec or bunker validation</summary>
+        <summary>Advanced users: bunker token validation</summary>
         <p>
-          Paste an nsec key or bunker:// token to verify format before connecting with your signer flow.
+          Paste a bunker:// token to verify format before connecting with your remote signer flow.
+        </p>
+        <p>
+          Never paste private keys (nsec or raw hex) into websites.
         </p>
         <div class="onboarding-advanced-row">
           <input
-            type="text"
+            type="password"
             class="onboarding-advanced-input"
-            placeholder="nsec1... or bunker://..."
+            placeholder="bunker://..."
             autocomplete="off"
           />
           <button type="button" class="onboarding-advanced-apply">Validate input</button>
@@ -181,10 +154,7 @@ export async function showAuthOnboarding(
 
   dialogComponent.showModal();
 
-  const dialogNodes = document.querySelectorAll<HTMLDialogElement>(
-    '.nostr-base-dialog'
-  );
-  const dialog = dialogNodes[dialogNodes.length - 1];
+  const dialog = dialogComponent.getDialogElement();
   if (!dialog) {
     return { connected: false, source: 'dismissed' };
   }
@@ -258,8 +228,8 @@ export async function showAuthOnboarding(
         const pubkey = await getPublicKey();
         if (pubkey) {
           setStatus('Connected. Continuing action...', 'success');
-          dialogComponent.close();
           settle({ connected: true, source: 'connect' });
+          dialogComponent.close();
           return;
         }
 

--- a/src/common/auth-onboarding.ts
+++ b/src/common/auth-onboarding.ts
@@ -224,25 +224,18 @@ export async function showAuthOnboarding(
       connectButton.disabled = true;
       setStatus('Opening signer connection...', 'neutral');
 
-      try {
-        if (await getPublicKey()) {
-          setStatus('Connected. Continuing action...', 'success');
-          settle({ connected: true, source: 'connect' });
-          dialogComponent.close();
-          return;
-        }
-
-        setStatus(
-          'Connection is still pending. Complete signer auth, then try Connect again.',
-          'error'
-        );
-      } catch (error) {
-        const message =
-          error instanceof Error ? error.message : 'Could not start signer connection.';
-        setStatus(message, 'error');
-      } finally {
-        connectButton.disabled = false;
+      if (await getPublicKey()) {
+        setStatus('Connected. Continuing action...', 'success');
+        settle({ connected: true, source: 'connect' });
+        dialogComponent.close();
+        return;
       }
+
+      setStatus(
+        'Connection is still pending. Complete signer auth, then try Connect again.',
+        'error'
+      );
+      connectButton.disabled = false;
     });
   });
 }

--- a/src/nostr-follow-button/nostr-follow-button.ts
+++ b/src/nostr-follow-button/nostr-follow-button.ts
@@ -5,7 +5,8 @@ import { NostrUserComponent } from '../base/user-component/nostr-user-component'
 import { renderFollowButton, RenderFollowButtonOptions } from './render';
 import { NCStatus } from '../base/base-component/nostr-base-component';
 import { getFollowButtonStyles } from './style';
-import { ensureInitialized } from '../common/nostr-login-service';
+import { ensureInitialized, getPublicKey } from '../common/nostr-login-service';
+import { showAuthOnboarding } from '../common/auth-onboarding';
 
 export default class NostrFollowButton extends NostrUserComponent {
   protected followStatus = this.channel('follow');
@@ -76,6 +77,31 @@ export default class NostrFollowButton extends NostrUserComponent {
           'Could not resolve user to follow.'
         );
         return;
+      }
+
+      let signerPubkey = await getPublicKey();
+      if (!signerPubkey) {
+        const onboardingResult = await showAuthOnboarding({
+          action: 'follow',
+          theme: this.theme === 'dark' ? 'dark' : 'light',
+        });
+
+        if (!onboardingResult.connected) {
+          this.followStatus.set(
+            NCStatus.Error,
+            'Connect a Nostr signer to follow this profile.'
+          );
+          return;
+        }
+
+        signerPubkey = await getPublicKey();
+        if (!signerPubkey) {
+          this.followStatus.set(
+            NCStatus.Error,
+            'Signer is not ready yet. Complete connection and try again.'
+          );
+          return;
+        }
       }
 
       const signer = new NDKNip07Signer();

--- a/src/nostr-follow-button/nostr-follow-button.ts
+++ b/src/nostr-follow-button/nostr-follow-button.ts
@@ -79,8 +79,7 @@ export default class NostrFollowButton extends NostrUserComponent {
         return;
       }
 
-      let signerPubkey = await getPublicKey();
-      if (!signerPubkey) {
+      if (!(await getPublicKey())) {
         const onboardingResult = await showAuthOnboarding({
           action: 'follow',
           theme: this.theme === 'dark' ? 'dark' : 'light',
@@ -94,8 +93,7 @@ export default class NostrFollowButton extends NostrUserComponent {
           return;
         }
 
-        signerPubkey = await getPublicKey();
-        if (!signerPubkey) {
+        if (!(await getPublicKey())) {
           this.followStatus.set(
             NCStatus.Error,
             'Signer is not ready yet. Complete connection and try again.'

--- a/src/nostr-like-button/nostr-like.ts
+++ b/src/nostr-like-button/nostr-like.ts
@@ -17,6 +17,7 @@ import {
   LikeCountResult 
 } from './like-utils';
 import { ensureInitialized } from '../common/nostr-login-service';
+import { showAuthOnboarding } from '../common/auth-onboarding';
 import { normalizeURL } from 'nostr-tools/utils';
 
 /**
@@ -172,10 +173,31 @@ export default class NostrLike extends NostrBaseComponent {
       await ensureInitialized();
 
       // Check user like status
-      const userPubkey = await getUserPubkey();
-      if (userPubkey) {
-        this.isLiked = await hasUserLiked(this.currentUrl, userPubkey, this.getRelays());
+      let userPubkey = await getUserPubkey();
+      if (!userPubkey) {
+        const onboardingResult = await showAuthOnboarding({
+          action: 'like',
+          theme: this.theme === 'dark' ? 'dark' : 'light',
+        });
+
+        if (!onboardingResult.connected) {
+          this.likeActionStatus.set(NCStatus.Error, 'Connect a Nostr signer to like this page.');
+          this.render();
+          return;
+        }
+
+        userPubkey = await getUserPubkey();
+        if (!userPubkey) {
+          this.likeActionStatus.set(
+            NCStatus.Error,
+            'Signer is not ready yet. Complete connection and try again.'
+          );
+          this.render();
+          return;
+        }
       }
+
+      this.isLiked = await hasUserLiked(this.currentUrl, userPubkey, this.getRelays());
 
       // If already liked, show confirmation dialog
       if (this.isLiked) {

--- a/src/nostr-zap-button/nostr-zap.ts
+++ b/src/nostr-zap-button/nostr-zap.ts
@@ -10,7 +10,8 @@ import { getZapButtonStyles } from './style';
 import { fetchTotalZapAmount, ZapDetails } from './zap-utils';
 import { isValidUrl } from '../common/utils';
 import type { DialogComponent } from '../base/dialog-component/dialog-component';
-import { ensureInitialized } from '../common/nostr-login-service';
+import { ensureInitialized, getPublicKey } from '../common/nostr-login-service';
+import { showAuthOnboarding } from '../common/auth-onboarding';
 
 /**
  * <nostr-zap-button>
@@ -146,6 +147,33 @@ export default class NostrZap extends NostrUserComponent {
         this.zapActionStatus.set(NCStatus.Error, "Could not resolve user to zap.");
         this.render();
         return;
+      }
+
+      let signerPubkey = await getPublicKey();
+      if (!signerPubkey) {
+        const onboardingResult = await showAuthOnboarding({
+          action: 'zap',
+          theme: this.theme === 'dark' ? 'dark' : 'light',
+        });
+
+        if (!onboardingResult.connected) {
+          this.zapActionStatus.set(
+            NCStatus.Error,
+            'Connect a Nostr signer to send a zap.'
+          );
+          this.render();
+          return;
+        }
+
+        signerPubkey = await getPublicKey();
+        if (!signerPubkey) {
+          this.zapActionStatus.set(
+            NCStatus.Error,
+            'Signer is not ready yet. Complete connection and try again.'
+          );
+          this.render();
+          return;
+        }
       }
 
       const relays = this.getRelays().join(",");

--- a/src/nostr-zap-button/nostr-zap.ts
+++ b/src/nostr-zap-button/nostr-zap.ts
@@ -149,8 +149,7 @@ export default class NostrZap extends NostrUserComponent {
         return;
       }
 
-      let signerPubkey = await getPublicKey();
-      if (!signerPubkey) {
+      if (!(await getPublicKey())) {
         const onboardingResult = await showAuthOnboarding({
           action: 'zap',
           theme: this.theme === 'dark' ? 'dark' : 'light',
@@ -165,8 +164,7 @@ export default class NostrZap extends NostrUserComponent {
           return;
         }
 
-        signerPubkey = await getPublicKey();
-        if (!signerPubkey) {
+        if (!(await getPublicKey())) {
           this.zapActionStatus.set(
             NCStatus.Error,
             'Signer is not ready yet. Complete connection and try again.'


### PR DESCRIPTION
This PR introduces the first implementation slice for Issue #60 by adding a newcomer-friendly signer onboarding flow for Like, Zap, and Follow actions.

**What this PR changes**:

- Adds a shared onboarding dialog module and styles to explain Nostr actions in plain language and guide first-time users.
- Adds a clear connect path when signer is unavailable at action time.
- Adds optional advanced input validation for nsec and bunker token formats.
- Wires the onboarding flow into:
  - Like click flow
  - Zap click flow
  - Follow click flow

Why this PR is opened now
This is an initial V1 implementation slice intended to gather maintainer feedback before continuing with deeper follow-up changes.

Request for @saiy2k feedback before further work

- Onboarding content direction and tone for non-Nostr users.
- Whether advanced nsec and bunker handling should stay as validation-only in this phase or be expanded.
- Expected final auth behavior parity across Like, Zap, Follow.
- Preferred next phase scope (render state refinements, docs/spec updates, additional tests).

- Design iteration based on external forum feedback (to be done after maintainer guidance).

Work on issue #60 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authentication onboarding dialog (light/dark, responsive, reduced-motion) with setup guidance, advanced input, status messages, and CTAs.
  * Follow, Like, and Zap actions now prompt onboarding when a signer is not available.

* **Bug Fixes**
  * Improved connection messaging and button states to better reflect progress, success, and error outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->