### PR TITLE
Fix like count drift on failed like/unlike mutations

### DIFF
--- a/src/nostr-like-button/__tests__/optimistic-state.test.ts
+++ b/src/nostr-like-button/__tests__/optimistic-state.test.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+import {
+  applyOptimisticLike,
+  applyOptimisticUnlike,
+  clampLikeCount,
+  rollbackOptimisticLikeState,
+} from '../optimistic-state';
+
+describe('optimistic-state', () => {
+  it('clamps negative counts to zero', () => {
+    expect(clampLikeCount(-2)).toBe(0);
+  });
+
+  it('applies optimistic like', () => {
+    const next = applyOptimisticLike({ isLiked: false, likeCount: 7 });
+    expect(next).toEqual({ isLiked: true, likeCount: 8 });
+  });
+
+  it('applies optimistic unlike without going negative', () => {
+    const next = applyOptimisticUnlike({ isLiked: true, likeCount: 0 });
+    expect(next).toEqual({ isLiked: false, likeCount: 0 });
+  });
+
+  it('failure-before-optimistic preserves current state and clamps count', () => {
+    const result = rollbackOptimisticLikeState({
+      current: { isLiked: false, likeCount: -9 },
+      snapshot: { isLiked: false, likeCount: 6 },
+      didApplyOptimisticUpdate: false,
+    });
+
+    expect(result).toEqual({ isLiked: false, likeCount: 0 });
+  });
+
+  it('failure-before-optimistic does not drift the count', () => {
+    const result = rollbackOptimisticLikeState({
+      current: { isLiked: false, likeCount: 5 },
+      snapshot: { isLiked: false, likeCount: 6 },
+      didApplyOptimisticUpdate: false,
+    });
+
+    expect(result).toEqual({ isLiked: false, likeCount: 5 });
+  });
+
+  it('failure-after-optimistic restores the pre-mutation snapshot', () => {
+    const result = rollbackOptimisticLikeState({
+      current: { isLiked: true, likeCount: 6 },
+      snapshot: { isLiked: false, likeCount: 5 },
+      didApplyOptimisticUpdate: true,
+    });
+
+    expect(result).toEqual({ isLiked: false, likeCount: 5 });
+  });
+});

--- a/src/nostr-like-button/nostr-like.ts
+++ b/src/nostr-like-button/nostr-like.ts
@@ -18,6 +18,13 @@ import {
 } from './like-utils';
 import { ensureInitialized } from '../common/nostr-login-service';
 import { normalizeURL } from 'nostr-tools/utils';
