### PR TITLE
Add shared signer onboarding for like, zap, and follow

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ All interactive components (Follow, Like, Zap) require user authentication. Comp
 - **NIP-07 Browser Extensions** (Alby, nos2x, etc.)
 - **NIP-46 Remote Signers** (Bunkers)
 
-No host-page setup is required. Users can connect with an existing signer or through the floating `window.nostr.js` widget when prompted.
+No host-page setup is required. First-time users are guided through a lightweight onboarding dialog with a quick setup path and signer install links, while already-connected users go straight into the signer approval flow.
 
 ---
 
 ## 1. Nostr Zap
 
 A Zap button that sends sats to a Nostr user and can optionally scope those zaps to a specific URL for open-web attribution.
-When `url` is provided, the component uses a deterministic `["a", "39735:<pubkey>:<normalized_url>"]` tag so relays can apply URL-specific `#a` filtering when fetching zap receipts.
+When `url` is provided, the component uses a deterministic `["a", "39735:<pubkey>:<normalized_url>"]` tag so relays can apply URL-specific `#a` filtering when fetching zap receipts. First-time users are guided through a quick signer onboarding flow before the zap modal opens.
 What is [Zap](https://www.youtube.com/shorts/PDnrh8pkF3g)? 
 
 **Usage:**
@@ -108,7 +108,7 @@ What is [Zap](https://www.youtube.com/shorts/PDnrh8pkF3g)?
 
 ## 2. Nostr Follow
 
-A simple button that allows users to follow a Nostr profile.
+A simple button that allows users to follow a Nostr profile. If the user has not connected a signer yet, the first click opens a short onboarding flow and then continues with the follow action.
 
 **Usage:**
 
@@ -135,7 +135,7 @@ A simple button that allows users to follow a Nostr profile.
 ## 3. Nostr Like
 
 A like button that uses NIP-25 external content reactions to like or unlike any URL on the web and display the net reaction count.
-If `url` is omitted, the component automatically uses the current page URL.
+First-time users get a short onboarding flow before the like/unlike action continues. If `url` is omitted, the component automatically uses the current page URL.
 
 **Usage:**
 

--- a/src/base/dialog-component/dialog-component.ts
+++ b/src/base/dialog-component/dialog-component.ts
@@ -168,6 +168,13 @@ export class DialogComponent extends HTMLElement {
   }
 
   /**
+   * Returns the native dialog element rendered by this component instance.
+   */
+  public getDialogElement(): HTMLDialogElement | null {
+    return this.dialog;
+  }
+
+  /**
    * Show the dialog as modal
    */
   public showModal(): void {
@@ -254,4 +261,3 @@ export class DialogComponent extends HTMLElement {
 if (!customElements.get('dialog-component')) {
   customElements.define('dialog-component', DialogComponent);
 }
-

--- a/src/common/__tests__/auth-onboarding.test.ts
+++ b/src/common/__tests__/auth-onboarding.test.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createEnsureSignerForAction,
+  getAuthOnboardingContent,
+  getAuthOnboardingLinks,
+  getSignerUnavailableMessage,
+} from '../auth-onboarding';
+
+describe('auth onboarding helpers', () => {
+  it('returns action-aware onboarding copy', () => {
+    const likeContent = getAuthOnboardingContent('like');
+    const zapContent = getAuthOnboardingContent('zap');
+    const followContent = getAuthOnboardingContent('follow');
+
+    expect(likeContent.title).toContain('likes');
+    expect(zapContent.description).toContain('Lightning');
+    expect(followContent.whyItMatters).toContain('audience');
+  });
+
+  it('returns stable setup and signer install links', () => {
+    expect(getAuthOnboardingLinks()).toEqual({
+      quickSetupUrl: 'https://nstart.me/',
+      signerInstallUrl: 'https://getalby.com/',
+    });
+  });
+
+  it('returns action-aware unavailable messages', () => {
+    expect(getSignerUnavailableMessage('like')).toBe(
+      'Connect a Nostr signer to like this page.'
+    );
+    expect(getSignerUnavailableMessage('zap')).toBe(
+      'Connect a Nostr signer to send a zap.'
+    );
+    expect(getSignerUnavailableMessage('follow')).toBe(
+      'Connect a Nostr signer to follow this profile.'
+    );
+  });
+});
+
+describe('createEnsureSignerForAction', () => {
+  it('skips onboarding when the signer is already connected', async () => {
+    const showAuthOnboarding = vi.fn();
+    const ensureSignerForAction = createEnsureSignerForAction({
+      ensureInitialized: vi.fn().mockResolvedValue(undefined),
+      getPublicKey: vi.fn().mockResolvedValue('pubkey-123'),
+      showAuthOnboarding,
+    });
+
+    const result = await ensureSignerForAction({
+      action: 'like',
+      theme: 'dark',
+    });
+
+    expect(result).toEqual({
+      status: 'already-connected',
+      publicKey: 'pubkey-123',
+    });
+    expect(showAuthOnboarding).not.toHaveBeenCalled();
+  });
+
+  it('returns dismissed when the user closes onboarding', async () => {
+    const ensureSignerForAction = createEnsureSignerForAction({
+      ensureInitialized: vi.fn().mockResolvedValue(undefined),
+      getPublicKey: vi.fn().mockResolvedValue(null),
+      showAuthOnboarding: vi
+        .fn()
+        .mockResolvedValue({ status: 'dismissed' }),
+    });
+
+    const result = await ensureSignerForAction({
+      action: 'zap',
+      theme: 'light',
+    });
+
+    expect(result).toEqual({
+      status: 'dismissed',
+      publicKey: null,
+    });
+  });
+
+  it('returns connected after onboarding succeeds', async () => {
+    const getPublicKey = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce('pubkey-connected');
+    const showAuthOnboarding = vi
+      .fn()
+      .mockResolvedValue({ status: 'connect' });
+
+    const ensureSignerForAction = createEnsureSignerForAction({
+      ensureInitialized: vi.fn().mockResolvedValue(undefined),
+      getPublicKey,
+      showAuthOnboarding,
+    });
+
+    const result = await ensureSignerForAction({
+      action: 'follow',
+      theme: 'dark',
+    });
+
+    expect(showAuthOnboarding).toHaveBeenCalledWith({
+      action: 'follow',
+      theme: 'dark',
+    });
+    expect(result).toEqual({
+      status: 'connected',
+      publicKey: 'pubkey-connected',
+    });
+  });
+
+  it('returns unavailable when initialization fails', async () => {
+    const ensureSignerForAction = createEnsureSignerForAction({
+      ensureInitialized: vi
+        .fn()
+        .mockRejectedValue(new Error('init failed')),
+      getPublicKey: vi.fn(),
+      showAuthOnboarding: vi.fn(),
+    });
+
+    const result = await ensureSignerForAction({
+      action: 'zap',
+      theme: 'light',
+    });
+
+    expect(result).toEqual({
+      status: 'unavailable',
+      publicKey: null,
+      message: 'Connect a Nostr signer to send a zap.',
+    });
+  });
+});

--- a/src/common/__tests__/auth-onboarding.test.ts
+++ b/src/common/__tests__/auth-onboarding.test.ts
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MIT
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createEnsureSignerForAction,
   getAuthOnboardingContent,
   getAuthOnboardingLinks,
   getSignerUnavailableMessage,
+  hasConnectedSigner,
 } from '../auth-onboarding';
 
 describe('auth onboarding helpers', () => {
@@ -39,12 +40,63 @@ describe('auth onboarding helpers', () => {
   });
 });
 
+describe('hasConnectedSigner', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const stubBrowser = (options: {
+    nostr?: unknown;
+    storedSession?: string | null;
+    storageThrows?: boolean;
+  }) => {
+    vi.stubGlobal('window', {
+      nostr: options.nostr,
+      localStorage: {
+        getItem: vi.fn((key: string) => {
+          if (options.storageThrows) {
+            throw new Error('storage blocked');
+          }
+          return key === 'wnj:bunkerPointer'
+            ? (options.storedSession ?? null)
+            : null;
+        }),
+      },
+    });
+  };
+
+  it('returns false outside a browser', () => {
+    expect(hasConnectedSigner()).toBe(false);
+  });
+
+  it('detects a NIP-07 extension', () => {
+    stubBrowser({ nostr: { getPublicKey: () => {} } });
+    expect(hasConnectedSigner()).toBe(true);
+  });
+
+  it('does not treat the window.nostr.js shim as an extension', () => {
+    stubBrowser({ nostr: { isWnj: true } });
+    expect(hasConnectedSigner()).toBe(false);
+  });
+
+  it('detects a stored window.nostr.js session', () => {
+    stubBrowser({ nostr: { isWnj: true }, storedSession: 'nsec1example' });
+    expect(hasConnectedSigner()).toBe(true);
+  });
+
+  it('returns false when storage access is blocked', () => {
+    stubBrowser({ storageThrows: true });
+    expect(hasConnectedSigner()).toBe(false);
+  });
+});
+
 describe('createEnsureSignerForAction', () => {
-  it('skips onboarding when the signer is already connected', async () => {
+  it('skips onboarding when a signer is already reachable', async () => {
     const showAuthOnboarding = vi.fn();
     const ensureSignerForAction = createEnsureSignerForAction({
       ensureInitialized: vi.fn().mockResolvedValue(undefined),
       getPublicKey: vi.fn().mockResolvedValue('pubkey-123'),
+      hasConnectedSigner: vi.fn().mockReturnValue(true),
       showAuthOnboarding,
     });
 
@@ -60,10 +112,76 @@ describe('createEnsureSignerForAction', () => {
     expect(showAuthOnboarding).not.toHaveBeenCalled();
   });
 
-  it('returns dismissed when the user closes onboarding', async () => {
+  it('returns unavailable when a reachable signer yields no public key', async () => {
+    const showAuthOnboarding = vi.fn();
     const ensureSignerForAction = createEnsureSignerForAction({
       ensureInitialized: vi.fn().mockResolvedValue(undefined),
       getPublicKey: vi.fn().mockResolvedValue(null),
+      hasConnectedSigner: vi.fn().mockReturnValue(true),
+      showAuthOnboarding,
+    });
+
+    const result = await ensureSignerForAction({
+      action: 'like',
+      theme: 'light',
+    });
+
+    expect(result).toEqual({
+      status: 'unavailable',
+      publicKey: null,
+      message: 'Connect a Nostr signer to like this page.',
+    });
+    expect(showAuthOnboarding).not.toHaveBeenCalled();
+  });
+
+  it('shows onboarding before any signer call for first-time users', async () => {
+    const callOrder: string[] = [];
+    const ensureInitialized = vi.fn(async () => {
+      callOrder.push('ensureInitialized');
+    });
+    const getPublicKey = vi.fn(async () => {
+      callOrder.push('getPublicKey');
+      return 'pubkey-connected';
+    });
+    const showAuthOnboarding = vi.fn(async () => {
+      callOrder.push('showAuthOnboarding');
+      return { status: 'connect' as const };
+    });
+
+    const ensureSignerForAction = createEnsureSignerForAction({
+      ensureInitialized,
+      getPublicKey,
+      hasConnectedSigner: vi.fn().mockReturnValue(false),
+      showAuthOnboarding,
+    });
+
+    const result = await ensureSignerForAction({
+      action: 'follow',
+      theme: 'dark',
+    });
+
+    expect(callOrder).toEqual([
+      'showAuthOnboarding',
+      'ensureInitialized',
+      'getPublicKey',
+    ]);
+    expect(showAuthOnboarding).toHaveBeenCalledWith({
+      action: 'follow',
+      theme: 'dark',
+    });
+    expect(result).toEqual({
+      status: 'connected',
+      publicKey: 'pubkey-connected',
+    });
+  });
+
+  it('returns dismissed without touching the signer when the user closes onboarding', async () => {
+    const ensureInitialized = vi.fn();
+    const getPublicKey = vi.fn();
+    const ensureSignerForAction = createEnsureSignerForAction({
+      ensureInitialized,
+      getPublicKey,
+      hasConnectedSigner: vi.fn().mockReturnValue(false),
       showAuthOnboarding: vi
         .fn()
         .mockResolvedValue({ status: 'dismissed' }),
@@ -78,45 +196,38 @@ describe('createEnsureSignerForAction', () => {
       status: 'dismissed',
       publicKey: null,
     });
+    expect(ensureInitialized).not.toHaveBeenCalled();
+    expect(getPublicKey).not.toHaveBeenCalled();
   });
 
-  it('returns connected after onboarding succeeds', async () => {
-    const getPublicKey = vi
-      .fn()
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce('pubkey-connected');
-    const showAuthOnboarding = vi
-      .fn()
-      .mockResolvedValue({ status: 'connect' });
-
+  it('returns unavailable when the user backs out of the signer widget', async () => {
     const ensureSignerForAction = createEnsureSignerForAction({
       ensureInitialized: vi.fn().mockResolvedValue(undefined),
-      getPublicKey,
-      showAuthOnboarding,
+      getPublicKey: vi.fn().mockResolvedValue(null),
+      hasConnectedSigner: vi.fn().mockReturnValue(false),
+      showAuthOnboarding: vi.fn().mockResolvedValue({ status: 'connect' }),
     });
 
     const result = await ensureSignerForAction({
       action: 'follow',
-      theme: 'dark',
+      theme: 'light',
     });
 
-    expect(showAuthOnboarding).toHaveBeenCalledWith({
-      action: 'follow',
-      theme: 'dark',
-    });
     expect(result).toEqual({
-      status: 'connected',
-      publicKey: 'pubkey-connected',
+      status: 'unavailable',
+      publicKey: null,
+      message: 'Connect a Nostr signer to follow this profile.',
     });
   });
 
-  it('returns unavailable when initialization fails', async () => {
+  it('returns unavailable when initialization fails after onboarding', async () => {
     const ensureSignerForAction = createEnsureSignerForAction({
       ensureInitialized: vi
         .fn()
         .mockRejectedValue(new Error('init failed')),
       getPublicKey: vi.fn(),
-      showAuthOnboarding: vi.fn(),
+      hasConnectedSigner: vi.fn().mockReturnValue(false),
+      showAuthOnboarding: vi.fn().mockResolvedValue({ status: 'connect' }),
     });
 
     const result = await ensureSignerForAction({

--- a/src/common/auth-onboarding-style.ts
+++ b/src/common/auth-onboarding-style.ts
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MIT
+
+/**
+ * Onboarding dialog content styles.
+ * The shared dialog shell comes from DialogComponent.
+ */
+export function getAuthOnboardingDialogStyles(): string {
+  return `
+    .auth-onboarding {
+      display: grid;
+      gap: 14px;
+    }
+
+    .auth-onboarding-hero {
+      display: grid;
+      gap: 8px;
+      padding: 14px;
+      border-radius: 14px;
+      border: 1px solid #f1c35b;
+      background: linear-gradient(145deg, #fff8df 0%, #ffeab9 55%, #ffd978 100%);
+      color: #503100;
+    }
+
+    .nostr-base-dialog[data-theme='dark'] .auth-onboarding-hero {
+      border-color: #7d5b13;
+      background: linear-gradient(145deg, #3f2d08 0%, #5a410d 55%, #765515 100%);
+      color: #ffecb8;
+    }
+
+    .auth-onboarding-eyebrow {
+      font-size: 0.76rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .auth-onboarding-hero h3 {
+      margin: 0;
+      font-size: 1rem;
+      line-height: 1.35;
+    }
+
+    .auth-onboarding-hero p,
+    .auth-onboarding-why {
+      margin: 0;
+      font-size: 0.92rem;
+      line-height: 1.5;
+    }
+
+    .auth-onboarding-why {
+      color: var(--nostrc-theme-text-secondary, #4b5563);
+    }
+
+    .auth-onboarding-steps {
+      margin: 0;
+      padding-left: 18px;
+      display: grid;
+      gap: 6px;
+      color: var(--nostrc-theme-text-primary, #111827);
+      font-size: 0.9rem;
+    }
+
+    .auth-onboarding-steps li {
+      line-height: 1.45;
+    }
+
+    .auth-onboarding-actions {
+      display: grid;
+      gap: 10px;
+    }
+
+    .auth-onboarding-primary,
+    .auth-onboarding-secondary,
+    .auth-onboarding-dismiss {
+      min-height: 42px;
+      border-radius: 10px;
+      border: 1px solid transparent;
+      font: inherit;
+      font-size: 0.92rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition:
+        transform 0.18s ease,
+        background-color 0.18s ease,
+        color 0.18s ease,
+        border-color 0.18s ease,
+        opacity 0.18s ease;
+    }
+
+    .auth-onboarding-primary {
+      background: #d97706;
+      color: #ffffff;
+      border-color: #b45309;
+    }
+
+    .auth-onboarding-primary:hover:not(:disabled) {
+      background: #b45309;
+      transform: translateY(-1px);
+    }
+
+    .auth-onboarding-secondary {
+      background: #0f766e;
+      color: #ffffff;
+      border-color: #115e59;
+    }
+
+    .auth-onboarding-secondary:hover:not(:disabled) {
+      background: #115e59;
+      transform: translateY(-1px);
+    }
+
+    .auth-onboarding-dismiss {
+      background: transparent;
+      color: var(--nostrc-theme-text-secondary, #4b5563);
+      border-color: var(--nostrc-theme-border, #d1d5db);
+    }
+
+    .auth-onboarding-dismiss:hover:not(:disabled) {
+      background: var(--nostrc-theme-hover-bg, rgba(0, 0, 0, 0.05));
+    }
+
+    .auth-onboarding-primary:disabled,
+    .auth-onboarding-secondary:disabled {
+      opacity: 0.65;
+      cursor: not-allowed;
+      transform: none;
+    }
+
+    .auth-onboarding-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      font-size: 0.86rem;
+    }
+
+    .auth-onboarding-links a {
+      color: #0f766e;
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+
+    .nostr-base-dialog[data-theme='dark'] .auth-onboarding-links a {
+      color: #5eead4;
+    }
+
+    .auth-onboarding-status {
+      min-height: 18px;
+      color: var(--nostrc-theme-text-secondary, #4b5563);
+      font-size: 0.83rem;
+    }
+
+    .auth-onboarding-status.error {
+      color: #b91c1c;
+    }
+
+    .auth-onboarding-status.success {
+      color: #047857;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .auth-onboarding-primary,
+      .auth-onboarding-secondary,
+      .auth-onboarding-dismiss {
+        transition: none;
+      }
+    }
+  `;
+}

--- a/src/common/auth-onboarding.ts
+++ b/src/common/auth-onboarding.ts
@@ -50,11 +50,39 @@ export interface EnsureSignerForActionResult {
 interface EnsureSignerDependencies {
   ensureInitialized: typeof ensureInitialized;
   getPublicKey: typeof getPublicKey;
+  hasConnectedSigner: typeof hasConnectedSigner;
   showAuthOnboarding: (options: ShowAuthOnboardingOptions) => Promise<ShowAuthOnboardingResult>;
 }
 
 const QUICK_SETUP_URL = 'https://nstart.me/';
 const SIGNER_INSTALL_URL = 'https://getalby.com/';
+
+/** localStorage key window.nostr.js uses to persist its session (nsec or bunker pointer). */
+const WNJ_SESSION_STORAGE_KEY = 'wnj:bunkerPointer';
+
+/**
+ * Passive check for a signer that is usable without opening any connect UI:
+ * a NIP-07 extension, or a window.nostr.js session stored by a previous
+ * connect.
+ *
+ * window.nostr.js marks its shim with `isWnj`, and its `getPublicKey()`
+ * opens the connect widget when no session exists — so calling
+ * `getPublicKey()` is not a safe way to probe for an existing connection.
+ */
+export function hasConnectedSigner(): boolean {
+  if (typeof window === 'undefined') return false;
+
+  const nostr = (window as any).nostr;
+  if (nostr && nostr.isWnj !== true) {
+    return true;
+  }
+
+  try {
+    return !!window.localStorage.getItem(WNJ_SESSION_STORAGE_KEY);
+  } catch {
+    return false;
+  }
+}
 
 const ACTION_CONTENT: Record<AuthAction, AuthOnboardingContent> = {
   like: {
@@ -128,32 +156,42 @@ export function createEnsureSignerForAction(
   dependencies: EnsureSignerDependencies = {
     ensureInitialized,
     getPublicKey,
+    hasConnectedSigner,
     showAuthOnboarding,
   }
 ) {
   return async function ensureSignerForAction(
     options: EnsureSignerForActionOptions
   ): Promise<EnsureSignerForActionResult> {
-    try {
-      await dependencies.ensureInitialized();
-    } catch (error) {
-      console.error('[AuthOnboarding] Failed to initialize signer flow:', error);
-      return {
-        status: 'unavailable',
-        publicKey: null,
-        message: getSignerUnavailableMessage(options.action),
-      };
+    const unavailable = (): EnsureSignerForActionResult => ({
+      status: 'unavailable',
+      publicKey: null,
+      message: getSignerUnavailableMessage(options.action),
+    });
+
+    // A signer is already reachable (NIP-07 extension or stored
+    // window.nostr.js session): resolve the public key directly and skip
+    // onboarding. Extensions may show their own permission prompt here.
+    if (dependencies.hasConnectedSigner()) {
+      try {
+        await dependencies.ensureInitialized();
+        const existingPubKey = await dependencies.getPublicKey();
+        if (existingPubKey) {
+          return {
+            status: 'already-connected',
+            publicKey: existingPubKey,
+          };
+        }
+        return unavailable();
+      } catch (error) {
+        console.error('[AuthOnboarding] Failed to reach connected signer:', error);
+        return unavailable();
+      }
     }
 
+    // First-time user: show onboarding before any signer call, so
+    // window.nostr.js cannot open its own widget ahead of our dialog.
     try {
-      const existingPubKey = await dependencies.getPublicKey();
-      if (existingPubKey) {
-        return {
-          status: 'already-connected',
-          publicKey: existingPubKey,
-        };
-      }
-
       const onboardingResult = await dependencies.showAuthOnboarding(options);
       if (onboardingResult.status === 'dismissed') {
         return {
@@ -162,6 +200,9 @@ export function createEnsureSignerForAction(
         };
       }
 
+      // The user chose to connect and the dialog is closed, so the
+      // window.nostr.js widget opens without competing with our dialog.
+      await dependencies.ensureInitialized();
       const connectedPubKey = await dependencies.getPublicKey();
       if (connectedPubKey) {
         return {
@@ -170,18 +211,10 @@ export function createEnsureSignerForAction(
         };
       }
 
-      return {
-        status: 'unavailable',
-        publicKey: null,
-        message: getSignerUnavailableMessage(options.action),
-      };
+      return unavailable();
     } catch (error) {
       console.error('[AuthOnboarding] Failed during signer onboarding:', error);
-      return {
-        status: 'unavailable',
-        publicKey: null,
-        message: getSignerUnavailableMessage(options.action),
-      };
+      return unavailable();
     }
   };
 }
@@ -301,23 +334,13 @@ export async function showAuthOnboarding(
         settle({ status: 'dismissed' });
       });
 
-      connectButton?.addEventListener('click', async () => {
-        connectButton.disabled = true;
-        setStatus('Opening your signer connection...', 'neutral');
-
-        const connectedPubKey = await getPublicKey();
-        if (connectedPubKey) {
-          setStatus('Connected. Continuing...', 'success');
-          settle({ status: 'connect' });
-          dialogComponent.close();
-          return;
-        }
-
-        connectButton.disabled = false;
-        setStatus(
-          'No signer connected yet. Finish setup in the signer widget, then try Connect again.',
-          'error'
-        );
+      connectButton?.addEventListener('click', () => {
+        // Settle as `connect` before closing, since the dialog `close`
+        // event settles as `dismissed`. The signer prompt itself is
+        // triggered by the caller after the dialog is gone, so the
+        // window.nostr.js widget never stacks on top of this dialog.
+        settle({ status: 'connect' });
+        dialogComponent.close();
       });
     });
   })();

--- a/src/common/auth-onboarding.ts
+++ b/src/common/auth-onboarding.ts
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: MIT
+
+import type { Theme } from './types';
+import {
+  ensureInitialized,
+  getPublicKey,
+} from './nostr-login-service';
+import { getAuthOnboardingDialogStyles } from './auth-onboarding-style';
+
+export type AuthAction = 'like' | 'zap' | 'follow';
+export type EnsureSignerStatus =
+  | 'already-connected'
+  | 'connected'
+  | 'dismissed'
+  | 'unavailable';
+
+interface AuthOnboardingContent {
+  eyebrow: string;
+  title: string;
+  description: string;
+  whyItMatters: string;
+}
+
+interface ShowAuthOnboardingOptions {
+  action: AuthAction;
+  theme?: Theme;
+}
+
+interface ShowAuthOnboardingResult {
+  status: 'connect' | 'dismissed';
+}
+
+interface DialogComponentElement extends HTMLElement {
+  showModal(): void;
+  close(): void;
+  getDialogElement(): HTMLDialogElement | null;
+}
+
+export interface EnsureSignerForActionOptions {
+  action: AuthAction;
+  theme?: Theme;
+}
+
+export interface EnsureSignerForActionResult {
+  status: EnsureSignerStatus;
+  publicKey: string | null;
+  message?: string;
+}
+
+interface EnsureSignerDependencies {
+  ensureInitialized: typeof ensureInitialized;
+  getPublicKey: typeof getPublicKey;
+  showAuthOnboarding: (options: ShowAuthOnboardingOptions) => Promise<ShowAuthOnboardingResult>;
+}
+
+const QUICK_SETUP_URL = 'https://nstart.me/';
+const SIGNER_INSTALL_URL = 'https://getalby.com/';
+
+const ACTION_CONTENT: Record<AuthAction, AuthOnboardingContent> = {
+  like: {
+    eyebrow: 'Open social proof',
+    title: 'Save your likes on Nostr',
+    description:
+      'Connect a Nostr signer once to like this page and carry your reactions with you across the web.',
+    whyItMatters:
+      'Nostr gives regular websites a shared social layer, and creators can add zap buttons to receive sats directly.',
+  },
+  zap: {
+    eyebrow: 'Instant Lightning tips',
+    title: 'Send sats in a couple of clicks',
+    description:
+      'Connect a Nostr signer once to send a zap. Zaps are instant Bitcoin Lightning tips that go straight to creators.',
+    whyItMatters:
+      'This same setup lets creators add zap buttons to their own sites and receive sats without a platform in the middle.',
+  },
+  follow: {
+    eyebrow: 'Portable audience graph',
+    title: 'Follow creators without platform lock-in',
+    description:
+      'Connect a Nostr signer once to follow this creator and keep that relationship in your own account, not inside one app.',
+    whyItMatters:
+      'Creators can own their audience and add sats-enabled actions on regular websites instead of depending on one platform.',
+  },
+};
+
+let activeOnboardingPromise: Promise<ShowAuthOnboardingResult> | null = null;
+
+function injectAuthOnboardingStyles(): void {
+  if (document.querySelector('style[data-auth-onboarding-styles]')) return;
+
+  const style = document.createElement('style');
+  style.setAttribute('data-auth-onboarding-styles', 'true');
+  style.textContent = getAuthOnboardingDialogStyles();
+  document.head.appendChild(style);
+}
+
+export function getAuthOnboardingContent(
+  action: AuthAction
+): AuthOnboardingContent {
+  return ACTION_CONTENT[action];
+}
+
+export function getAuthOnboardingLinks() {
+  return {
+    quickSetupUrl: QUICK_SETUP_URL,
+    signerInstallUrl: SIGNER_INSTALL_URL,
+  };
+}
+
+export function getSignerUnavailableMessage(action: AuthAction): string {
+  switch (action) {
+    case 'like':
+      return 'Connect a Nostr signer to like this page.';
+    case 'zap':
+      return 'Connect a Nostr signer to send a zap.';
+    case 'follow':
+      return 'Connect a Nostr signer to follow this profile.';
+    default:
+      return 'Connect a Nostr signer to continue.';
+  }
+}
+
+function normalizeOnboardingTheme(theme?: Theme): 'light' | 'dark' {
+  return theme === 'dark' ? 'dark' : 'light';
+}
+
+export function createEnsureSignerForAction(
+  dependencies: EnsureSignerDependencies = {
+    ensureInitialized,
+    getPublicKey,
+    showAuthOnboarding,
+  }
+) {
+  return async function ensureSignerForAction(
+    options: EnsureSignerForActionOptions
+  ): Promise<EnsureSignerForActionResult> {
+    try {
+      await dependencies.ensureInitialized();
+    } catch (error) {
+      console.error('[AuthOnboarding] Failed to initialize signer flow:', error);
+      return {
+        status: 'unavailable',
+        publicKey: null,
+        message: getSignerUnavailableMessage(options.action),
+      };
+    }
+
+    try {
+      const existingPubKey = await dependencies.getPublicKey();
+      if (existingPubKey) {
+        return {
+          status: 'already-connected',
+          publicKey: existingPubKey,
+        };
+      }
+
+      const onboardingResult = await dependencies.showAuthOnboarding(options);
+      if (onboardingResult.status === 'dismissed') {
+        return {
+          status: 'dismissed',
+          publicKey: null,
+        };
+      }
+
+      const connectedPubKey = await dependencies.getPublicKey();
+      if (connectedPubKey) {
+        return {
+          status: 'connected',
+          publicKey: connectedPubKey,
+        };
+      }
+
+      return {
+        status: 'unavailable',
+        publicKey: null,
+        message: getSignerUnavailableMessage(options.action),
+      };
+    } catch (error) {
+      console.error('[AuthOnboarding] Failed during signer onboarding:', error);
+      return {
+        status: 'unavailable',
+        publicKey: null,
+        message: getSignerUnavailableMessage(options.action),
+      };
+    }
+  };
+}
+
+export const ensureSignerForAction = createEnsureSignerForAction();
+
+export async function showAuthOnboarding(
+  options: ShowAuthOnboardingOptions
+): Promise<ShowAuthOnboardingResult> {
+  if (activeOnboardingPromise) {
+    return activeOnboardingPromise;
+  }
+
+  activeOnboardingPromise = (async () => {
+    injectAuthOnboardingStyles();
+    await import('../base/dialog-component/dialog-component');
+    await customElements.whenDefined('dialog-component');
+
+    const theme = normalizeOnboardingTheme(options.theme);
+    const content = getAuthOnboardingContent(options.action);
+    const links = getAuthOnboardingLinks();
+
+    const dialogComponent = document.createElement(
+      'dialog-component'
+    ) as DialogComponentElement;
+    dialogComponent.setAttribute('header', 'Start with Nostr in seconds');
+    dialogComponent.setAttribute('data-theme', theme);
+    dialogComponent.innerHTML = `
+      <div class="auth-onboarding">
+        <section class="auth-onboarding-hero">
+          <div class="auth-onboarding-eyebrow">${content.eyebrow}</div>
+          <h3>${content.title}</h3>
+          <p>${content.description}</p>
+        </section>
+
+        <p class="auth-onboarding-why">${content.whyItMatters}</p>
+
+        <ol class="auth-onboarding-steps">
+          <li>Connect a Nostr signer once.</li>
+          <li>Approve this action when your signer asks.</li>
+          <li>Use Like, Zap, and Follow across regular websites.</li>
+        </ol>
+
+        <div class="auth-onboarding-actions">
+          <button type="button" class="auth-onboarding-primary">Connect Nostr</button>
+          <button type="button" class="auth-onboarding-secondary">Quick setup guide</button>
+          <button type="button" class="auth-onboarding-dismiss">Maybe later</button>
+        </div>
+
+        <div class="auth-onboarding-links">
+          <a href="${links.quickSetupUrl}" target="_blank" rel="noopener noreferrer">Beginner setup guide</a>
+          <a href="${links.signerInstallUrl}" target="_blank" rel="noopener noreferrer">Install a signer</a>
+        </div>
+
+        <div class="auth-onboarding-status" aria-live="polite"></div>
+      </div>
+    `;
+
+    dialogComponent.showModal();
+
+    const dialog = dialogComponent.getDialogElement();
+    if (!dialog) {
+      return { status: 'dismissed' };
+    }
+
+    const connectButton = dialog.querySelector<HTMLButtonElement>(
+      '.auth-onboarding-primary'
+    );
+    const guideButton = dialog.querySelector<HTMLButtonElement>(
+      '.auth-onboarding-secondary'
+    );
+    const dismissButton = dialog.querySelector<HTMLButtonElement>(
+      '.auth-onboarding-dismiss'
+    );
+    const statusNode = dialog.querySelector<HTMLElement>(
+      '.auth-onboarding-status'
+    );
+
+    const setStatus = (
+      message: string,
+      kind: 'neutral' | 'error' | 'success' = 'neutral'
+    ) => {
+      if (!statusNode) return;
+      statusNode.textContent = message;
+      statusNode.classList.remove('error', 'success');
+      if (kind === 'error') statusNode.classList.add('error');
+      if (kind === 'success') statusNode.classList.add('success');
+    };
+
+    return await new Promise<ShowAuthOnboardingResult>((resolve) => {
+      let settled = false;
+
+      const settle = (result: ShowAuthOnboardingResult) => {
+        if (settled) return;
+        settled = true;
+        resolve(result);
+      };
+
+      dialog.addEventListener(
+        'close',
+        () => {
+          settle({ status: 'dismissed' });
+        },
+        { once: true }
+      );
+
+      guideButton?.addEventListener('click', () => {
+        window.open(links.quickSetupUrl, '_blank', 'noopener,noreferrer');
+        setStatus(
+          'Setup guide opened in a new tab. Return here when you are ready to connect.',
+          'neutral'
+        );
+      });
+
+      dismissButton?.addEventListener('click', () => {
+        dialogComponent.close();
+        settle({ status: 'dismissed' });
+      });
+
+      connectButton?.addEventListener('click', async () => {
+        connectButton.disabled = true;
+        setStatus('Opening your signer connection...', 'neutral');
+
+        const connectedPubKey = await getPublicKey();
+        if (connectedPubKey) {
+          setStatus('Connected. Continuing...', 'success');
+          settle({ status: 'connect' });
+          dialogComponent.close();
+          return;
+        }
+
+        connectButton.disabled = false;
+        setStatus(
+          'No signer connected yet. Finish setup in the signer widget, then try Connect again.',
+          'error'
+        );
+      });
+    });
+  })();
+
+  try {
+    return await activeOnboardingPromise;
+  } finally {
+    activeOnboardingPromise = null;
+  }
+}

--- a/src/nostr-follow-button/nostr-follow-button.ts
+++ b/src/nostr-follow-button/nostr-follow-button.ts
@@ -5,8 +5,8 @@ import { NostrUserComponent } from '../base/user-component/nostr-user-component'
 import { renderFollowButton, RenderFollowButtonOptions } from './render';
 import { NCStatus } from '../base/base-component/nostr-base-component';
 import { getFollowButtonStyles } from './style';
-import { ensureInitialized } from '../common/nostr-login-service';
 import { parseBooleanAttribute } from '../common/utils';
+import { ensureSignerForAction } from '../common/auth-onboarding';
 
 export default class NostrFollowButton extends NostrUserComponent {
   protected followStatus = this.channel('follow');
@@ -68,8 +68,23 @@ export default class NostrFollowButton extends NostrUserComponent {
     this.render();
 
     try {
-      // Ensure NostrLogin is initialized
-      await ensureInitialized();
+      const signerResult = await ensureSignerForAction({
+        action: 'follow',
+        theme: this.theme,
+      });
+
+      if (signerResult.status === 'dismissed') {
+        this.followStatus.set(NCStatus.Ready);
+        return;
+      }
+
+      if (!signerResult.publicKey) {
+        this.followStatus.set(
+          NCStatus.Error,
+          signerResult.message || 'Connect a Nostr signer to follow this profile.'
+        );
+        return;
+      }
 
       if (!this.user) {
         this.followStatus.set(

--- a/src/nostr-like-button/nostr-like.ts
+++ b/src/nostr-like-button/nostr-like.ts
@@ -12,11 +12,10 @@ import {
   createLikeEvent,
   createUnlikeEvent,
   hasUserLiked, 
-  getUserPubkey, 
   signEvent, 
   LikeCountResult 
 } from './like-utils';
-import { ensureInitialized } from '../common/nostr-login-service';
+import { ensureSignerForAction } from '../common/auth-onboarding';
 import { normalizeURL } from 'nostr-tools/utils';
 
 /**
@@ -168,14 +167,32 @@ export default class NostrLike extends NostrBaseComponent {
     this.render();
 
     try {
-      // Ensure NostrLogin is initialized (sets up window.nostr)
-      await ensureInitialized();
+      const signerResult = await ensureSignerForAction({
+        action: 'like',
+        theme: this.theme,
+      });
+
+      if (signerResult.status === 'dismissed') {
+        this.likeActionStatus.set(NCStatus.Ready);
+        this.render();
+        return;
+      }
+
+      if (!signerResult.publicKey) {
+        this.likeActionStatus.set(
+          NCStatus.Error,
+          signerResult.message || 'Connect a Nostr signer to like this page.'
+        );
+        this.render();
+        return;
+      }
 
       // Check user like status
-      const userPubkey = await getUserPubkey();
-      if (userPubkey) {
-        this.isLiked = await hasUserLiked(this.currentUrl, userPubkey, this.getRelays());
-      }
+      this.isLiked = await hasUserLiked(
+        this.currentUrl,
+        signerResult.publicKey,
+        this.getRelays()
+      );
 
       // If already liked, show confirmation dialog
       if (this.isLiked) {

--- a/src/nostr-zap-button/nostr-zap.ts
+++ b/src/nostr-zap-button/nostr-zap.ts
@@ -10,7 +10,7 @@ import { getZapButtonStyles } from './style';
 import { fetchTotalZapAmount, ZapDetails } from './zap-utils';
 import { isValidUrl } from '../common/utils';
 import type { DialogComponent } from '../base/dialog-component/dialog-component';
-import { ensureInitialized } from '../common/nostr-login-service';
+import { ensureSignerForAction } from '../common/auth-onboarding';
 
 /**
  * <nostr-zap-button>
@@ -139,8 +139,25 @@ export default class NostrZap extends NostrUserComponent {
     this.render();
 
     try {
-      // Ensure NostrLogin is initialized (sets up window.nostr)
-      await ensureInitialized();
+      const signerResult = await ensureSignerForAction({
+        action: 'zap',
+        theme: this.theme,
+      });
+
+      if (signerResult.status === 'dismissed') {
+        this.zapActionStatus.set(NCStatus.Ready);
+        this.render();
+        return;
+      }
+
+      if (!signerResult.publicKey) {
+        this.zapActionStatus.set(
+          NCStatus.Error,
+          signerResult.message || 'Connect a Nostr signer to send a zap.'
+        );
+        this.render();
+        return;
+      }
 
       if (!this.user) {
         this.zapActionStatus.set(NCStatus.Error, "Could not resolve user to zap.");

--- a/stories/Introduction.mdx
+++ b/stories/Introduction.mdx
@@ -85,14 +85,14 @@ All interactive components (Follow, Like, Zap) require user authentication. Comp
 - **NIP-07 Browser Extensions** (Alby, nos2x, etc.)
 - **NIP-46 Remote Signers** (Bunkers)
 
-No host-page setup is required. Users can connect with an existing signer or through the floating `window.nostr.js` widget when prompted.
+No host-page setup is required. First-time users are guided through a lightweight onboarding dialog with a quick setup path and signer install links, while already-connected users go straight into the signer approval flow.
 
 ---
 
 ## 1. Nostr Zap
 
 A Zap button that sends sats to a Nostr user and can optionally scope those zaps to a specific URL for open-web attribution.
-When `url` is provided, the component uses a deterministic `["a", "39735:<pubkey>:<normalized_url>"]` tag so relays can apply URL-specific `#a` filtering when fetching zap receipts.
+When `url` is provided, the component uses a deterministic `["a", "39735:<pubkey>:<normalized_url>"]` tag so relays can apply URL-specific `#a` filtering when fetching zap receipts. First-time users are guided through a quick signer onboarding flow before the zap modal opens.
 What is [Zap](https://www.youtube.com/shorts/PDnrh8pkF3g)? 
 
 **Usage:**
@@ -122,7 +122,7 @@ What is [Zap](https://www.youtube.com/shorts/PDnrh8pkF3g)?
 
 ## 2. Nostr Follow
 
-A simple button that allows users to follow a Nostr profile.
+A simple button that allows users to follow a Nostr profile. If the user has not connected a signer yet, the first click opens a short onboarding flow and then continues with the follow action.
 
 **Usage:**
 
@@ -149,7 +149,7 @@ A simple button that allows users to follow a Nostr profile.
 ## 3. Nostr Like
 
 A like button that uses NIP-25 external content reactions to like or unlike any URL on the web and display the net reaction count.
-If `url` is omitted, the component automatically uses the current page URL.
+First-time users get a short onboarding flow before the like/unlike action continues. If `url` is omitted, the component automatically uses the current page URL.
 
 **Usage:**
 

--- a/stories/nostr-follow-button/NostrFollowButton.stories.tsx
+++ b/stories/nostr-follow-button/NostrFollowButton.stories.tsx
@@ -11,7 +11,8 @@ const meta: Meta = {
   parameters: {
     docs: {
       description: {
-        component: 'A web component that displays a follow button for Nostr profiles. Supports npub, nip05, and pubkey inputs with theme customization.',
+        // Keep this copy aligned with README.md and stories/Introduction.mdx auth wording.
+        component: 'A web component that displays a follow button for Nostr profiles. Supports npub, nip05, and pubkey inputs with theme customization. First-time users see a short onboarding flow before the follow action continues through window.nostr.js.',
       },
       source: {
         transform: (code, storyContext) =>

--- a/stories/nostr-like/NostrLike.stories.tsx
+++ b/stories/nostr-like/NostrLike.stories.tsx
@@ -15,7 +15,7 @@ const meta: Meta = {
       description: {
         // Keep this description aligned with README.md, stories/Introduction.mdx,
         // and src/nostr-like-button/spec/spec.md.
-        component: 'A web component that displays a like button for URLs using NIP-25 External Content Reactions (kind 17). Supports URL-based likes with theme customization and shows net like counts with a clickable likers list.\n\n**Features:**\n- Like and unlike support with confirmation before unlike\n- Automatic URL detection from the current page\n- Connected signer support via `window.nostr.js` (NIP-07 / NIP-46)\n- Progressive profile loading in the likers dialog\n\n⚠️ **Scalability Limitation:** The component queries up to 1000 reaction events per URL. For viral content, net like counts and likers lists may be incomplete.',
+        component: 'A web component that displays a like button for URLs using NIP-25 External Content Reactions (kind 17). Supports URL-based likes with theme customization and shows net like counts with a clickable likers list.\n\n**Features:**\n- Like and unlike support with confirmation before unlike\n- Automatic URL detection from the current page\n- First-click onboarding before the signer approval flow\n- Connected signer support via `window.nostr.js` (NIP-07 / NIP-46)\n- Progressive profile loading in the likers dialog\n\n⚠️ **Scalability Limitation:** The component queries up to 1000 reaction events per URL. For viral content, net like counts and likers lists may be incomplete.',
       },
       source: {
         transform: (code, storyContext) =>

--- a/stories/nostr-zap/NostrZap.stories.tsx
+++ b/stories/nostr-zap/NostrZap.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta = {
       description: {
         // Keep this description aligned with README.md, stories/Introduction.mdx,
         // and src/nostr-zap-button/spec/spec.md.
-        component: 'A web component that displays a zap button for Nostr profiles. Supports npub, nip05, and pubkey inputs with theme customization, zap amount configuration, and URL-based zaps for content creators.\n\n**URL-based zaps:** When `url` is provided, zap requests include `["a", "39735:<recipient_pubkey>:<normalized_url>"]`. NIP-57 relays copy that tag into zap receipts, enabling relay-side `#a` filtering for URL-specific totals and zappers lists.\n\n⚠️ **Scalability Limitation:** The component queries up to 1000 matching zap receipt events. For high-traffic creators, total zap amounts and zappers lists may be incomplete.',
+        component: 'A web component that displays a zap button for Nostr profiles. Supports npub, nip05, and pubkey inputs with theme customization, zap amount configuration, and URL-based zaps for content creators.\n\n**Onboarding and signing:** First-time users see a short onboarding flow before the zap modal opens, and connected users continue through window.nostr.js.\n\n**URL-based zaps:** When `url` is provided, zap requests include `["a", "39735:<recipient_pubkey>:<normalized_url>"]`. NIP-57 relays copy that tag into zap receipts, enabling relay-side `#a` filtering for URL-specific totals and zappers lists.\n\n⚠️ **Scalability Limitation:** The component queries up to 1000 matching zap receipt events. For high-traffic creators, total zap amounts and zappers lists may be incomplete.',
       },
       source: {
         transform: (code, storyContext) =>


### PR DESCRIPTION
Closes #60

## Summary

This PR adds a newcomer-friendly signer onboarding flow for the interactive components:
- `nostr-like-button`
- `nostr-zap-button`
- `nostr-follow-button`

The implementation is built on top of the repo’s current `window.nostr.js` setup and keeps the scope focused on first-click onboarding UX rather than introducing a parallel signer UI.

Instead of duplicating signer checks across components, this PR centralizes the flow in a shared auth gate and uses one shared onboarding dialog with action-aware copy.

## What changed

### Shared onboarding/auth gate
- Added a shared signer gate in `src/common/auth-onboarding.ts`
- Added shared onboarding modal styles in `src/common/auth-onboarding-style.ts`
- The shared flow:
  - initializes the signer integration
  - checks for an already connected public key
  - opens onboarding only when needed
  - re-checks signer availability after the user chooses to connect
  - returns structured outcomes:
    - `already-connected`
    - `connected`
    - `dismissed`
    - `unavailable`

### Shared onboarding dialog
- Added one lightweight onboarding modal for Like, Zap, and Follow
- The dialog keeps the flow intentionally simple:
  - primary CTA: `Connect Nostr`
  - secondary CTA: `Quick setup guide`
  - dismiss action: `Maybe later`
  - beginner setup link
  - signer install link
- The copy is action-aware:
  - Like: open social proof / portable reactions
  - Zap: Lightning tips / sats for creators
  - Follow: portable audience relationships
- This PR intentionally does **not** include:
  - manual bunker input
  - `nsec` input
  - advanced remote signer forms
  - secret handling in the website UI

### Component integration
- Updated `nostr-like-button` to use the shared auth gate before checking like/unlike state
- Updated `nostr-zap-button` to use the shared auth gate before opening the zap modal
- Updated `nostr-follow-button` to use the shared auth gate before creating the signer and following the target user
- All three components now behave consistently:
  - if already connected, continue immediately
  - if connect succeeds, continue the original action without requiring a second click
  - if onboarding is dismissed, return to a ready/idle state without showing an error shell
  - if signer setup fails, show a short actionable error message

### Dialog support
- Added a small public getter to `DialogComponent` so the onboarding flow can safely access the underlying native `<dialog>` element for result handling

### Docs
Updated docs to reflect the new first-click onboarding flow:
- `README.md`
- `stories/Introduction.mdx`
- `stories/nostr-like/NostrLike.stories.tsx`
- `stories/nostr-zap/NostrZap.stories.tsx`
- `stories/nostr-follow-button/NostrFollowButton.stories.tsx`

The updated docs now describe:
- first-click onboarding before signer approval
- current `window.nostr.js` usage
- beginner-oriented auth flow for Like, Zap, and Follow

### Tests
Added focused unit tests for the shared onboarding/auth gate in:
- `src/common/__tests__/auth-onboarding.test.ts`

Covered cases include:
- already-connected path skips onboarding
- dismissed path returns a neutral result
- successful connect path resumes the action
- initialization failure returns an actionable unavailable result
- helper content/link/message mappings

## Why this approach

There is an older PR linked to the issue, but this implementation intentionally keeps the scope tighter and better aligned with the current repo state:

- `window.nostr.js` is already the active auth path in the repo
- onboarding is shared instead of duplicated per component
- dismissing onboarding is treated as a neutral exit
- no manual signer secret or advanced connection input is introduced into the site UI
- the issue is solved as a UX/onboarding problem, not as a signer transport configuration problem

## Verification

Ran:
- `npm test -- --run`
- `npm run build-storybook`

## Notes

- This PR is intentionally scoped to Like, Zap, Follow, and related auth docs only
- No public event API changes were made
- No new component attributes were added
- Storybook build still prints pre-existing declaration/type warnings from older legacy modules outside the scope of this PR, but the build completes successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-click authentication onboarding dialog that guides users through signer setup before Like, Zap, and Follow actions.
  * Provides a quick setup path with signer install links for users without a connected signer.

* **Bug Fixes**
  * Improved Like/Zap/Follow behavior when onboarding is dismissed or signer access is unavailable (actions stop cleanly and show appropriate status).

* **Documentation**
  * Updated README, Storybook, and component guidance to reflect the new onboarding flow for first-time users.

* **Tests**
  * Added coverage for onboarding copy, links, signer-availability checks, and action gating outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->