### PR TITLE
Fix/issue 78 like count drift clean

### DIFF
--- a/src/nostr-like-button/__tests__/optimistic-state.test.ts
+++ b/src/nostr-like-button/__tests__/optimistic-state.test.ts
@@ -23,7 +23,7 @@ describe('optimistic-state', () => {
     expect(next).toEqual({ isLiked: false, likeCount: 0 });
   });
 
-  it('does not rollback when optimistic update was never applied', () => {
+  it('failure-before-optimistic keeps current state unchanged', () => {
     const result = rollbackOptimisticLikeState({
       current: { isLiked: false, likeCount: 5 },
       snapshot: { isLiked: false, likeCount: 6 },
@@ -33,7 +33,17 @@ describe('optimistic-state', () => {
     expect(result).toEqual({ isLiked: false, likeCount: 5 });
   });
 
-  it('restores snapshot when optimistic update was applied', () => {
+  it('failure-before-optimistic still clamps invalid current counts', () => {
+    const result = rollbackOptimisticLikeState({
+      current: { isLiked: false, likeCount: -9 },
+      snapshot: { isLiked: false, likeCount: 6 },
+      didApplyOptimisticUpdate: false,
+    });
+
+    expect(result).toEqual({ isLiked: false, likeCount: 0 });
+  });
+
+  it('failure-after-optimistic restores pre-mutation snapshot', () => {
     const result = rollbackOptimisticLikeState({
       current: { isLiked: true, likeCount: 6 },
       snapshot: { isLiked: false, likeCount: 5 },

--- a/src/nostr-like-button/__tests__/optimistic-state.test.ts
+++ b/src/nostr-like-button/__tests__/optimistic-state.test.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+import {
+  applyOptimisticLike,
+  applyOptimisticUnlike,
+  clampLikeCount,
+  rollbackOptimisticLikeState,
+} from '../optimistic-state';
+
+describe('optimistic-state', () => {
+  it('clamps negative counts to zero', () => {
+    expect(clampLikeCount(-2)).toBe(0);
+  });
+
+  it('applies optimistic like', () => {
+    const next = applyOptimisticLike({ isLiked: false, likeCount: 7 });
+    expect(next).toEqual({ isLiked: true, likeCount: 8 });
+  });
+
+  it('applies optimistic unlike without going negative', () => {
+    const next = applyOptimisticUnlike({ isLiked: true, likeCount: 0 });
+    expect(next).toEqual({ isLiked: false, likeCount: 0 });
+  });
+
+  it('does not rollback when optimistic update was never applied', () => {
+    const result = rollbackOptimisticLikeState({
+      current: { isLiked: false, likeCount: 5 },
+      snapshot: { isLiked: false, likeCount: 6 },
+      didApplyOptimisticUpdate: false,
+    });
+
+    expect(result).toEqual({ isLiked: false, likeCount: 5 });
+  });
+
+  it('restores snapshot when optimistic update was applied', () => {
+    const result = rollbackOptimisticLikeState({
+      current: { isLiked: true, likeCount: 6 },
+      snapshot: { isLiked: false, likeCount: 5 },
+      didApplyOptimisticUpdate: true,
+    });
+
+    expect(result).toEqual({ isLiked: false, likeCount: 5 });
+  });
+});

--- a/src/nostr-like-button/nostr-like.ts
+++ b/src/nostr-like-button/nostr-like.ts
@@ -18,6 +18,12 @@ import {
 } from './like-utils';
 import { ensureInitialized } from '../common/nostr-login-service';
 import { normalizeURL } from 'nostr-tools/utils';
+import {
+  applyOptimisticLike,
+  applyOptimisticUnlike,
+  rollbackOptimisticLikeState,
+  type LikeUiState,
+} from './optimistic-state';
 
 /**
  * <nostr-like-button>
@@ -213,6 +219,12 @@ export default class NostrLike extends NostrBaseComponent {
     this.likeActionStatus.set(NCStatus.Loading);
     this.render();
 
+    const snapshot: LikeUiState = {
+      isLiked: this.isLiked,
+      likeCount: this.likeCount,
+    };
+    let didApplyOptimisticUpdate = false;
+
     try {
       // Create like event
       const event = createLikeEvent(this.currentUrl);
@@ -225,8 +237,10 @@ export default class NostrLike extends NostrBaseComponent {
       await ndkEvent.publish();
       
       // Update state optimistically
-      this.isLiked = true;
-      this.likeCount++;
+      const optimisticState = applyOptimisticLike(snapshot);
+      this.isLiked = optimisticState.isLiked;
+      this.likeCount = optimisticState.likeCount;
+      didApplyOptimisticUpdate = true;
       this.likeActionStatus.set(NCStatus.Ready);
       
       // Refresh like count to get accurate data
@@ -234,9 +248,17 @@ export default class NostrLike extends NostrBaseComponent {
     } catch (error) {
       console.error('[NostrLike] Failed to like:', error);
       
-      // Rollback optimistic update
-      this.isLiked = false;
-      this.likeCount--;
+      // Restore previous state only if local optimistic state was applied.
+      const restoredState = rollbackOptimisticLikeState({
+        current: {
+          isLiked: this.isLiked,
+          likeCount: this.likeCount,
+        },
+        snapshot,
+        didApplyOptimisticUpdate,
+      });
+      this.isLiked = restoredState.isLiked;
+      this.likeCount = restoredState.likeCount;
       
       const errorMessage = error instanceof Error ? error.message : 'Failed to like';
       this.likeActionStatus.set(NCStatus.Error, errorMessage);
@@ -257,6 +279,12 @@ export default class NostrLike extends NostrBaseComponent {
 
     this.likeActionStatus.set(NCStatus.Loading);
     this.render();
+
+    const snapshot: LikeUiState = {
+      isLiked: this.isLiked,
+      likeCount: this.likeCount,
+    };
+    let didApplyOptimisticUpdate = false;
     
     try {
       // Create unlike event
@@ -270,10 +298,10 @@ export default class NostrLike extends NostrBaseComponent {
       await ndkEvent.publish();
       
       // Update state optimistically
-      this.isLiked = false;
-      if (this.likeCount > 0) {
-        this.likeCount--;
-      }
+      const optimisticState = applyOptimisticUnlike(snapshot);
+      this.isLiked = optimisticState.isLiked;
+      this.likeCount = optimisticState.likeCount;
+      didApplyOptimisticUpdate = true;
       this.likeActionStatus.set(NCStatus.Ready);
       
       // Refresh like count to get accurate data
@@ -281,9 +309,17 @@ export default class NostrLike extends NostrBaseComponent {
     } catch (error) {
       console.error('[NostrLike] Failed to unlike:', error);
       
-      // Rollback optimistic update
-      this.isLiked = true;
-      this.likeCount++;
+      // Restore previous state only if local optimistic state was applied.
+      const restoredState = rollbackOptimisticLikeState({
+        current: {
+          isLiked: this.isLiked,
+          likeCount: this.likeCount,
+        },
+        snapshot,
+        didApplyOptimisticUpdate,
+      });
+      this.isLiked = restoredState.isLiked;
+      this.likeCount = restoredState.likeCount;
       
       const errorMessage = error instanceof Error ? error.message : 'Failed to unlike';
       this.likeActionStatus.set(NCStatus.Error, errorMessage);

--- a/src/nostr-like-button/nostr-like.ts
+++ b/src/nostr-like-button/nostr-like.ts
@@ -48,6 +48,7 @@ export default class NostrLike extends NostrBaseComponent {
   private cachedLikeDetails: LikeCountResult | null = null;
   private loadSeq = 0;
   private isResyncingLikeCount = false;
+  private needsResyncLikeCount = false;
 
   constructor() {
     super();
@@ -167,12 +168,16 @@ export default class NostrLike extends NostrBaseComponent {
    * This keeps local UI from staying stale when an operation partially fails.
    */
   private queueAuthoritativeCountResync(): void {
+    this.needsResyncLikeCount = true;
     if (this.isResyncingLikeCount) return;
 
     this.isResyncingLikeCount = true;
     void (async () => {
       try {
-        await this.updateLikeCount();
+        while (this.needsResyncLikeCount) {
+          this.needsResyncLikeCount = false;
+          await this.updateLikeCount();
+        }
       } finally {
         this.isResyncingLikeCount = false;
       }
@@ -262,7 +267,7 @@ export default class NostrLike extends NostrBaseComponent {
     this.likeActionStatus.set(NCStatus.Loading);
     this.render();
 
-    const snapshot: LikeUiState = {
+    let rollbackSnapshot: LikeUiState = {
       isLiked: this.isLiked,
       likeCount: this.likeCount,
     };
@@ -274,16 +279,21 @@ export default class NostrLike extends NostrBaseComponent {
       
       // Sign with NIP-07
       const signedEvent = await signEvent(event);
+
+      // Apply optimistic state from the latest UI state at mutation time.
+      rollbackSnapshot = {
+        isLiked: this.isLiked,
+        likeCount: this.likeCount,
+      };
+      const optimisticState = applyOptimisticLike(rollbackSnapshot);
+      this.isLiked = optimisticState.isLiked;
+      this.likeCount = optimisticState.likeCount;
+      didApplyOptimisticUpdate = true;
       
       // Create NDKEvent and publish
       const ndkEvent = new NDKEvent(this.nostrService.getNDK(), signedEvent);
       await ndkEvent.publish();
-      
-      // Update state optimistically
-      const optimisticState = applyOptimisticLike(snapshot);
-      this.isLiked = optimisticState.isLiked;
-      this.likeCount = optimisticState.likeCount;
-      didApplyOptimisticUpdate = true;
+
       this.likeActionStatus.set(NCStatus.Ready);
       
       // Refresh like count to get accurate data
@@ -293,7 +303,7 @@ export default class NostrLike extends NostrBaseComponent {
 
       this.handleLikeMutationFailure(
         error,
-        snapshot,
+        rollbackSnapshot,
         didApplyOptimisticUpdate,
         'Failed to like'
       );
@@ -315,7 +325,7 @@ export default class NostrLike extends NostrBaseComponent {
     this.likeActionStatus.set(NCStatus.Loading);
     this.render();
 
-    const snapshot: LikeUiState = {
+    let rollbackSnapshot: LikeUiState = {
       isLiked: this.isLiked,
       likeCount: this.likeCount,
     };
@@ -327,16 +337,21 @@ export default class NostrLike extends NostrBaseComponent {
       
       // Sign with NIP-07
       const signedEvent = await signEvent(event);
+
+      // Apply optimistic state from the latest UI state at mutation time.
+      rollbackSnapshot = {
+        isLiked: this.isLiked,
+        likeCount: this.likeCount,
+      };
+      const optimisticState = applyOptimisticUnlike(rollbackSnapshot);
+      this.isLiked = optimisticState.isLiked;
+      this.likeCount = optimisticState.likeCount;
+      didApplyOptimisticUpdate = true;
       
       // Create NDKEvent and publish
       const ndkEvent = new NDKEvent(this.nostrService.getNDK(), signedEvent);
       await ndkEvent.publish();
-      
-      // Update state optimistically
-      const optimisticState = applyOptimisticUnlike(snapshot);
-      this.isLiked = optimisticState.isLiked;
-      this.likeCount = optimisticState.likeCount;
-      didApplyOptimisticUpdate = true;
+
       this.likeActionStatus.set(NCStatus.Ready);
       
       // Refresh like count to get accurate data
@@ -346,7 +361,7 @@ export default class NostrLike extends NostrBaseComponent {
 
       this.handleLikeMutationFailure(
         error,
-        snapshot,
+        rollbackSnapshot,
         didApplyOptimisticUpdate,
         'Failed to unlike'
       );

--- a/src/nostr-like-button/nostr-like.ts
+++ b/src/nostr-like-button/nostr-like.ts
@@ -21,6 +21,7 @@ import { normalizeURL } from 'nostr-tools/utils';
 import {
   applyOptimisticLike,
   applyOptimisticUnlike,
+  clampLikeCount,
   rollbackOptimisticLikeState,
   type LikeUiState,
 } from './optimistic-state';
@@ -46,6 +47,7 @@ export default class NostrLike extends NostrBaseComponent {
   private likeCount: number   = 0;
   private cachedLikeDetails: LikeCountResult | null = null;
   private loadSeq = 0;
+  private isResyncingLikeCount = false;
 
   constructor() {
     super();
@@ -149,7 +151,7 @@ export default class NostrLike extends NostrBaseComponent {
      
       const result = await fetchLikesForUrl(this.currentUrl, this.getRelays());
       if (seq !== this.loadSeq) return; // stale
-      this.likeCount = result.totalCount;
+      this.likeCount = clampLikeCount(result.totalCount);
       this.cachedLikeDetails = result;
       this.likeListStatus.set(NCStatus.Ready);
     } catch (error) {
@@ -158,6 +160,47 @@ export default class NostrLike extends NostrBaseComponent {
     } finally {
       this.render();
     }
+  }
+
+  /**
+   * Best-effort reconciliation with relay state after a failed mutation.
+   * This keeps local UI from staying stale when an operation partially fails.
+   */
+  private queueAuthoritativeCountResync(): void {
+    if (this.isResyncingLikeCount) return;
+
+    this.isResyncingLikeCount = true;
+    void (async () => {
+      try {
+        await this.updateLikeCount();
+      } finally {
+        this.isResyncingLikeCount = false;
+      }
+    })();
+  }
+
+  private handleLikeMutationFailure(
+    error: unknown,
+    snapshot: LikeUiState,
+    didApplyOptimisticUpdate: boolean,
+    fallbackMessage: string
+  ): void {
+    const restoredState = rollbackOptimisticLikeState({
+      current: {
+        isLiked: this.isLiked,
+        likeCount: this.likeCount,
+      },
+      snapshot,
+      didApplyOptimisticUpdate,
+    });
+
+    this.isLiked = restoredState.isLiked;
+    this.likeCount = restoredState.likeCount;
+
+    const errorMessage = error instanceof Error ? error.message : fallbackMessage;
+    this.likeActionStatus.set(NCStatus.Error, errorMessage);
+
+    this.queueAuthoritativeCountResync();
   }
 
   private async handleLikeClick() {
@@ -247,21 +290,13 @@ export default class NostrLike extends NostrBaseComponent {
       await this.updateLikeCount();
     } catch (error) {
       console.error('[NostrLike] Failed to like:', error);
-      
-      // Restore previous state only if local optimistic state was applied.
-      const restoredState = rollbackOptimisticLikeState({
-        current: {
-          isLiked: this.isLiked,
-          likeCount: this.likeCount,
-        },
+
+      this.handleLikeMutationFailure(
+        error,
         snapshot,
         didApplyOptimisticUpdate,
-      });
-      this.isLiked = restoredState.isLiked;
-      this.likeCount = restoredState.likeCount;
-      
-      const errorMessage = error instanceof Error ? error.message : 'Failed to like';
-      this.likeActionStatus.set(NCStatus.Error, errorMessage);
+        'Failed to like'
+      );
     } finally {
       this.render();
     }
@@ -308,21 +343,13 @@ export default class NostrLike extends NostrBaseComponent {
       await this.updateLikeCount();
     } catch (error) {
       console.error('[NostrLike] Failed to unlike:', error);
-      
-      // Restore previous state only if local optimistic state was applied.
-      const restoredState = rollbackOptimisticLikeState({
-        current: {
-          isLiked: this.isLiked,
-          likeCount: this.likeCount,
-        },
+
+      this.handleLikeMutationFailure(
+        error,
         snapshot,
         didApplyOptimisticUpdate,
-      });
-      this.isLiked = restoredState.isLiked;
-      this.likeCount = restoredState.likeCount;
-      
-      const errorMessage = error instanceof Error ? error.message : 'Failed to unlike';
-      this.likeActionStatus.set(NCStatus.Error, errorMessage);
+        'Failed to unlike'
+      );
     } finally {
       this.render();
     }

--- a/src/nostr-like-button/optimistic-state.ts
+++ b/src/nostr-like-button/optimistic-state.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+export interface LikeUiState {
+  isLiked: boolean;
+  likeCount: number;
+}
+
+interface RollbackOptimisticLikeStateParams {
+  current: LikeUiState;
+  snapshot: LikeUiState;
+  didApplyOptimisticUpdate: boolean;
+}
+
+export function clampLikeCount(nextCount: number): number {
+  return Math.max(0, nextCount);
+}
+
+export function applyOptimisticLike(state: LikeUiState): LikeUiState {
+  return {
+    isLiked: true,
+    likeCount: clampLikeCount(state.likeCount + 1),
+  };
+}
+
+export function applyOptimisticUnlike(state: LikeUiState): LikeUiState {
+  return {
+    isLiked: false,
+    likeCount: clampLikeCount(state.likeCount - 1),
+  };
+}
+
+export function rollbackOptimisticLikeState({
+  current,
+  snapshot,
+  didApplyOptimisticUpdate,
+}: RollbackOptimisticLikeStateParams): LikeUiState {
+  if (!didApplyOptimisticUpdate) {
+    return {
+      isLiked: current.isLiked,
+      likeCount: clampLikeCount(current.likeCount),
+    };
+  }
+
+  return {
+    isLiked: snapshot.isLiked,
+    likeCount: clampLikeCount(snapshot.likeCount),
+  };
+}


### PR DESCRIPTION
Fixes #78

This PR fully resolves the like-count drift bug in failed like/unlike mutation paths.

When a like or unlike operation fails before optimistic state is applied, the UI no longer performs rollback arithmetic that can incorrectly increment or decrement the displayed count. The implementation now restores state deterministically and keeps count values non-negative.

Root Cause
----------

The previous catch-path rollback assumed optimistic mutation had already been applied.If a failure occurred earlier (for example signer denial or publish failure), rollback logic could still run and drift local count.

What Changed
------------

*   Added pure optimistic-state helpers in [`optimistic-state.ts`](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
    
*   Updated mutation and failure handling in [`nostr-like.ts`](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
    
*   Expanded regression coverage in [`optimistic-state.test.ts`](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
    

Implementation Details
----------------------

*   Like/unlike flows now snapshot pre-mutation UI state.
    
*   A local didApplyOptimisticUpdate flag controls rollback behavior.
    
*   Rollback is state-based (restore snapshot) rather than arithmetic.
    
*   Fetched relay totals are clamped before assigning to displayed count.
    
*   Added best-effort authoritative count resync after failed mutations, with an in-flight guard to prevent redundant resync calls.
    

Behavior After This Change
--------------------------

*   Failure-before-optimistic: local count does not drift.
    
*   Failure-after-optimistic: local state is restored to pre-mutation snapshot.
    
*   Displayed like count never drops below zero.
    
*   Failed mutations attempt relay-backed reconciliation to converge UI state.
    

Testing
-------

Executed targeted regression tests:

*   npm run -s test -- [`optimistic-state.test.ts`](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
    

Result:

*   1 test file passed
    
*   6 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Like button now applies optimistic like/unlike updates immediately and clamps counts to never go below zero.
  * Improved recovery: failed like/unlike attempts restore prior UI state and surface a clear error status; authoritative count resynchronization is queued to avoid repeated concurrent resyncs.

* **Tests**
  * Added tests covering clamping, optimistic apply/rollback flows, and failure/resync scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->