+import {
+  applyOptimisticLike,
+  applyOptimisticUnlike,
+  clampLikeCount,
+  rollbackOptimisticLikeState,
+  type LikeUiState,
+} from './optimistic-state';
 
 /**
  * <nostr-like-button>
@@ -40,6 +47,8 @@ export default class NostrLike extends NostrBaseComponent {
   private likeCount: number   = 0;
   private cachedLikeDetails: LikeCountResult | null = null;
   private loadSeq = 0;
+  private isResyncingLikeCount = false;
+  private needsResyncLikeCount = false;
 
   constructor() {
     super();
@@ -143,7 +152,7 @@ export default class NostrLike extends NostrBaseComponent {
      
       const result = await fetchLikesForUrl(this.currentUrl, this.getRelays());
       if (seq !== this.loadSeq) return; // stale
-      this.likeCount = result.totalCount;
+      this.likeCount = clampLikeCount(result.totalCount);
       this.cachedLikeDetails = result;
       this.likeListStatus.set(NCStatus.Ready);
     } catch (error) {
@@ -152,6 +161,47 @@ export default class NostrLike extends NostrBaseComponent {
     } finally {
       this.render();
     }
+  }
+
+  private queueAuthoritativeCountResync(): void {
+    this.needsResyncLikeCount = true;
+    if (this.isResyncingLikeCount) return;
+
+    this.isResyncingLikeCount = true;
+    void (async () => {
+      try {
+        while (this.needsResyncLikeCount) {
+          this.needsResyncLikeCount = false;
+          await this.updateLikeCount();
+        }
+      } finally {
+        this.isResyncingLikeCount = false;
+      }
+    })();
+  }
+
+  private handleLikeMutationFailure(
+    error: unknown,
+    snapshot: LikeUiState,
+    didApplyOptimisticUpdate: boolean,
+    fallbackMessage: string
+  ): void {
+    const restoredState = rollbackOptimisticLikeState({
+      current: {
+        isLiked: this.isLiked,
+        likeCount: this.likeCount,
+      },
+      snapshot,
+      didApplyOptimisticUpdate,
+    });
+
+    this.isLiked = restoredState.isLiked;
+    this.likeCount = restoredState.likeCount;
+
+    const errorMessage = error instanceof Error ? error.message : fallbackMessage;
+    this.likeActionStatus.set(NCStatus.Error, errorMessage);
+
+    this.queueAuthoritativeCountResync();
   }
 
   private async handleLikeClick() {
@@ -213,33 +263,44 @@ export default class NostrLike extends NostrBaseComponent {
     this.likeActionStatus.set(NCStatus.Loading);
     this.render();
 
+    let rollbackSnapshot: LikeUiState = {
+      isLiked: this.isLiked,
+      likeCount: this.likeCount,
+    };
+    let didApplyOptimisticUpdate = false;
+
     try {
       // Create like event
       const event = createLikeEvent(this.currentUrl);
       
       // Sign with NIP-07
       const signedEvent = await signEvent(event);
+
+      rollbackSnapshot = {
+        isLiked: this.isLiked,
+        likeCount: this.likeCount,
+      };
+      const optimisticState = applyOptimisticLike(rollbackSnapshot);
+      this.isLiked = optimisticState.isLiked;
+      this.likeCount = optimisticState.likeCount;
+      didApplyOptimisticUpdate = true;
       
       // Create NDKEvent and publish
       const ndkEvent = new NDKEvent(this.nostrService.getNDK(), signedEvent);
       await ndkEvent.publish();
-      
-      // Update state optimistically
-      this.isLiked = true;
-      this.likeCount++;
       this.likeActionStatus.set(NCStatus.Ready);
       
       // Refresh like count to get accurate data
       await this.updateLikeCount();
     } catch (error) {
       console.error('[NostrLike] Failed to like:', error);
-      
-      // Rollback optimistic update
-      this.isLiked = false;
-      this.likeCount--;
-      
-      const errorMessage = error instanceof Error ? error.message : 'Failed to like';
-      this.likeActionStatus.set(NCStatus.Error, errorMessage);
+
+      this.handleLikeMutationFailure(
+        error,
+        rollbackSnapshot,
+        didApplyOptimisticUpdate,
+        'Failed to like'
+      );
     } finally {
       this.render();
     }
@@ -257,6 +318,12 @@ export default class NostrLike extends NostrBaseComponent {
 
     this.likeActionStatus.set(NCStatus.Loading);
     this.render();
+
+    let rollbackSnapshot: LikeUiState = {
+      isLiked: this.isLiked,
+      likeCount: this.likeCount,
+    };
+    let didApplyOptimisticUpdate = false;
     
     try {
       // Create unlike event
@@ -264,29 +331,32 @@ export default class NostrLike extends NostrBaseComponent {
       
       // Sign with NIP-07
       const signedEvent = await signEvent(event);
+
+      rollbackSnapshot = {
+        isLiked: this.isLiked,
+        likeCount: this.likeCount,
+      };
+      const optimisticState = applyOptimisticUnlike(rollbackSnapshot);
+      this.isLiked = optimisticState.isLiked;
+      this.likeCount = optimisticState.likeCount;
+      didApplyOptimisticUpdate = true;
       
       // Create NDKEvent and publish
       const ndkEvent = new NDKEvent(this.nostrService.getNDK(), signedEvent);
       await ndkEvent.publish();
-      
-      // Update state optimistically
-      this.isLiked = false;
-      if (this.likeCount > 0) {
-        this.likeCount--;
-      }
       this.likeActionStatus.set(NCStatus.Ready);
       
       // Refresh like count to get accurate data
       await this.updateLikeCount();
     } catch (error) {
       console.error('[NostrLike] Failed to unlike:', error);
-      
-      // Rollback optimistic update
-      this.isLiked = true;
-      this.likeCount++;
-      
-      const errorMessage = error instanceof Error ? error.message : 'Failed to unlike';
-      this.likeActionStatus.set(NCStatus.Error, errorMessage);
+
+      this.handleLikeMutationFailure(
+        error,
+        rollbackSnapshot,
+        didApplyOptimisticUpdate,
+        'Failed to unlike'
+      );
     } finally {
       this.render();
     }

--- a/src/nostr-like-button/optimistic-state.ts
+++ b/src/nostr-like-button/optimistic-state.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+export interface LikeUiState {
+  isLiked: boolean;
+  likeCount: number;
+}
+
+interface RollbackOptimisticLikeStateParams {
+  current: LikeUiState;
+  snapshot: LikeUiState;
+  didApplyOptimisticUpdate: boolean;
+}
+
+export function clampLikeCount(nextCount: number): number {
+  return Math.max(0, nextCount);
+}
+
+export function applyOptimisticLike(state: LikeUiState): LikeUiState {
+  return {
+    isLiked: true,
+    likeCount: clampLikeCount(state.likeCount + 1),
+  };
+}
+
+export function applyOptimisticUnlike(state: LikeUiState): LikeUiState {
+  return {
+    isLiked: false,
+    likeCount: clampLikeCount(state.likeCount - 1),
+  };
+}
+
+export function rollbackOptimisticLikeState({
+  current,
+  snapshot,
+  didApplyOptimisticUpdate,
+}: RollbackOptimisticLikeStateParams): LikeUiState {
+  if (!didApplyOptimisticUpdate) {
+    return {
+      isLiked: current.isLiked,
+      likeCount: clampLikeCount(current.likeCount),
+    };
+  }
+
+  return {
+    isLiked: snapshot.isLiked,
+    likeCount: clampLikeCount(snapshot.likeCount),
+  };
+}


### PR DESCRIPTION
Closes #78

## Summary

This PR fixes the local like-count drift bug in `nostr-like-button` when like or unlike operations fail.

Previously, the component used unconditional arithmetic rollback in the catch path. That meant failures could push the displayed count in the wrong direction even when an optimistic mutation had not actually been applied.

This PR replaces that with snapshot-based rollback, clamps displayed counts to non-negative values, and adds a coalesced authoritative resync path after failed mutations.

## What changed

### Optimistic state helpers
Added a small internal helper module:

- `src/nostr-like-button/optimistic-state.ts`

It provides:
- `LikeUiState`
- `clampLikeCount()`
- `applyOptimisticLike()`
- `applyOptimisticUnlike()`
- `rollbackOptimisticLikeState()`

These helpers keep the mutation/rollback behavior explicit and easy to test.

### `nostr-like` rollback and resync behavior
Updated:

- `src/nostr-like-button/nostr-like.ts`

Changes include:
- fetched totals are now clamped before being assigned to the displayed count
- like/unlike mutation flows now snapshot the pre-mutation UI state
- optimistic state is applied explicitly via helper functions
- rollback only restores the snapshot when an optimistic update was actually applied
- failure-before-optimistic no longer drifts local count
- failed mutations now queue a best-effort authoritative resync
- resync requests are coalesced so repeated failures during an in-flight resync still result in a final refresh

## Why this fixes the bug

The previous implementation assumed that rollback arithmetic should always run in the error path:
- failed like: decrement count
- failed unlike: increment count

That is only valid if the optimistic mutation was already applied.

With this PR:
- if failure happens before optimistic state is applied, the component preserves the current UI state and only clamps the count
- if failure happens after optimistic state is applied, the component restores the exact pre-mutation snapshot

This removes count drift and makes failure handling deterministic.

## Tests

Added focused regression tests in:

- `src/nostr-like-button/__tests__/optimistic-state.test.ts`

Covered cases:
- clamp negative counts to zero
- optimistic like increments count and sets liked state
- optimistic unlike never drops below zero
- failure-before-optimistic preserves current state and avoids drift
- failure-after-optimistic restores the original snapshot

## Verification

Ran:
- `npm test -- --run`
- `npm run build-storybook`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Like and unlike actions now update the interface immediately for a more responsive experience.
  * Like counts are protected from dropping below zero.
  * Failed like actions restore the previous state and automatically resynchronize the displayed count.

* **Bug Fixes**
  * Improved recovery when like or unlike updates fail.

* **Tests**
  * Added coverage for optimistic updates, rollback behavior, and count safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->