### PR TITLE
Harden active rendered surfaces against XSS

### DIFF
--- a/src/common/__tests__/sanitize.test.ts
+++ b/src/common/__tests__/sanitize.test.ts
@@ -1,7 +1,15 @@
 // SPDX-License-Identifier: MIT
 
 import { describe, expect, it } from 'vitest';
-import { sanitizeHttpUrl, sanitizeMultilineText } from '../sanitize';
+import {
+  sanitizeHttpUrl,
+  sanitizeMultilineText,
+  sanitizePostInlineFragment,
+} from '../sanitize';
+import {
+  createProfileMentionToken,
+  renderPostInlineText,
+} from '../../nostr-post/inline-fragment';
 
 describe('sanitizeHttpUrl', () => {
   it('accepts valid https and http URLs', () => {
@@ -38,5 +46,39 @@ describe('sanitizeMultilineText', () => {
     ).toBe(
       '&lt;img src=x onerror=&quot;alert(&#39;xss&#39;)&quot;&gt;<br />next',
     );
+  });
+});
+
+describe('sanitizePostInlineFragment', () => {
+  it('preserves trusted mention markup in non-browser environments', () => {
+    const trusted =
+      '<a href="https://njump.me/npub1test" target="_blank" rel="noopener noreferrer">@Alice</a> ' +
+      '<span class="nostr-mention" data-username="bob">@bob</span>';
+
+    expect(sanitizePostInlineFragment(trusted)).toBe(trusted);
+  });
+});
+
+describe('renderPostInlineText', () => {
+  it('escapes script payloads and preserves line breaks', () => {
+    const html = renderPostInlineText(
+      `<script>alert(1)</script>\nhello`,
+    );
+
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;<br />hello');
+    expect(html).not.toContain('<script>alert(1)</script>');
+  });
+
+  it('renders profile mentions when display names contain parentheses', () => {
+    const token = createProfileMentionToken(
+      'https://njump.me/npub1test',
+      'Alice (work)',
+    );
+    const html = renderPostInlineText(`${token} hi`);
+
+    expect(html).toContain(
+      '<a href="https://njump.me/npub1test" target="_blank" rel="noopener noreferrer">@Alice (work)</a>',
+    );
+    expect(html).not.toContain('__NOSTRC_PROFILE_MENTION__');
   });
 });

--- a/src/common/__tests__/sanitize.test.ts
+++ b/src/common/__tests__/sanitize.test.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+import { sanitizeHttpUrl, sanitizeMultilineText } from '../sanitize';
+
+describe('sanitizeHttpUrl', () => {
+  it('accepts valid https and http URLs', () => {
+    expect(sanitizeHttpUrl('https://example.com/path')).toBe(
+      'https://example.com/path',
+    );
+    expect(sanitizeHttpUrl('http://example.com/path')).toBe(
+      'http://example.com/path',
+    );
+  });
+
+  it('rejects javascript, data, malformed, and empty URLs', () => {
+    expect(sanitizeHttpUrl('javascript:alert(1)')).toBe('');
+    expect(sanitizeHttpUrl('data:text/html,<script>alert(1)</script>')).toBe(
+      '',
+    );
+    expect(sanitizeHttpUrl('not a real url')).toBe('');
+    expect(sanitizeHttpUrl('')).toBe('');
+    expect(sanitizeHttpUrl(null)).toBe('');
+    expect(sanitizeHttpUrl(undefined)).toBe('');
+  });
+
+  it('returns attribute-safe escaped output', () => {
+    expect(sanitizeHttpUrl('https://example.com/search?q="zap"&next=1')).toBe(
+      'https://example.com/search?q=%22zap%22&amp;next=1',
+    );
+  });
+});
+
+describe('sanitizeMultilineText', () => {
+  it('escapes HTML special characters and preserves line breaks', () => {
+    expect(
+      sanitizeMultilineText(`<img src=x onerror="alert('xss')">\nnext`),
+    ).toBe(
+      '&lt;img src=x onerror=&quot;alert(&#39;xss&#39;)&quot;&gt;<br />next',
+    );
+  });
+});

--- a/src/common/sanitize.ts
+++ b/src/common/sanitize.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+
+import createDOMPurify from 'dompurify';
+import { escapeHtml, sanitizeUrl } from './utils';
+
+const POST_INLINE_ALLOWED_TAGS = ['a', 'span', 'br'];
+const POST_INLINE_ALLOWED_ATTRS = [
+  'href',
+  'target',
+  'rel',
+  'class',
+  'data-username',
+];
+const POST_INLINE_URI_REGEXP =
+  /^(?:(?:https?):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i;
+
+let postInlinePurifier: ReturnType<typeof createDOMPurify> | null = null;
+
+function getPostInlinePurifier() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  if (!postInlinePurifier) {
+    postInlinePurifier = createDOMPurify(window);
+  }
+
+  return postInlinePurifier;
+}
+
+export function sanitizeHttpUrl(url: string | null | undefined): string {
+  return sanitizeUrl(url);
+}
+
+export function sanitizeMultilineText(text: string | null | undefined): string {
+  return escapeHtml(text || '').replace(/\r\n|\r|\n/g, '<br />');
+}
+
+export function sanitizePostInlineFragment(html: string): string {
+  const purifier = getPostInlinePurifier();
+
+  if (!purifier) {
+    return sanitizeMultilineText(html);
+  }
+
+  return purifier.sanitize(html, {
+    ALLOWED_TAGS: POST_INLINE_ALLOWED_TAGS,
+    ALLOWED_ATTR: POST_INLINE_ALLOWED_ATTRS,
+    ALLOW_DATA_ATTR: false,
+    ALLOWED_URI_REGEXP: POST_INLINE_URI_REGEXP,
+  });
+}

--- a/src/common/sanitize.ts
+++ b/src/common/sanitize.ts
@@ -28,6 +28,11 @@ function getPostInlinePurifier() {
   return postInlinePurifier;
 }
 
+/**
+ * Validates http/https URLs and returns an HTML attribute-safe string
+ * (HTML-escaped via `sanitizeUrl`). Use only when interpolating into
+ * `href`/`src`/similar attributes — not for fetch, navigation, or comparisons.
+ */
 export function sanitizeHttpUrl(url: string | null | undefined): string {
   return sanitizeUrl(url);
 }
@@ -40,7 +45,11 @@ export function sanitizePostInlineFragment(html: string): string {
   const purifier = getPostInlinePurifier();
 
   if (!purifier) {
-    return sanitizeMultilineText(html);
+    // No DOMPurify available (SSR / tests). The pipeline in
+    // renderPostInlineText has already escaped all dynamic text and only
+    // injected mention markup from a small, trusted allowlist, so return
+    // the fragment as-is rather than re-escaping our own <a>/<span>/<br>.
+    return html;
   }
 
   return purifier.sanitize(html, {

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 import NDK, { NDKKind, NDKEvent } from '@nostr-dev-kit/ndk';
-import { nip19 } from "nostr-tools";
-
+import { nip19 } from 'nostr-tools';
 
 import { Theme } from './types';
 import { DEFAULT_RELAYS, MILLISATS_PER_SAT } from './constants';
@@ -20,7 +19,7 @@ export const decodeNpub = (npub: string): string => {
   } catch (error) {
     console.error('Failed to decode npub:', error);
   }
-  
+
   return '';
 };
 
@@ -39,7 +38,10 @@ export function hexToNpub(hex: string): string {
 
 // Could be npub, note1, naddr, nsec, etc.,
 export const decodeNip19Entity = (entity: string): any => {
-  if (typeof entity !== 'string' || !/^[a-z0-9]+1[ac-hj-np-z02-9]+/.test(entity)) {
+  if (
+    typeof entity !== 'string' ||
+    !/^[a-z0-9]+1[ac-hj-np-z02-9]+/.test(entity)
+  ) {
     return null;
   }
 
@@ -124,7 +126,7 @@ export async function getPostStats(ndk: NDK, postId: string): Promise<Stats> {
   });
 
   const isDirectRepost = (repost: NDKEvent): boolean => {
-    const pTagCounts = repost.tags.filter(tag => tag[0] === 'p').length;
+    const pTagCounts = repost.tags.filter((tag) => tag[0] === 'p').length;
     return pTagCounts === 1;
   };
 
@@ -192,7 +194,7 @@ export function parseRelays(relaysAttr: string | null): string[] {
   if (relaysAttr) {
     const list = relaysAttr
       .split(',')
-      .map(r => r.trim())
+      .map((r) => r.trim())
       .filter(Boolean)
       .filter(isValidRelayUrl);
     // fall back to defaults if user provided no valid entries
@@ -202,7 +204,6 @@ export function parseRelays(relaysAttr: string | null): string[] {
 }
 
 export function parseTheme(themeAttr: string | null): Theme {
-
   const theme = themeAttr?.trim().toLowerCase();
 
   if (theme === 'light' || theme === 'dark') {
@@ -297,7 +298,10 @@ export function validateNip05(nip05: string): boolean {
   return nip05Regex.test(nip05);
 }
 
-function validateBech32OfType(input: string, expected: 'note' | 'nevent'): boolean {
+function validateBech32OfType(
+  input: string,
+  expected: 'note' | 'nevent',
+): boolean {
   try {
     const { type } = nip19.decode(input);
     return type === expected;
@@ -315,7 +319,7 @@ export function validateEventId(eventId: string): boolean {
 }
 
 export function copyToClipboard(text: string): Promise<void> {
-  return navigator.clipboard.writeText(text)
+  return navigator.clipboard.writeText(text);
 }
 
 /**
@@ -325,8 +329,12 @@ export function copyToClipboard(text: string): Promise<void> {
  * @param index Index of the tag occurrence (0 for first)
  * @returns The tag value or undefined if not found
  */
-export function getTagValue(tags: string[][], tagName: string, index: number = 0): string | undefined {
-  const matchingTags = tags.filter(tag => tag[0] === tagName);
+export function getTagValue(
+  tags: string[][],
+  tagName: string,
+  index: number = 0,
+): string | undefined {
+  const matchingTags = tags.filter((tag) => tag[0] === tagName);
   if (matchingTags.length > index && matchingTags[index].length > 1) {
     return matchingTags[index][1];
   }
@@ -341,8 +349,8 @@ export function getTagValue(tags: string[][], tagName: string, index: number = 0
  */
 export function getTagValues(tags: string[][], tagName: string): string[] {
   return tags
-    .filter(tag => tag[0] === tagName)
-    .map(tag => tag.slice(1)) // Get all values after tag name
+    .filter((tag) => tag[0] === tagName)
+    .map((tag) => tag.slice(1)) // Get all values after tag name
     .flat();
 }
 
@@ -399,13 +407,15 @@ export function formatRelativeTime(ts: number): string {
     }
 
     // Days
-    if (diffSec < 2592000) { // ~30 days
+    if (diffSec < 2592000) {
+      // ~30 days
       const days = Math.floor(diffSec / 86400);
       return `${days} ${days === 1 ? 'day' : 'days'} ago`;
     }
 
     // Months
-    if (diffSec < 31536000) { // ~365 days
+    if (diffSec < 31536000) {
+      // ~365 days
       const months = Math.floor(diffSec / 2592000);
       return `${months} ${months === 1 ? 'month' : 'months'} ago`;
     }

--- a/src/nostr-follow-button/render.ts
+++ b/src/nostr-follow-button/render.ts
@@ -44,7 +44,8 @@ export function renderFollowButton({
     return renderError(errorMessage || '');
   }
 
-  const avatarUrl = sanitizeUrl(profile?.image || profile?.picture || '');
+  const avatarUrl =
+    sanitizeUrl(profile?.image || '') || sanitizeUrl(profile?.picture || '');
   const iconContent = isFollowed
     ? getSuccessAnimation(theme)
     : showAvatar && user && avatarUrl

--- a/src/nostr-follow-button/render.ts
+++ b/src/nostr-follow-button/render.ts
@@ -32,7 +32,6 @@ export function renderFollowButton({
   profile,
   customText = 'Follow me on nostr',
 }: RenderFollowButtonOptions): string {
-
   if (isFollowing) {
     return renderFollowing();
   }
@@ -45,11 +44,11 @@ export function renderFollowButton({
     return renderError(errorMessage || '');
   }
 
-  const avatarUrl = profile?.image ? sanitizeUrl(profile.image) : '';
+  const avatarUrl = sanitizeUrl(profile?.image || profile?.picture || '');
   const iconContent = isFollowed
     ? getSuccessAnimation(theme)
     : showAvatar && user && avatarUrl
-      ? `<img src="${avatarUrl}" alt="${escapeHtml(profile?.name || user.npub)}" class="user-avatar" />`
+      ? `<img src="${avatarUrl}" alt="${escapeHtml(profile?.displayName || profile?.name || user.npub)}" class="user-avatar" />`
       : getNostrLogo();
   const textContent = isFollowed
     ? 'Followed'
@@ -61,21 +60,21 @@ export function renderFollowButton({
 function renderLoading(): string {
   return renderContainer(
     getLoadingNostrich(), // Use default values
-    '<span>Loading...</span>'
+    '<span>Loading...</span>',
   );
 }
 
 function renderFollowing(): string {
   return renderContainer(
     getLoadingNostrich(), // Use default values
-    '<span>Following...</span>'
+    '<span>Following...</span>',
   );
 }
 
 function renderError(errorMessage: string): string {
   return renderContainer(
     '<div class="error-icon">&#9888;</div>',
-    escapeHtml(errorMessage)
+    escapeHtml(errorMessage),
   );
 }
 

--- a/src/nostr-like-button/dialog-likers.ts
+++ b/src/nostr-like-button/dialog-likers.ts
@@ -4,13 +4,17 @@
 import '../base/dialog-component/dialog-component';
 import type { DialogComponent } from '../base/dialog-component/dialog-component';
 import { getLikersDialogStyles } from './dialog-likers-style';
-import { getBatchedProfileMetadata, extractProfileMetadataContent } from '../nostr-zap-button/zap-utils';
-import { escapeHtml, formatRelativeTime, hexToNpub, isValidUrl } from '../common/utils';
+import {
+  getBatchedProfileMetadata,
+  extractProfileMetadataContent,
+} from '../nostr-zap-button/zap-utils';
+import { escapeHtml, formatRelativeTime, hexToNpub } from '../common/utils';
 import { LikeDetails } from './like-utils';
+import { sanitizeHttpUrl } from '../common/sanitize';
 
 /**
  * Modal dialog for displaying individual like details (likers).
- * 
+ *
  * Shows a list of all users who liked a URL with:
  * - User's name
  * - User's profile picture
@@ -30,14 +34,16 @@ export interface OpenLikersModalParams {
  */
 export const injectLikersDialogStyles = (theme: 'light' | 'dark' = 'light') => {
   // Remove existing likers dialog styles
-  const existingStyles = document.querySelectorAll('style[data-likers-dialog-styles]');
-  existingStyles.forEach(style => style.remove());
-  
+  const existingStyles = document.querySelectorAll(
+    'style[data-likers-dialog-styles]',
+  );
+  existingStyles.forEach((style) => style.remove());
+
   const style = document.createElement('style');
   style.setAttribute('data-likers-dialog-styles', 'true');
   style.textContent = getLikersDialogStyles(theme);
   document.head.appendChild(style);
-}
+};
 
 interface EnhancedLikeDetails extends LikeDetails {
   authorName?: string;
@@ -51,25 +57,31 @@ interface EnhancedLikeDetails extends LikeDetails {
 function renderLikeEntry(like: EnhancedLikeDetails, index: number): string {
   const authorNameSafe = escapeHtml(like.authorName || 'Unknown liker');
   const npubSafe = like.authorNpub || hexToNpub(like.authorPubkey);
-  const njumpUrl = `https://njump.me/${npubSafe}`;
-  const profilePictureSafe = isValidUrl(like.authorPicture || '') ? like.authorPicture || '' : '';
-  
-  const profilePicture = profilePictureSafe 
+  const njumpUrl = npubSafe
+    ? sanitizeHttpUrl(`https://njump.me/${npubSafe}`)
+    : '';
+  const profilePictureSafe = sanitizeHttpUrl(like.authorPicture);
+  const authorPubkeySafe = escapeHtml(like.authorPubkey);
+
+  const profilePicture = profilePictureSafe
     ? `<img src="${profilePictureSafe}" alt="${authorNameSafe}" class="like-author-picture" />`
     : `<div class="like-author-picture-default">👤</div>`;
-  
+
   const isDislike = like.content === '-';
   const statusText = isDislike ? 'Disliked' : 'Liked';
   const statusClass = isDislike ? 'disliked' : 'liked';
-  
+  const authorNameHtml = njumpUrl
+    ? `<a href="${njumpUrl}" target="_blank" rel="noopener noreferrer" class="like-author-link">
+            ${authorNameSafe}
+          </a>`
+    : `<span class="like-author-link">${authorNameSafe}</span>`;
+
   return `
-    <div class="like-entry" data-like-index="${index}" data-author-pubkey="${like.authorPubkey}">
+    <div class="like-entry" data-like-index="${index}" data-author-pubkey="${authorPubkeySafe}">
       <div class="like-author-info">
         ${profilePicture}
         <div class="like-author-details">
-          <a href="${njumpUrl}" target="_blank" rel="noopener noreferrer" class="like-author-link">
-            ${authorNameSafe}
-          </a>
+          ${authorNameHtml}
           <div class="like-date">
             ${formatRelativeTime(Math.floor(like.date.getTime() / 1000))}
             <span class="like-status ${statusClass}">${statusText}</span>
@@ -83,13 +95,17 @@ function renderLikeEntry(like: EnhancedLikeDetails, index: number): string {
 /**
  * Render skeleton like entry HTML (with npub)
  */
-function renderSkeletonLikeEntry(like: LikeDetails, npub: string, index: number): string {
+function renderSkeletonLikeEntry(
+  like: LikeDetails,
+  npub: string,
+  index: number,
+): string {
   const isDislike = like.content === '-';
   const statusText = isDislike ? 'Disliked' : 'Liked';
   const statusClass = isDislike ? 'disliked' : 'liked';
-  
+
   return `
-    <div class="like-entry skeleton-entry" data-like-index="${index}" data-author-pubkey="${like.authorPubkey}">
+    <div class="like-entry skeleton-entry" data-like-index="${index}" data-author-pubkey="${escapeHtml(like.authorPubkey)}">
       <div class="like-author-info">
         <div class="skeleton-picture"></div>
         <div class="like-author-details">
@@ -109,45 +125,53 @@ function renderSkeletonLikeEntry(like: LikeDetails, npub: string, index: number)
 /**
  * Opens the likers dialog showing individual like details
  */
-export async function openLikersDialog(params: OpenLikersModalParams): Promise<DialogComponent> {
+export async function openLikersDialog(
+  params: OpenLikersModalParams,
+): Promise<DialogComponent> {
   const { likeDetails, theme = 'light', relays } = params;
-  
+
   // Inject styles
   injectLikersDialogStyles(theme);
-  
+
   // Ensure custom element is defined
   if (!customElements.get('dialog-component')) {
     await customElements.whenDefined('dialog-component');
   }
-  
+
   // Create dialog component (not added to DOM)
-  const dialogComponent = document.createElement('dialog-component') as DialogComponent;
+  const dialogComponent = document.createElement(
+    'dialog-component',
+  ) as DialogComponent;
   dialogComponent.setAttribute('header', 'Likers');
   if (params.theme) {
     dialogComponent.setAttribute('data-theme', params.theme);
   }
-  
+
   // Initial content with skeleton loaders showing npubs
   const initialContent = await renderInitialContent(likeDetails);
   dialogComponent.innerHTML = initialContent;
-  
+
   // Show the dialog (this will create and append the actual dialog element)
   dialogComponent.showModal();
-  
+
   // Get the actual dialog element for progressive enhancement
-  const dialogElement: HTMLDialogElement | null = 
+  const dialogElement: HTMLDialogElement | null =
     dialogComponent.querySelector('.nostr-base-dialog') ||
     dialogComponent.shadowRoot?.querySelector('.nostr-base-dialog') ||
     document.body.querySelector('.nostr-base-dialog');
-  
+
   if (!dialogElement) {
-    console.error('[openLikersDialog] Failed to find dialog element after showModal()');
-    throw new Error('Dialog element not found. The dialog may not have been created properly.');
+    console.error(
+      '[openLikersDialog] Failed to find dialog element after showModal()',
+    );
+    throw new Error(
+      'Dialog element not found. The dialog may not have been created properly.',
+    );
   }
-  
+
   // Type assertion: dialog is guaranteed to be non-null after the check above
   const dialog = dialogElement as HTMLDialogElement;
-  
+
   // Start progressive enhancement
   if (dialog && likeDetails.length > 0) {
     enhanceLikeDetailsProgressively(dialog, likeDetails, relays);
@@ -159,7 +183,9 @@ export async function openLikersDialog(params: OpenLikersModalParams): Promise<D
 /**
  * Render initial dialog content with skeleton loaders showing npubs
  */
-async function renderInitialContent(likeDetails: LikeDetails[]): Promise<string> {
+async function renderInitialContent(
+  likeDetails: LikeDetails[],
+): Promise<string> {
   if (likeDetails.length === 0) {
     return `
       <div class="likers-dialog-content">
@@ -171,11 +197,11 @@ async function renderInitialContent(likeDetails: LikeDetails[]): Promise<string>
   }
 
   // Convert all pubkeys to npubs for immediate display
-  const npubs = likeDetails.map(like => hexToNpub(like.authorPubkey));
+  const npubs = likeDetails.map((like) => hexToNpub(like.authorPubkey));
 
-  const skeletonEntries = likeDetails.map((like, index) => 
-    renderSkeletonLikeEntry(like, npubs[index], index)
-  ).join('');
+  const skeletonEntries = likeDetails
+    .map((like, index) => renderSkeletonLikeEntry(like, npubs[index], index))
+    .join('');
 
   return `
     <div class="likers-dialog-content">
@@ -189,27 +215,40 @@ async function renderInitialContent(likeDetails: LikeDetails[]): Promise<string>
 /**
  * Progressively enhance like details with profile information (batched approach)
  */
-async function enhanceLikeDetailsProgressively(dialog: HTMLDialogElement, likeDetails: LikeDetails[], relays?: string[]): Promise<void> {
+async function enhanceLikeDetailsProgressively(
+  dialog: HTMLDialogElement,
+  likeDetails: LikeDetails[],
+  relays?: string[],
+): Promise<void> {
   const likersList = dialog.querySelector('.likers-list') as HTMLElement;
   if (!likersList) return;
 
   // Get unique author IDs
-  const uniqueAuthorIds = [...new Set(likeDetails.map(like => like.authorPubkey))];
-  console.log("Nostr-Components: Likers dialog: Fetching profiles for", uniqueAuthorIds.length, "unique authors");
+  const uniqueAuthorIds = [
+    ...new Set(likeDetails.map((like) => like.authorPubkey)),
+  ];
+  console.log(
+    'Nostr-Components: Likers dialog: Fetching profiles for',
+    uniqueAuthorIds.length,
+    'unique authors',
+  );
 
   try {
     // Fetch all profiles in a single batched call
-    const profileResults = await getBatchedProfileMetadata(uniqueAuthorIds, relays);
-    
+    const profileResults = await getBatchedProfileMetadata(
+      uniqueAuthorIds,
+      relays,
+    );
+
     // Create a map for quick lookup
     const profileMap = new Map<string, any>();
-    profileResults.forEach(result => {
+    profileResults.forEach((result) => {
       profileMap.set(result.id, result.profile);
     });
 
     // Convert all pubkeys to npubs for display
     const npubMap = new Map<string, string>();
-    uniqueAuthorIds.forEach(pubkey => {
+    uniqueAuthorIds.forEach((pubkey) => {
       npubMap.set(pubkey, hexToNpub(pubkey));
     });
 
@@ -218,14 +257,15 @@ async function enhanceLikeDetailsProgressively(dialog: HTMLDialogElement, likeDe
       const like = likeDetails[index];
       const profile = profileMap.get(like.authorPubkey);
       const npub = npubMap.get(like.authorPubkey) || like.authorPubkey;
-      
+
       let enhanced: EnhancedLikeDetails;
-      
+
       if (profile) {
         const profileContent = extractProfileMetadataContent(profile);
         enhanced = {
           ...like,
-          authorName: profileContent.display_name || profileContent.name || npub,
+          authorName:
+            profileContent.display_name || profileContent.name || npub,
           authorPicture: profileContent.picture,
           authorNpub: npub,
         };
@@ -239,19 +279,30 @@ async function enhanceLikeDetailsProgressively(dialog: HTMLDialogElement, likeDe
       }
 
       // Find the corresponding skeleton entry by index and replace it
-      const skeletonEntry = likersList.querySelector(`[data-like-index="${index}"]`);
+      const skeletonEntry = likersList.querySelector(
+        `[data-like-index="${index}"]`,
+      );
       if (skeletonEntry) {
         const enhancedEntry = renderLikeEntry(enhanced, index);
         skeletonEntry.outerHTML = enhancedEntry;
       }
     }
 
-    console.log("Nostr-Components: Likers dialog: Progressive enhancement completed for", likeDetails.length, "like entries");
+    console.log(
+      'Nostr-Components: Likers dialog: Progressive enhancement completed for',
+      likeDetails.length,
+      'like entries',
+    );
   } catch (error) {
-    console.error("Nostr-Components: Likers dialog: Error in batched profile enhancement", error);
-    
+    console.error(
+      'Nostr-Components: Likers dialog: Error in batched profile enhancement',
+      error,
+    );
+
     // Fallback to individual processing if batched approach fails
-    console.log("Nostr-Components: Likers dialog: Falling back to individual profile fetching");
+    console.log(
+      'Nostr-Components: Likers dialog: Falling back to individual profile fetching',
+    );
     await enhanceLikeDetailsIndividually(dialog, likeDetails, relays);
   }
 }
@@ -259,13 +310,17 @@ async function enhanceLikeDetailsProgressively(dialog: HTMLDialogElement, likeDe
 /**
  * Fallback: Enhance like details individually (original approach)
  */
-async function enhanceLikeDetailsIndividually(dialog: HTMLDialogElement, likeDetails: LikeDetails[], relays?: string[]): Promise<void> {
+async function enhanceLikeDetailsIndividually(
+  dialog: HTMLDialogElement,
+  likeDetails: LikeDetails[],
+  relays?: string[],
+): Promise<void> {
   const likersList = dialog.querySelector('.likers-list') as HTMLElement;
   if (!likersList) return;
 
   // Create a map to track which profiles we've already fetched
   const profileCache = new Map<string, EnhancedLikeDetails>();
-  
+
   // Fetch all profile metadata in parallel
   const profilePromises = likeDetails.map(async (like, index) => {
     // Check if we already have this profile cached
@@ -278,16 +333,21 @@ async function enhanceLikeDetailsIndividually(dialog: HTMLDialogElement, likeDet
           authorName: cachedProfile.authorName,
           authorPicture: cachedProfile.authorPicture,
           authorNpub: cachedProfile.authorNpub,
-        }
+        },
       };
     }
 
     try {
-      const { getProfileMetadata } = await import('../nostr-zap-button/zap-utils');
-      const profileMetadata = await getProfileMetadata(like.authorPubkey, relays);
+      const { getProfileMetadata } = await import(
+        '../nostr-zap-button/zap-utils'
+      );
+      const profileMetadata = await getProfileMetadata(
+        like.authorPubkey,
+        relays,
+      );
       const profileContent = extractProfileMetadataContent(profileMetadata);
       const npub = hexToNpub(like.authorPubkey);
-      
+
       const enhanced = {
         ...like,
         authorName: profileContent.display_name || profileContent.name || npub,
@@ -297,13 +357,17 @@ async function enhanceLikeDetailsIndividually(dialog: HTMLDialogElement, likeDet
 
       // Cache the profile for other entries from the same author
       profileCache.set(like.authorPubkey, enhanced);
-      
+
       return {
         index,
-        enhanced
+        enhanced,
       };
     } catch (error) {
-      console.error("Nostr-Components: Likers dialog: Error fetching profile for", like.authorPubkey, error);
+      console.error(
+        'Nostr-Components: Likers dialog: Error fetching profile for',
+        like.authorPubkey,
+        error,
+      );
       // Fallback with just pubkey converted to npub
       const npub = hexToNpub(like.authorPubkey);
       const enhanced = {
@@ -311,13 +375,13 @@ async function enhanceLikeDetailsIndividually(dialog: HTMLDialogElement, likeDet
         authorName: npub,
         authorNpub: npub,
       };
-      
+
       // Cache the fallback profile
       profileCache.set(like.authorPubkey, enhanced);
-      
+
       return {
         index,
-        enhanced
+        enhanced,
       };
     }
   });
@@ -326,15 +390,20 @@ async function enhanceLikeDetailsIndividually(dialog: HTMLDialogElement, likeDet
   for (const promise of profilePromises) {
     try {
       const { index, enhanced } = await promise;
-      
+
       // Find the corresponding skeleton entry by index and replace it
-      const skeletonEntry = likersList.querySelector(`[data-like-index="${index}"]`);
+      const skeletonEntry = likersList.querySelector(
+        `[data-like-index="${index}"]`,
+      );
       if (skeletonEntry) {
         const enhancedEntry = renderLikeEntry(enhanced, index);
         skeletonEntry.outerHTML = enhancedEntry;
       }
     } catch (error) {
-      console.error("Nostr-Components: Likers dialog: Error processing profile enhancement", error);
+      console.error(
+        'Nostr-Components: Likers dialog: Error processing profile enhancement',
+        error,
+      );
     }
   }
 }

--- a/src/nostr-livestream/render.ts
+++ b/src/nostr-livestream/render.ts
@@ -57,14 +57,13 @@ function renderLivestreamHeader(
   parsedLivestream: ParsedLivestreamEvent,
 ): string {
   const authorImage = author?.picture || author?.image || '';
-  const safeAuthorImage = authorImage ? sanitizeUrl(authorImage) : '';
+  const safeAuthorImage = sanitizeUrl(authorImage);
   const authorName = author?.displayName || author?.name || 'Unknown';
   const authorNip05 = author?.nip05 || '';
   const title = parsedLivestream.title || 'Untitled Livestream';
   const status = parsedLivestream.status || 'planned';
   const statusBadgeClass = `livestream-status-badge livestream-status-${status}`;
   const statusLabel = status.charAt(0).toUpperCase() + status.slice(1);
-  const safeAuthorImage = sanitizeHttpUrl(authorImage);
 
   return `
     <div class="livestream-header">
@@ -168,12 +167,11 @@ function renderPreviewImage(imageUrl?: string): string {
 function renderRecordingLink(url: string): string {
   const safeUrl = sanitizeUrl(url);
   if (!safeUrl) {
-    // Render safe fallback: non-clickable div with escaped URL text
     return `
       <div class="livestream-recording-link">
         <div>
           <span class="recording-icon">▶</span>
-          <span>Watch Recording: ${escapeHtml(url)}</span>
+          <span>Recording unavailable</span>
         </div>
       </div>
     `;

--- a/src/nostr-livestream/render.ts
+++ b/src/nostr-livestream/render.ts
@@ -28,7 +28,7 @@ export function renderLivestream(options: RenderLivestreamOptions): string {
     showParticipantCount,
     participantProfiles,
     participantsStatus,
-    autoPlay
+    autoPlay,
   } = options;
 
   // Handle error state
@@ -54,9 +54,8 @@ export function renderLivestream(options: RenderLivestreamOptions): string {
 
 function renderLivestreamHeader(
   author: NDKUserProfile | null,
-  parsedLivestream: ParsedLivestreamEvent
+  parsedLivestream: ParsedLivestreamEvent,
 ): string {
-
   const authorImage = author?.picture || author?.image || '';
   const safeAuthorImage = authorImage ? sanitizeUrl(authorImage) : '';
   const authorName = author?.displayName || author?.name || 'Unknown';
@@ -65,6 +64,7 @@ function renderLivestreamHeader(
   const status = parsedLivestream.status || 'planned';
   const statusBadgeClass = `livestream-status-badge livestream-status-${status}`;
   const statusLabel = status.charAt(0).toUpperCase() + status.slice(1);
+  const safeAuthorImage = sanitizeHttpUrl(authorImage);
 
   return `
     <div class="livestream-header">
@@ -89,7 +89,7 @@ function renderLivestreamHeader(
 
 function renderLivestreamMedia(
   parsedLivestream: ParsedLivestreamEvent,
-  autoPlay: boolean
+  autoPlay: boolean,
 ): string {
   const status = parsedLivestream.status || 'planned';
   const streamingUrl = parsedLivestream.streamingUrl;
@@ -147,7 +147,7 @@ function renderVideoPlayer(url: string, autoPlay: boolean): string {
 }
 
 function renderPreviewImage(imageUrl?: string): string {
-  const safeImageUrl = imageUrl ? sanitizeUrl(imageUrl) : '';
+  const safeImageUrl = sanitizeUrl(imageUrl);
   if (safeImageUrl) {
     return `
       <div class="livestream-preview-image">
@@ -200,10 +200,13 @@ function formatParticipantCount(current?: number, total?: number): string {
   return `${total || 0}`;
 }
 
-function getParticipantDisplayName(participant: { pubkey: string }, profile: any): string {
+function getParticipantDisplayName(
+  participant: { pubkey: string },
+  profile: any,
+): string {
   if (profile?.displayName) return profile.displayName;
   if (profile?.name) return profile.name;
-  
+
   // Fallback to shortened npub format
   try {
     const npub = hexToNpub(participant.pubkey);
@@ -225,21 +228,25 @@ function sanitizeRoleForClass(role: string | undefined): string {
   return normalized.replace(/[^a-z0-9]+/g, '-');
 }
 
-function renderParticipantItem(participant: { pubkey: string; role?: string; proof?: string }, participantProfiles: Map<string, any>): string {
+function renderParticipantItem(
+  participant: { pubkey: string; role?: string; proof?: string },
+  participantProfiles: Map<string, any>,
+): string {
   const profile = participantProfiles.get(participant.pubkey);
   const displayName = getParticipantDisplayName(participant, profile);
   const image = profile?.picture || profile?.image || '';
-  const safeImage = image ? sanitizeUrl(image) : '';
   const role = participant.role || 'Participant';
   const safeRole = sanitizeRoleForClass(participant.role);
   const roleClass = `participant-role participant-role-${safeRole}`;
+  const safeImage = sanitizeUrl(image);
 
   return `
     <div class="participant-item">
       <div class="participant-avatar">
-        ${safeImage
-          ? `<img src="${safeImage}" alt="${escapeHtml(displayName)}" loading="lazy" />`
-          : '<div class="participant-avatar-placeholder"></div>'
+        ${
+          safeImage
+            ? `<img src="${safeImage}" alt="${escapeHtml(displayName)}" loading="lazy" />`
+            : '<div class="participant-avatar-placeholder"></div>'
         }
       </div>
       <div class="participant-info">
@@ -253,14 +260,15 @@ function renderParticipantItem(participant: { pubkey: string; role?: string; pro
 
 function renderLivestreamMetadata(
   parsedLivestream: ParsedLivestreamEvent,
-  showParticipantCount: boolean
+  showParticipantCount: boolean,
 ): string {
   const summary = parsedLivestream.summary;
   const hashtags = parsedLivestream.hashtags || [];
   // Use explicit undefined check to preserve 0 as a valid value
-  const currentParticipants = parsedLivestream.currentParticipants !== undefined 
-    ? parsedLivestream.currentParticipants 
-    : parsedLivestream.participants.length;
+  const currentParticipants =
+    parsedLivestream.currentParticipants !== undefined
+      ? parsedLivestream.currentParticipants
+      : parsedLivestream.participants.length;
   const totalParticipants = parsedLivestream.totalParticipants;
   const starts = parsedLivestream.starts;
   const ends = parsedLivestream.ends;
@@ -277,8 +285,14 @@ function renderLivestreamMetadata(
   }
 
   // Participant count
-  if (showParticipantCount && (currentParticipants !== undefined || totalParticipants !== undefined)) {
-    const countText = formatParticipantCount(currentParticipants, totalParticipants);
+  if (
+    showParticipantCount &&
+    (currentParticipants !== undefined || totalParticipants !== undefined)
+  ) {
+    const countText = formatParticipantCount(
+      currentParticipants,
+      totalParticipants,
+    );
     metadataHtml += `
       <div class="livestream-participant-count">
         <strong>Participants:</strong> ${countText}
@@ -302,7 +316,7 @@ function renderLivestreamMetadata(
   if (hashtags.length > 0) {
     metadataHtml += `
       <div class="livestream-hashtags">
-        ${hashtags.map(tag => `<span class="hashtag">#${escapeHtml(tag)}</span>`).join(' ')}
+        ${hashtags.map((tag) => `<span class="hashtag">#${escapeHtml(tag)}</span>`).join(' ')}
       </div>
     `;
   }
@@ -314,7 +328,7 @@ function renderLivestreamMetadata(
 function renderParticipants(
   parsedLivestream: ParsedLivestreamEvent,
   participantProfiles: Map<string, any>,
-  participantsStatus: NCStatus
+  participantsStatus: NCStatus,
 ): string {
   const participants = parsedLivestream.participants || [];
 
@@ -324,12 +338,15 @@ function renderParticipants(
       <div class="livestream-participants">
         <h3 class="participants-title">Participants</h3>
         <div class="participants-list">
-          ${Array.from({ length: 3 }, () => `
+          ${Array.from(
+            { length: 3 },
+            () => `
             <div class="participant-item">
               <div class="skeleton" style="width: 32px; height: 32px; border-radius: 50%;"></div>
               <div class="skeleton" style="width: 120px; height: 14px; border-radius: 4px; margin-left: 8px;"></div>
             </div>
-          `).join('')}
+          `,
+          ).join('')}
         </div>
       </div>
     `;
@@ -349,7 +366,7 @@ function renderParticipants(
     <div class="livestream-participants">
       <h3 class="participants-title">Participants (${participants.length})</h3>
       <div class="participants-list">
-        ${participants.map(participant => renderParticipantItem(participant, participantProfiles)).join('')}
+        ${participants.map((participant) => renderParticipantItem(participant, participantProfiles)).join('')}
       </div>
     </div>
   `;

--- a/src/nostr-post/inline-fragment.ts
+++ b/src/nostr-post/inline-fragment.ts
@@ -14,15 +14,19 @@ const USERNAME_MENTION_TOKEN_PREFIX = '__NOSTRC_USERNAME_MENTION__(';
 const USERNAME_MENTION_TOKEN_REGEX =
   /__NOSTRC_USERNAME_MENTION__\(([^)]*)\)__/g;
 
+function encodeTokenPart(value: string): string {
+  return encodeURIComponent(value).replace(/\(/g, '%28').replace(/\)/g, '%29');
+}
+
 export function createProfileMentionToken(
   href: string,
   displayName: string,
 ): string {
-  return `${PROFILE_MENTION_TOKEN_PREFIX}${encodeURIComponent(href)})(${encodeURIComponent(displayName)})__`;
+  return `${PROFILE_MENTION_TOKEN_PREFIX}${encodeTokenPart(href)})(${encodeTokenPart(displayName)})__`;
 }
 
 export function createUsernameMentionToken(username: string): string {
-  return `${USERNAME_MENTION_TOKEN_PREFIX}${encodeURIComponent(username)})__`;
+  return `${USERNAME_MENTION_TOKEN_PREFIX}${encodeTokenPart(username)})__`;
 }
 
 function replaceProfileMentionTokens(fragment: string): string {

--- a/src/nostr-post/inline-fragment.ts
+++ b/src/nostr-post/inline-fragment.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+
+import {
+  sanitizeHttpUrl,
+  sanitizeMultilineText,
+  sanitizePostInlineFragment,
+} from '../common/sanitize';
+import { escapeHtml } from '../common/utils';
+
+const PROFILE_MENTION_TOKEN_PREFIX = '__NOSTRC_PROFILE_MENTION__(';
+const PROFILE_MENTION_TOKEN_REGEX =
+  /__NOSTRC_PROFILE_MENTION__\(([^)]*)\)\(([^)]*)\)__/g;
+const USERNAME_MENTION_TOKEN_PREFIX = '__NOSTRC_USERNAME_MENTION__(';
+const USERNAME_MENTION_TOKEN_REGEX =
+  /__NOSTRC_USERNAME_MENTION__\(([^)]*)\)__/g;
+
+export function createProfileMentionToken(
+  href: string,
+  displayName: string,
+): string {
+  return `${PROFILE_MENTION_TOKEN_PREFIX}${encodeURIComponent(href)})(${encodeURIComponent(displayName)})__`;
+}
+
+export function createUsernameMentionToken(username: string): string {
+  return `${USERNAME_MENTION_TOKEN_PREFIX}${encodeURIComponent(username)})__`;
+}
+
+function replaceProfileMentionTokens(fragment: string): string {
+  return fragment.replace(
+    PROFILE_MENTION_TOKEN_REGEX,
+    (_match, encodedHref, encodedDisplayName) => {
+      const href = sanitizeHttpUrl(decodeURIComponent(encodedHref));
+      const displayName = escapeHtml(decodeURIComponent(encodedDisplayName));
+
+      if (!href) {
+        return `@${displayName}`;
+      }
+
+      return `<a href="${href}" target="_blank" rel="noopener noreferrer">@${displayName}</a>`;
+    },
+  );
+}
+
+function replaceUsernameMentionTokens(fragment: string): string {
+  return fragment.replace(
+    USERNAME_MENTION_TOKEN_REGEX,
+    (_match, encodedUsername) => {
+      const username = escapeHtml(decodeURIComponent(encodedUsername));
+      return `<span class="nostr-mention" data-username="${username}">@${username}</span>`;
+    },
+  );
+}
+
+export function renderPostInlineText(text: string): string {
+  const escapedText = sanitizeMultilineText(text);
+  const withProfileMentions = replaceProfileMentionTokens(escapedText);
+  const withMentions = replaceUsernameMentionTokens(withProfileMentions);
+
+  return sanitizePostInlineFragment(withMentions);
+}

--- a/src/nostr-post/nostr-post.ts
+++ b/src/nostr-post/nostr-post.ts
@@ -10,7 +10,10 @@ import {
 } from '../common/utils';
 import { renderPost, RenderPostOptions } from './render';
 import { parseText } from './parse-text';
-import { renderContent, replaceEmbeddedPostPlaceholders } from './render-content';
+import {
+  renderContent,
+  replaceEmbeddedPostPlaceholders,
+} from './render-content';
 import { NostrEventComponent } from '../base/event-component/nostr-event-component';
 import { NCStatus } from '../base/base-component/nostr-base-component';
 import { getPostStyles } from './style';
@@ -21,7 +24,6 @@ const EVT_AUTHOR = 'nc:author';
 const EVT_MENTION = 'nc:mention';
 
 export default class NostrPost extends NostrEventComponent {
-
   protected stats: Stats | null = null;
   protected statsLoading: boolean = false;
   protected statsError: string | null = null;
@@ -55,7 +57,7 @@ export default class NostrPost extends NostrEventComponent {
   attributeChangedCallback(
     name: string,
     oldValue: string | null,
-    newValue: string | null
+    newValue: string | null,
   ) {
     if (oldValue === newValue) return;
     super.attributeChangedCallback?.(name, oldValue, newValue);
@@ -260,16 +262,18 @@ export default class NostrPost extends NostrEventComponent {
   }
 
   private onAuthorClick() {
-    const key =
-      this.author?.npub ||
-      this.authorProfile?.nip05;
+    const key = this.author?.npub || this.authorProfile?.nip05;
 
     if (key) {
-      this.handleNjumpClick(EVT_AUTHOR, {
-        author: this.author,
-        authorProfile: this.authorProfile,
-        npub: this.author?.npub
-      }, key);
+      this.handleNjumpClick(
+        EVT_AUTHOR,
+        {
+          author: this.author,
+          authorProfile: this.authorProfile,
+          npub: this.author?.npub,
+        },
+        key,
+      );
     }
   }
 
@@ -310,7 +314,8 @@ export default class NostrPost extends NostrEventComponent {
     // Click on mentions
     this.delegateEvent('click', '.nostr-mention', (e: Event) => {
       const target = e.target as HTMLElement;
-      const username = target.getAttribute('data-username') || target.textContent?.slice(1);
+      const username =
+        target.getAttribute('data-username') || target.textContent?.slice(1);
       if (username) {
         this.onMentionClick(username);
       }
@@ -322,21 +327,25 @@ export default class NostrPost extends NostrEventComponent {
   }
 
   protected async renderContent() {
-
-    const isLoading     =   this.computeOverall() == NCStatus.Loading;
-    const isError       =   this.computeOverall() === NCStatus.Error;
-    const date          =   this.formattedDate;
+    const isLoading = this.computeOverall() == NCStatus.Loading;
+    const isError = this.computeOverall() === NCStatus.Error;
+    const date = this.formattedDate;
     const content = this.event?.content || '';
-    
+
     // Cache parsed content to avoid re-parsing on every render
     if (!this.cachedParsedContent || !this.cachedHtmlToRender) {
-      const parsedContent = await parseText(content, this.event, this.embeddedPosts, this.nostrService);
+      const parsedContent = await parseText(
+        content,
+        this.event,
+        this.embeddedPosts,
+        this.nostrService,
+      );
       this.cachedParsedContent = JSON.stringify(parsedContent);
       this.cachedHtmlToRender = renderContent(parsedContent);
     }
-    
-    const htmlToRender  = this.cachedHtmlToRender;
-    const errorMessage  = this.errorMessage;
+
+    const htmlToRender = this.cachedHtmlToRender;
+    const errorMessage = this.errorMessage;
 
     const shouldShowStats = this.shouldShowStats();
 
@@ -363,7 +372,7 @@ export default class NostrPost extends NostrEventComponent {
       ${renderPost(renderOptions)}
     `;
 
-    if(htmlToRender.includes('glide') && !this.glideInitialized) {
+    if (htmlToRender.includes('glide') && !this.glideInitialized) {
       // Wait for DOM to be ready
       setTimeout(() => {
         const glideElement = this.shadowRoot?.querySelector('.glide');
@@ -379,10 +388,9 @@ export default class NostrPost extends NostrEventComponent {
     if (htmlToRender.includes('embedded-post-placeholder')) {
       setTimeout(() => {
         replaceEmbeddedPostPlaceholders(
-          this.shadowRoot, 
-          this.embeddedPosts, 
-          this.event, 
-          this.nostrService
+          this.shadowRoot,
+          this.embeddedPosts,
+          this.nostrService,
         );
       }, 0);
     }

--- a/src/nostr-post/parse-text.ts
+++ b/src/nostr-post/parse-text.ts
@@ -1,186 +1,208 @@
 // SPDX-License-Identifier: MIT
 
-import { NDKEvent, ProfilePointer } from "@nostr-dev-kit/ndk";
-import { NostrService } from "../common/nostr-service";
+import { NDKEvent, ProfilePointer } from '@nostr-dev-kit/ndk';
+import { NostrService } from '../common/nostr-service';
 import { nip21 } from 'nostr-tools';
+import {
+  createProfileMentionToken,
+  createUsernameMentionToken,
+} from './inline-fragment';
 
 export type ContentItem = {
   type: 'text' | 'image' | 'gif' | 'video' | 'link' | 'embedded-note';
   value?: string;
   noteId?: string;
 };
- 
-export async function parseText(text: string, post: NDKEvent | null, embeddedPosts: Map<string, NDKEvent>, nostrService: NostrService): Promise<ContentItem[]> {
-    let textContent = text;
-    let embeddedNotes: { id: string; position: number }[] = [];
 
-    // First capture embedded note references before other processing
-    // Example note1abcdef... or nostr:note1abcdef... or nevent1abcdef...
-    const noteRegex = /(nostr:)?(note[a-zA-Z0-9]{59,60}|nevent[a-zA-Z0-9]{58,})/g;
-    const noteMatches = [...textContent.matchAll(noteRegex)];
+export async function parseText(
+  text: string,
+  post: NDKEvent | null,
+  embeddedPosts: Map<string, NDKEvent>,
+  nostrService: NostrService,
+): Promise<ContentItem[]> {
+  let textContent = text;
+  let embeddedNotes: { id: string; position: number }[] = [];
 
-    for (const match of noteMatches) {
-      const fullMatch = match[0];
-      const noteId = match[2];
-      const position = match.index || 0;
+  // First capture embedded note references before other processing
+  // Example note1abcdef... or nostr:note1abcdef... or nevent1abcdef...
+  const noteRegex = /(nostr:)?(note[a-zA-Z0-9]{59,60}|nevent[a-zA-Z0-9]{58,})/g;
+  const noteMatches = [...textContent.matchAll(noteRegex)];
 
-      // Store the note ID and its position for later processing
-      embeddedNotes.push({
-        id: noteId,
-        position: position,
-      });
+  for (const match of noteMatches) {
+    const fullMatch = match[0];
+    const noteId = match[2];
+    const position = match.index || 0;
 
-      // Fetch the embedded post
-      try {
-        if (!embeddedPosts.has(noteId)) {
-          const embeddedPost = await nostrService.getPost(noteId);
-          if (embeddedPost) {
-            embeddedPosts.set(noteId, embeddedPost);
-          }
-        }
-      } catch (error) {
-        console.error(`Failed to fetch embedded post ${noteId}:`, error);
-      }
-
-      // Remove the note reference from the text to prevent @ symbols being added
-      textContent = textContent.replace(fullMatch, ' ');
-    }
-
-    // Handle Nostr URI schema for mentions - batch process to avoid multiple async operations
-    const nostrURISchemaMatches = [...textContent.matchAll(new RegExp(nip21.NOSTR_URI_REGEX, 'g'))];
-    const uriReplacements: { original: string; replacement: string }[] = [];
-
-    // Process all URIs concurrently
-    const uriPromises = nostrURISchemaMatches.map(async (match) => {
-      try {
-        const parsedNostrURI = nip21.parse(match[0]);
-        const decordedData = parsedNostrURI.decoded.data;
-
-        let pubkey = '';
-        if (typeof decordedData === 'string') {
-          pubkey = decordedData;
-        } else {
-          pubkey = (decordedData as ProfilePointer).pubkey;
-        }
-
-        if (pubkey) {
-          const user = nostrService.getNDK().getUser({ pubkey });
-          const profile = await user.fetchProfile();
-          const name = profile?.displayName || '';
-
-          uriReplacements.push({
-            original: match[0],
-            replacement: `<a href="https://njump.me/${parsedNostrURI.value}" target="_blank">@${name}</a>`
-          });
-        }
-      } catch (error) {
-        console.error('Failed to process Nostr URI:', error);
-      }
+    // Store the note ID and its position for later processing
+    embeddedNotes.push({
+      id: noteId,
+      position: position,
     });
 
-    await Promise.all(uriPromises);
-
-    // Apply all replacements at once
-    for (const replacement of uriReplacements) {
-      textContent = textContent.replace(replacement.original, replacement.replacement);
-    }
-
-    // Handle Twitter-like mentions (@username) - batch process
-    const mentionRegex = /(\s|^)@(\w+)/g;
-    const mentionMatches = [...textContent.matchAll(mentionRegex)];
-    const mentionReplacements: { original: string; replacement: string }[] = [];
-
-    for (const match of mentionMatches) {
-      const fullMatch = match[0];
-      const username = match[2];
-
-      mentionReplacements.push({
-        original: fullMatch,
-        replacement: `${match[1]}<span class="nostr-mention" data-username="${username}">@${username}</span>`
-      });
-    }
-
-    // Apply all mention replacements at once
-    for (const replacement of mentionReplacements) {
-      textContent = textContent.replace(replacement.original, replacement.replacement);
-    }
-
-   const result: ContentItem[] = [];
-
-   // First, check for Nostr attachments in the post
-   if (post) {
-     const videoTags = post.getMatchingTags('a');
-     for (const tag of videoTags) {
-       const mimeType = tag[1] as string;
-       const url = tag[2] as string;
-       if (mimeType?.startsWith('video/') && url) {
-         result.push({ type: 'video', value: url });
-       }
-     }
-   }
-
-    // Then handle URLs in the text - optimized with single pass
-    const urlRegex = /(https:\/\/(?!njump\.me)[\w.-]+(?:\.[\w.-]+)+(?:\/[^\s]*)?)/g;
-    const urlMatches = [...textContent.matchAll(urlRegex)];
-
-    if (urlMatches.length > 0) {
-      let lastIndex = 0;
-      
-      for (const match of urlMatches) {
-        const startIndex = match.index!;
-        const endIndex = startIndex + match[0].length;
-
-        // Add text before URL
-        if (startIndex > lastIndex) {
-          result.push({
-            type: 'text',
-            value: textContent.substring(lastIndex, startIndex),
-          });
+    // Fetch the embedded post
+    try {
+      if (!embeddedPosts.has(noteId)) {
+        const embeddedPost = await nostrService.getPost(noteId);
+        if (embeddedPost) {
+          embeddedPosts.set(noteId, embeddedPost);
         }
+      }
+    } catch (error) {
+      console.error(`Failed to fetch embedded post ${noteId}:`, error);
+    }
 
-        // Determine URL type efficiently
-        const url = match[0];
-        const pathname = new URL(url).pathname.toLowerCase();
-        let type: 'image' | 'gif' | 'video' | 'link';
+    // Remove the note reference from the text to prevent @ symbols being added
+    textContent = textContent.replace(fullMatch, ' ');
+  }
 
-        if (pathname.match(/\.(jpg|jpeg|png)$/)) {
-          type = 'image';
-        } else if (pathname.endsWith('.gif')) {
-          type = 'gif';
-        } else if (pathname.match(/\.(mp4|webm|mov)$/)) {
-          type = 'video';
-        } else {
-          type = 'link';
-        }
+  // Handle Nostr URI schema for mentions - batch process to avoid multiple async operations
+  const nostrURISchemaMatches = [
+    ...textContent.matchAll(new RegExp(nip21.NOSTR_URI_REGEX, 'g')),
+  ];
+  const uriReplacements: { original: string; replacement: string }[] = [];
 
-        result.push({ type, value: url });
-        lastIndex = endIndex;
+  // Process all URIs concurrently
+  const uriPromises = nostrURISchemaMatches.map(async (match) => {
+    try {
+      const parsedNostrURI = nip21.parse(match[0]);
+      const decordedData = parsedNostrURI.decoded.data;
+
+      let pubkey = '';
+      if (typeof decordedData === 'string') {
+        pubkey = decordedData;
+      } else {
+        pubkey = (decordedData as ProfilePointer).pubkey;
       }
 
-      // Add remaining text
-      if (lastIndex < textContent.length) {
-        result.push({ type: 'text', value: textContent.substring(lastIndex) });
-      }
-    } else {
-      result.push({ type: 'text', value: textContent });
-    }
+      if (pubkey) {
+        const user = nostrService.getNDK().getUser({ pubkey });
+        const profile = await user.fetchProfile();
+        const name =
+          profile?.displayName || profile?.name || parsedNostrURI.value;
 
-    // Add embedded notes to the result
-    // TODO: Embedded notes lose their original position in text and are appended at the end,
-    // losing their inline context. Consider inserting embedded notes at their original 
-    // positions using the captured position data to maintain content flow and semantic meaning.
-    // See: https://github.com/saiy2k/nostr-components/pull/23#discussion_r2238652376
-    if (embeddedNotes.length > 0) {
-      // Sort by position in descending order to avoid affecting earlier positions
-      embeddedNotes.sort((a, b) => b.position - a.position);
-
-      for (const note of embeddedNotes) {
-        result.push({
-          type: 'embedded-note',
-          noteId: note.id,
+        uriReplacements.push({
+          original: match[0],
+          replacement: createProfileMentionToken(
+            `https://njump.me/${parsedNostrURI.value}`,
+            name,
+          ),
         });
       }
+    } catch (error) {
+      console.error('Failed to process Nostr URI:', error);
+    }
+  });
+
+  await Promise.all(uriPromises);
+
+  // Apply all replacements at once
+  for (const replacement of uriReplacements) {
+    textContent = textContent.replace(
+      replacement.original,
+      replacement.replacement,
+    );
+  }
+
+  // Handle Twitter-like mentions (@username) - batch process
+  const mentionRegex = /(\s|^)@(\w+)/g;
+  const mentionMatches = [...textContent.matchAll(mentionRegex)];
+  const mentionReplacements: { original: string; replacement: string }[] = [];
+
+  for (const match of mentionMatches) {
+    const fullMatch = match[0];
+    const username = match[2];
+
+    mentionReplacements.push({
+      original: fullMatch,
+      replacement: `${match[1]}${createUsernameMentionToken(username)}`,
+    });
+  }
+
+  // Apply all mention replacements at once
+  for (const replacement of mentionReplacements) {
+    textContent = textContent.replace(
+      replacement.original,
+      replacement.replacement,
+    );
+  }
+
+  const result: ContentItem[] = [];
+
+  // First, check for Nostr attachments in the post
+  if (post) {
+    const videoTags = post.getMatchingTags('a');
+    for (const tag of videoTags) {
+      const mimeType = tag[1] as string;
+      const url = tag[2] as string;
+      if (mimeType?.startsWith('video/') && url) {
+        result.push({ type: 'video', value: url });
+      }
+    }
+  }
+
+  // Then handle URLs in the text - optimized with single pass
+  const urlRegex =
+    /(https:\/\/(?!njump\.me)[\w.-]+(?:\.[\w.-]+)+(?:\/[^\s]*)?)/g;
+  const urlMatches = [...textContent.matchAll(urlRegex)];
+
+  if (urlMatches.length > 0) {
+    let lastIndex = 0;
+
+    for (const match of urlMatches) {
+      const startIndex = match.index!;
+      const endIndex = startIndex + match[0].length;
+
+      // Add text before URL
+      if (startIndex > lastIndex) {
+        result.push({
+          type: 'text',
+          value: textContent.substring(lastIndex, startIndex),
+        });
+      }
+
+      // Determine URL type efficiently
+      const url = match[0];
+      const pathname = new URL(url).pathname.toLowerCase();
+      let type: 'image' | 'gif' | 'video' | 'link';
+
+      if (pathname.match(/\.(jpg|jpeg|png)$/)) {
+        type = 'image';
+      } else if (pathname.endsWith('.gif')) {
+        type = 'gif';
+      } else if (pathname.match(/\.(mp4|webm|mov)$/)) {
+        type = 'video';
+      } else {
+        type = 'link';
+      }
+
+      result.push({ type, value: url });
+      lastIndex = endIndex;
     }
 
-    return result;
+    // Add remaining text
+    if (lastIndex < textContent.length) {
+      result.push({ type: 'text', value: textContent.substring(lastIndex) });
+    }
+  } else {
+    result.push({ type: 'text', value: textContent });
   }
+
+  // Add embedded notes to the result
+  // TODO: Embedded notes lose their original position in text and are appended at the end,
+  // losing their inline context. Consider inserting embedded notes at their original
+  // positions using the captured position data to maintain content flow and semantic meaning.
+  // See: https://github.com/saiy2k/nostr-components/pull/23#discussion_r2238652376
+  if (embeddedNotes.length > 0) {
+    // Sort by position in descending order to avoid affecting earlier positions
+    embeddedNotes.sort((a, b) => b.position - a.position);
+
+    for (const note of embeddedNotes) {
+      result.push({
+        type: 'embedded-note',
+        noteId: note.id,
+      });
+    }
+  }
+
+  return result;
+}

--- a/src/nostr-post/parse-text.ts
+++ b/src/nostr-post/parse-text.ts
@@ -14,6 +14,14 @@ export type ContentItem = {
   noteId?: string;
 };
 
+function replaceAllLiteral(haystack: string, search: string, replacement: string): string {
+  if (!search) {
+    return haystack;
+  }
+
+  return haystack.split(search).join(replacement);
+}
+
 export async function parseText(
   text: string,
   post: NDKEvent | null,
@@ -52,7 +60,7 @@ export async function parseText(
     }
 
     // Remove the note reference from the text to prevent @ symbols being added
-    textContent = textContent.replace(fullMatch, ' ');
+    textContent = replaceAllLiteral(textContent, fullMatch, ' ');
   }
 
   // Handle Nostr URI schema for mentions - batch process to avoid multiple async operations
@@ -97,7 +105,8 @@ export async function parseText(
 
   // Apply all replacements at once
   for (const replacement of uriReplacements) {
-    textContent = textContent.replace(
+    textContent = replaceAllLiteral(
+      textContent,
       replacement.original,
       replacement.replacement,
     );
@@ -120,7 +129,8 @@ export async function parseText(
 
   // Apply all mention replacements at once
   for (const replacement of mentionReplacements) {
-    textContent = textContent.replace(
+    textContent = replaceAllLiteral(
+      textContent,
       replacement.original,
       replacement.replacement,
     );

--- a/src/nostr-post/render-content.ts
+++ b/src/nostr-post/render-content.ts
@@ -1,100 +1,105 @@
 // SPDX-License-Identifier: MIT
 
-  import { ContentItem } from './parse-text';
-  import { isValidUrl } from '../common/utils';
-  import { NDKEvent, NDKUserProfile } from '@nostr-dev-kit/ndk';
-  import { parseText } from './parse-text';
-  import { renderEmbeddedPost } from './render';
-  import { formatEventDate } from '../common/date-utils';
+import { ContentItem } from './parse-text';
+import { NDKEvent, NDKUserProfile } from '@nostr-dev-kit/ndk';
+import { parseText } from './parse-text';
+import { renderEmbeddedPost } from './render';
+import { formatEventDate } from '../common/date-utils';
+import { sanitizeHttpUrl } from '../common/sanitize';
+import { escapeHtml } from '../common/utils';
+import { renderPostInlineText } from './inline-fragment';
 
-  export function renderContent(content: ContentItem[]): string {
-    const html: string[] = [];
-    let mediaCount = 0;
-    let textBuffer = '';
+function renderBufferedText(textBuffer: string): string {
+  return `<span class="text-content">${renderPostInlineText(textBuffer)}</span>`;
+}
 
-    for (const item of content) {
-      if (item.type === 'text') {
-        textBuffer += (item.value ?? '');
-      } else if (item.type === 'embedded-note') {
-        // Handle embedded note placeholder
-        if (textBuffer) {
-          html.push(
-            `<span class="text-content">${textBuffer.replace(/\n/g, '<br />')}</span>`
-          );
-          textBuffer = '';
-        }
+export function renderContent(content: ContentItem[]): string {
+  const html: string[] = [];
+  let mediaCount = 0;
+  let textBuffer = '';
 
-        html.push(
-          `<div class="embedded-post-placeholder" data-note-id="${item.noteId}"></div>`
-        );
-      } else {
-        if (textBuffer) {
-          html.push(
-            `<span class="text-content">${textBuffer.replace(/\n/g, '<br />')}</span>`
-          );
-          textBuffer = '';
-        }
-
-        const url = item.value ?? "";
-        if (!isValidUrl(url)) continue;
-        switch (item.type) {
-          case 'image':
-            html.push(
-              `<img class="post-media-item" src="${url}" alt="User uploaded image" loading="lazy">`
-            );
-            mediaCount++;
-            break;
-          case 'gif':
-            html.push(
-              `<img class="post-media-item" src="${url}" alt="User uploaded GIF" loading="lazy">`
-            );
-            mediaCount++;
-            break;
-          case 'video':
-            html.push(
-              `<video class="post-media-item" src="${url}" controls></video>`
-            );
-            mediaCount++;
-            break;
-          case 'link':
-            html.push(`<a href="${url}">${url}</a>`);
-            break;
-        }
+  for (const item of content) {
+    if (item.type === 'text') {
+      textBuffer += item.value ?? '';
+    } else if (item.type === 'embedded-note') {
+      // Handle embedded note placeholder
+      if (textBuffer) {
+        html.push(renderBufferedText(textBuffer));
+        textBuffer = '';
       }
-    }
 
-    if (textBuffer) {
       html.push(
-        `<span class="text-content">${textBuffer.replace(/\n/g, '<br />')}</span>`
+        `<div class="embedded-post-placeholder" data-note-id="${escapeHtml(item.noteId || '')}"></div>`,
       );
-    }
-
-    if (mediaCount > 1) {
-      const carouselHtml: string[] = [];
-      const bullets: string[] = [];
-      let slideIndex = 0;
-      let firstMediaIndex = -1;
-
-      // First pass: collect media items and track first media position
-      for (let i = 0; i < html.length; i++) {
-        const item = html[i];
-        if (item.startsWith('<img') || item.startsWith('<video')) {
-          if (firstMediaIndex === -1) {
-            firstMediaIndex = i;
-          }
-          carouselHtml.push(`<li class="glide__slide">${item}</li>`);
-          bullets.push(`<button class="glide__bullet" data-glide-dir="=${slideIndex}"></button>`);
-          slideIndex++;
-        }
+    } else {
+      if (textBuffer) {
+        html.push(renderBufferedText(textBuffer));
+        textBuffer = '';
       }
 
-      // Remove media items from html array (filter in-place)
-      const filteredHtml = html.filter(item => 
-        !item.startsWith('<img') && !item.startsWith('<video')
-      );
+      const url = item.value ?? '';
+      const safeUrl = sanitizeHttpUrl(url);
+      if (!safeUrl) continue;
+      switch (item.type) {
+        case 'image':
+          html.push(
+            `<img class="post-media-item" src="${safeUrl}" alt="User uploaded image" loading="lazy">`,
+          );
+          mediaCount++;
+          break;
+        case 'gif':
+          html.push(
+            `<img class="post-media-item" src="${safeUrl}" alt="User uploaded GIF" loading="lazy">`,
+          );
+          mediaCount++;
+          break;
+        case 'video':
+          html.push(
+            `<video class="post-media-item" src="${safeUrl}" controls></video>`,
+          );
+          mediaCount++;
+          break;
+        case 'link':
+          html.push(
+            `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${escapeHtml(url)}</a>`,
+          );
+          break;
+      }
+    }
+  }
 
-      // Build carousel string
-      const carouselString = `
+  if (textBuffer) {
+    html.push(renderBufferedText(textBuffer));
+  }
+
+  if (mediaCount > 1) {
+    const carouselHtml: string[] = [];
+    const bullets: string[] = [];
+    let slideIndex = 0;
+    let firstMediaIndex = -1;
+
+    // First pass: collect media items and track first media position
+    for (let i = 0; i < html.length; i++) {
+      const item = html[i];
+      if (item.startsWith('<img') || item.startsWith('<video')) {
+        if (firstMediaIndex === -1) {
+          firstMediaIndex = i;
+        }
+        carouselHtml.push(`<li class="glide__slide">${item}</li>`);
+        bullets.push(
+          `<button class="glide__bullet" data-glide-dir="=${slideIndex}"></button>`,
+        );
+        slideIndex++;
+      }
+    }
+
+    // Remove media items from html array (filter in-place)
+    const filteredHtml = html.filter(
+      (item) => !item.startsWith('<img') && !item.startsWith('<video'),
+    );
+
+    // Build carousel string
+    const carouselString = `
         <div class="glide" style="margin-top: 20px">
             <div class="glide__track" data-glide-el="track">
                 <ul class="glide__slides">
@@ -108,80 +113,84 @@
         </div>
       `;
 
-      // Replace html with filtered content and splice carousel at first media position
-      html.length = 0;
-      html.push(...filteredHtml);
-      html.splice(firstMediaIndex, 0, carouselString);
-    }
-
-    return html.join('');
-  };
-
-  export async function replaceEmbeddedPostPlaceholders(
-    shadowRoot: ShadowRoot | null,
-    embeddedPosts: Map<string, NDKEvent>,
-    event: NDKEvent | null,
-    nostrService: any
-  ) {
-    const placeholders = shadowRoot?.querySelectorAll('.embedded-post-placeholder');
-
-    if (!placeholders) return;
-
-    for (const placeholder of placeholders) {
-      const noteId = placeholder.getAttribute('data-note-id');
-      if (noteId) {
-        const embedHtml = await renderEmbeddedPostContent(noteId, embeddedPosts, event, nostrService);
-
-        const temp = document.createElement('div');
-        temp.innerHTML = embedHtml;
-
-        // Replace the placeholder with the embedded post
-        placeholder.parentNode?.replaceChild(
-          temp.firstElementChild!,
-          placeholder
-        );
-      }
-    }
+    // Replace html with filtered content and splice carousel at first media position
+    html.length = 0;
+    html.push(...filteredHtml);
+    html.splice(firstMediaIndex, 0, carouselString);
   }
 
-  export async function renderEmbeddedPostContent(
-    noteId: string,
-    embeddedPosts: Map<string, NDKEvent>,
-    event: NDKEvent | null,
-    nostrService: any
-  ): Promise<string> {
-    const post = embeddedPosts.get(noteId);
-    if (!post) return '<div class="embedded-post-error">Post not found</div>';
+  return html.join('');
+}
 
-    let authorProfile: NDKUserProfile | null = null;
-    try {
-      authorProfile = await post.author.fetchProfile();
-    } catch (error) {
-      console.error(
-        `Failed to fetch profile for embedded post ${noteId}:`,
-        error
+export async function replaceEmbeddedPostPlaceholders(
+  shadowRoot: ShadowRoot | null,
+  embeddedPosts: Map<string, NDKEvent>,
+  nostrService: any,
+) {
+  const placeholders = shadowRoot?.querySelectorAll(
+    '.embedded-post-placeholder',
+  );
+
+  if (!placeholders) return;
+
+  for (const placeholder of placeholders) {
+    const noteId = placeholder.getAttribute('data-note-id');
+    if (noteId) {
+      const embedHtml = await renderEmbeddedPostContent(
+        noteId,
+        embeddedPosts,
+        nostrService,
+      );
+
+      const temp = document.createElement('div');
+      temp.innerHTML = embedHtml;
+
+      // Replace the placeholder with the embedded post
+      placeholder.parentNode?.replaceChild(
+        temp.firstElementChild!,
+        placeholder,
       );
     }
+  }
+}
 
-    const date = formatEventDate(post.created_at);
+export async function renderEmbeddedPostContent(
+  noteId: string,
+  embeddedPosts: Map<string, NDKEvent>,
+  nostrService: any,
+): Promise<string> {
+  const post = embeddedPosts.get(noteId);
+  if (!post) return '<div class="embedded-post-error">Post not found</div>';
 
-    // Process the post content
-    const content = await parseText(post.content, post, embeddedPosts, nostrService);
-    const renderedContent = renderContent(content);
-
-    const sanitizedProfile = authorProfile
-      ? {
-          displayName: authorProfile.displayName || '',
-          image: isValidUrl(authorProfile.picture || '') ? authorProfile.picture : '',
-          nip05: authorProfile.nip05 || '',
-        }
-      : undefined;
-
-    // Use the renderEmbeddedPost function from the render module
-    return renderEmbeddedPost(
-      noteId,
-      sanitizedProfile,
-      date,
-      renderedContent
+  let authorProfile: NDKUserProfile | null = null;
+  try {
+    authorProfile = await post.author.fetchProfile();
+  } catch (error) {
+    console.error(
+      `Failed to fetch profile for embedded post ${noteId}:`,
+      error,
     );
   }
+
+  const date = formatEventDate(post.created_at);
+
+  // Process the post content
+  const content = await parseText(
+    post.content,
+    post,
+    embeddedPosts,
+    nostrService,
+  );
+  const renderedContent = renderContent(content);
+
+  const sanitizedProfile = authorProfile
+    ? {
+        displayName: authorProfile.displayName || '',
+        image: sanitizeHttpUrl(authorProfile.picture || ''),
+        nip05: authorProfile.nip05 || '',
+      }
+    : undefined;
+
+  // Use the renderEmbeddedPost function from the render module
+  return renderEmbeddedPost(noteId, sanitizedProfile, date, renderedContent);
+}

--- a/src/nostr-post/render.ts
+++ b/src/nostr-post/render.ts
@@ -110,6 +110,7 @@ function renderPostHeader(
   const authorImage = sanitizeUrl(author?.image || '');
   const authorDisplayName = escapeHtml(author?.displayName || '');
   const authorNip05 = escapeHtml(author?.nip05 || '');
+  const safeDate = escapeHtml(date);
 
   return `
     <div class="post-header">
@@ -123,7 +124,7 @@ function renderPostHeader(
         ${authorNip05 ? `<span class="author-username">${authorNip05}</span>` : ''}
       </div>
       <div class="post-header-right">
-        <span class="post-date">${date}</span>
+        <span class="post-date">${safeDate}</span>
       </div>
     </div>
   `;
@@ -303,6 +304,7 @@ export function renderEmbeddedPost(
   const authorNip05 = escapeHtml(authorProfile?.nip05 || '');
   const authorImage = sanitizeUrl(authorProfile?.image || '');
   const safeNoteId = escapeHtml(noteId);
+  const safeDate = escapeHtml(date);
 
   // Process media items from content
   const mediaItems: { type: 'image' | 'video'; url: string }[] = [];
@@ -395,7 +397,7 @@ export function renderEmbeddedPost(
           <span class="embedded-author-name">${authorDisplayName}</span>
           ${authorNip05 ? `<span class="embedded-author-username">${authorNip05}</span>` : ''}
         </div>
-        <div class="embedded-post-date">${date}</div>
+        <div class="embedded-post-date">${safeDate}</div>
       </div>
       <div class="embedded-post-content">
         ${processedContent}

--- a/src/nostr-post/render.ts
+++ b/src/nostr-post/render.ts
@@ -6,11 +6,11 @@ import * as DomUtils from 'domutils';
 import { replyIcon, heartIcon } from '../common/icons';
 import { IRenderOptions } from '../base/render-options';
 import { NDKUserProfile } from '@nostr-dev-kit/ndk';
-import { escapeHtml } from '../common/utils';
+import { escapeHtml, sanitizeUrl } from '../common/utils';
 import { ReplyItem } from './reply-utils';
 
 export interface RenderPostOptions extends IRenderOptions {
-  author: NDKUserProfile | null| undefined;
+  author: NDKUserProfile | null | undefined;
   date: string;
   shouldShowStats: boolean;
   stats: {
@@ -86,7 +86,7 @@ function renderPostHeader(
       }
     | null
     | undefined,
-  date: string
+  date: string,
 ): string {
   if (isLoading) {
     return `
@@ -107,16 +107,20 @@ function renderPostHeader(
     `;
   }
 
+  const authorImage = sanitizeUrl(author?.image || '');
+  const authorDisplayName = escapeHtml(author?.displayName || '');
+  const authorNip05 = escapeHtml(author?.nip05 || '');
+
   return `
     <div class="post-header">
       <div class="post-header-left">
         <div class="author-picture">
-          ${author?.image ? `<img src="${author.image}" alt="Author" />` : ''}
+          ${authorImage ? `<img src="${authorImage}" alt="${authorDisplayName || 'Author'}" />` : ''}
         </div>
       </div>
       <div class="post-header-middle">
-        ${author?.displayName ? `<span class="author-name">${author.displayName}</span>` : ''}
-        ${author?.nip05 ? `<span class="author-username">${author.nip05}</span>` : ''}
+        ${authorDisplayName ? `<span class="author-name">${authorDisplayName}</span>` : ''}
+        ${authorNip05 ? `<span class="author-username">${authorNip05}</span>` : ''}
       </div>
       <div class="post-header-right">
         <span class="post-date">${date}</span>
@@ -125,10 +129,7 @@ function renderPostHeader(
   `;
 }
 
-function renderPostBody(
-  isLoading: boolean,
-  htmlToRender: string
-): string {
+function renderPostBody(isLoading: boolean, htmlToRender: string): string {
   if (isLoading) {
     return `
       <div class="post-body">
@@ -296,9 +297,12 @@ export function renderEmbeddedPost(
       }
     | undefined,
   date: string,
-  content: string
+  content: string,
 ): string {
-  const authorDisplayName = authorProfile?.displayName || '';
+  const authorDisplayName = escapeHtml(authorProfile?.displayName || '');
+  const authorNip05 = escapeHtml(authorProfile?.nip05 || '');
+  const authorImage = sanitizeUrl(authorProfile?.image || '');
+  const safeNoteId = escapeHtml(noteId);
 
   // Process media items from content
   const mediaItems: { type: 'image' | 'video'; url: string }[] = [];
@@ -318,7 +322,7 @@ export function renderEmbeddedPost(
         normalizeWhitespace: false,
         withEndIndices: false,
         withStartIndices: false,
-      }
+      },
     );
 
     const parser = new Parser(handler);
@@ -337,7 +341,7 @@ export function renderEmbeddedPost(
     }, dom) as any[];
 
     // Extract media items and remove them from the DOM
-    mediaElements.forEach(elem => {
+    mediaElements.forEach((elem) => {
       if (elem.attribs?.src) {
         const type = elem.name === 'img' ? 'image' : 'video';
         mediaItems.push({ type, url: elem.attribs.src });
@@ -346,7 +350,7 @@ export function renderEmbeddedPost(
         const parent = elem.parent;
         if (parent?.children) {
           parent.children = parent.children.filter(
-            (child: any) => child !== elem
+            (child: any) => child !== elem,
           );
         }
       }
@@ -367,24 +371,29 @@ export function renderEmbeddedPost(
   if (mediaItems.length > 0) {
     mediaHtml = '<div class="embedded-media-list">';
     for (const item of mediaItems) {
+      const safeMediaUrl = sanitizeUrl(item.url);
+      if (!safeMediaUrl) {
+        continue;
+      }
+
       if (item.type === 'image') {
-        mediaHtml += `<div class="embedded-media-item"><img src="${item.url}" alt="Embedded image" loading="lazy" /></div>`;
+        mediaHtml += `<div class="embedded-media-item"><img src="${safeMediaUrl}" alt="Embedded image" loading="lazy" /></div>`;
       } else if (item.type === 'video') {
-        mediaHtml += `<div class="embedded-media-item"><video src="${item.url}" controls preload="none"></video></div>`;
+        mediaHtml += `<div class="embedded-media-item"><video src="${safeMediaUrl}" controls preload="none"></video></div>`;
       }
     }
     mediaHtml += '</div>';
   }
 
   return `
-    <div class="embedded-post" data-note-id="${noteId}">
+    <div class="embedded-post" data-note-id="${safeNoteId}">
       <div class="embedded-post-header">
         <div class="embedded-author-avatar" style="cursor: pointer;">
-          ${authorProfile?.image ? `<img src="${authorProfile.image}" alt="Profile">` : ''}
+          ${authorImage ? `<img src="${authorImage}" alt="${authorDisplayName || 'Profile'}">` : ''}
         </div>
         <div class="embedded-author-info" style="cursor: pointer;">
           <span class="embedded-author-name">${authorDisplayName}</span>
-          ${authorProfile?.nip05 ? `<span class="embedded-author-username">${authorProfile.nip05}</span>` : ''}
+          ${authorNip05 ? `<span class="embedded-author-username">${authorNip05}</span>` : ''}
         </div>
         <div class="embedded-post-date">${date}</div>
       </div>

--- a/src/nostr-profile-badge/render.ts
+++ b/src/nostr-profile-badge/render.ts
@@ -6,6 +6,7 @@ import { DEFAULT_PROFILE_IMAGE } from '../common/constants';
 import { renderNpub } from '../base/text-row/render-npub';
 import { renderNip05 } from '../base/text-row/render-nip05';
 import { renderName } from '../base/text-row/render-name';
+import { sanitizeHttpUrl } from '../common/sanitize';
 
 export interface RenderProfileBadgeOptions {
   isLoading: boolean;
@@ -24,9 +25,8 @@ export function renderProfileBadge({
   userProfile,
   ndkUser,
   showNpub,
-  showFollow
+  showFollow,
 }: RenderProfileBadgeOptions): string {
-
   if (isLoading) {
     return renderLoading();
   }
@@ -35,11 +35,13 @@ export function renderProfileBadge({
     return renderError(errorMessage || '');
   }
 
-  const rawName = userProfile.displayName ||
+  const rawName =
+    userProfile.displayName ||
     userProfile.name ||
-    maskNPub(ndkUser?.npub || '')
+    maskNPub(ndkUser?.npub || '');
   const escapedName = escapeHtml(rawName);
-  const profileImage = escapeHtml(userProfile.picture || DEFAULT_PROFILE_IMAGE);
+  const profileImage =
+    sanitizeHttpUrl(userProfile.picture || '') || DEFAULT_PROFILE_IMAGE;
   const npub = ndkUser?.npub || '';
   const nip05 = userProfile?.nip05 || '';
   const pubkey = escapeHtml(ndkUser?.pubkey || '');
@@ -49,7 +51,7 @@ export function renderProfileBadge({
     `${renderName({ name: rawName })}
      ${userProfile.nip05 ? renderNip05(nip05) : ''}
      ${showNpub === true ? renderNpub(npub || '') : ''}
-     ${showFollow === true && ndkUser?.pubkey ? `<nostr-follow-button pubkey="${pubkey}"></nostr-follow-button>` : ''}`
+     ${showFollow === true && ndkUser?.pubkey ? `<nostr-follow-button pubkey="${pubkey}"></nostr-follow-button>` : ''}`,
   );
 }
 
@@ -57,14 +59,14 @@ function renderLoading(): string {
   return renderContainer(
     '<div class="skeleton img-skeleton"></div>',
     `<div class="skeleton" style="width: 120px;"></div>
-     <div class="skeleton" style="width: 160px;"></div>`
+     <div class="skeleton" style="width: 160px;"></div>`,
   );
 }
 
 function renderError(errorMessage: string): string {
   return renderContainer(
     '<div class="error-icon">&#9888;</div>',
-    escapeHtml(errorMessage)
+    escapeHtml(errorMessage),
   );
 }
 

--- a/src/nostr-profile/__tests__/render.test.ts
+++ b/src/nostr-profile/__tests__/render.test.ts
@@ -101,4 +101,38 @@ describe('renderProfile', () => {
     expect(html).not.toContain('src="javascript:alert(1)"');
     expect(html).not.toContain('src="data:text/html,boom"');
   });
+
+  it('renders valid https website links', () => {
+    const html = renderProfile({
+      isLoading: false,
+      isError: false,
+      errorMessage: '',
+      npub: 'npub1test',
+      userProfile: {
+        displayName: 'Alice',
+        name: 'Alice',
+        nip05: 'alice@example.com',
+        picture: 'https://example.com/avatar.png',
+        about: 'Hello',
+        website: 'https://example.com',
+        banner: 'https://example.com/banner.png',
+      },
+      isStatsLoading: false,
+      isStatsFollowersLoading: false,
+      isStatsFollowsLoading: false,
+      isZapsLoading: false,
+      stats: {
+        notes: 0,
+        replies: 0,
+        follows: 0,
+        followers: 0,
+        zaps: 0,
+        relays: 0,
+      },
+      showFollow: false,
+      showNpub: false,
+    });
+
+    expect(html).toContain('href="https://example.com/"');
+  });
 });

--- a/src/nostr-profile/__tests__/render.test.ts
+++ b/src/nostr-profile/__tests__/render.test.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+import { renderProfile } from '../render';
+
+describe('renderProfile', () => {
+  it('escapes malicious display names and error strings', () => {
+    const html = renderProfile({
+      isLoading: false,
+      isError: false,
+      errorMessage: '',
+      npub: 'npub1test',
+      userProfile: {
+        displayName: '<img src=x onerror=alert(1)>',
+        name: '',
+        nip05: 'alice@example.com',
+        picture: 'https://example.com/avatar.png',
+        about: 'Hello',
+        website: 'https://example.com',
+        banner: 'https://example.com/banner.png',
+      },
+      isStatsLoading: false,
+      isStatsFollowersLoading: false,
+      isStatsFollowsLoading: false,
+      isZapsLoading: false,
+      stats: {
+        notes: 1,
+        replies: 2,
+        follows: 3,
+        followers: 4,
+        zaps: 5,
+        relays: 0,
+      },
+      showFollow: false,
+      showNpub: false,
+    });
+
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+    expect(html).not.toContain('<img src=x onerror=alert(1)>');
+
+    const errorHtml = renderProfile({
+      isLoading: false,
+      isError: true,
+      errorMessage: '<script>alert(1)</script>',
+      npub: '',
+      userProfile: {} as any,
+      isStatsLoading: false,
+      isStatsFollowersLoading: false,
+      isStatsFollowsLoading: false,
+      isZapsLoading: false,
+      stats: {
+        notes: 0,
+        replies: 0,
+        follows: 0,
+        followers: 0,
+        zaps: 0,
+        relays: 0,
+      },
+      showFollow: false,
+      showNpub: false,
+    });
+
+    expect(errorHtml).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(errorHtml).not.toContain('<script>alert(1)</script>');
+  });
+
+  it('omits invalid banner, avatar, and website URLs from the output', () => {
+    const html = renderProfile({
+      isLoading: false,
+      isError: false,
+      errorMessage: '',
+      npub: 'npub1test',
+      userProfile: {
+        displayName: 'Alice',
+        name: 'Alice',
+        nip05: 'alice@example.com',
+        picture: 'javascript:alert(1)',
+        about: 'Hello',
+        website: 'javascript:alert(1)',
+        banner: 'data:text/html,boom',
+      },
+      isStatsLoading: false,
+      isStatsFollowersLoading: false,
+      isStatsFollowsLoading: false,
+      isZapsLoading: false,
+      stats: {
+        notes: 0,
+        replies: 0,
+        follows: 0,
+        followers: 0,
+        zaps: 0,
+        relays: 0,
+      },
+      showFollow: false,
+      showNpub: false,
+    });
+
+    expect(html).toContain('banner-placeholder');
+    expect(html).toContain('avatar-placeholder');
+    expect(html).not.toContain('href="javascript:alert(1)"');
+    expect(html).not.toContain('src="javascript:alert(1)"');
+    expect(html).not.toContain('src="data:text/html,boom"');
+  });
+});

--- a/src/nostr-profile/render.ts
+++ b/src/nostr-profile/render.ts
@@ -59,12 +59,13 @@ export function renderProfile(options: RenderProfileOptions): string {
   const sanitizedImage = sanitizeUrl(userProfile?.picture || '');
   const sanitizedWebsite = sanitizeUrl(website);
   const safeDisplayName = escapeHtml(displayName);
+  const safeNpub = escapeHtml(npub);
 
   const renderFollowButton = () => {
     if (!showFollow || npub === '') return '';
     return `
       <nostr-follow-button
-        npub="${npub}">
+        npub="${safeNpub}">
       </nostr-follow-button>
     `;
   };
@@ -151,7 +152,7 @@ export function renderProfile(options: RenderProfileOptions): string {
       
         <div class="stats">
 
-          ${renderStats('Following', stats.follows, isStatsFollowersLoading)}
+          ${renderStats('Following', stats.follows, isStatsFollowsLoading)}
           
           ${renderStats('Followers', stats.followers, isStatsFollowersLoading)}
 

--- a/src/nostr-profile/render.ts
+++ b/src/nostr-profile/render.ts
@@ -7,7 +7,7 @@ import { renderNip05 } from '../base/text-row/render-nip05';
 import { renderStats } from './render-stats';
 import { renderName } from '../base/text-row/render-name';
 import { renderTextRow } from '../base/text-row/render-text-row';
-import { escapeHtml, isValidUrl, sanitizeUrl } from '../common/utils';
+import { escapeHtml, sanitizeUrl } from '../common/utils';
 
 export interface Stats {
   notes: number;
@@ -53,12 +53,12 @@ export function renderProfile(options: RenderProfileOptions): string {
   // Extract profile data with null checks and default values
   const displayName = userProfile?.displayName || userProfile?.name || '';
   const nip05 = userProfile?.nip05 || '';
-  const image = userProfile?.picture || '';
   const about = userProfile?.about || '';
   const website = userProfile?.website || '';
-  const sanitizedBanner = userProfile?.banner ? sanitizeUrl(userProfile.banner) : '';
-  const sanitizedImage = image ? sanitizeUrl(image) : '';
-  const sanitizedWebsite = website && isValidUrl(website) ? sanitizeUrl(website) : '';
+  const sanitizedBanner = sanitizeUrl(userProfile?.banner || '');
+  const sanitizedImage = sanitizeUrl(userProfile?.picture || '');
+  const sanitizedWebsite = sanitizeUrl(website);
+  const safeDisplayName = escapeHtml(displayName);
 
   const renderFollowButton = () => {
     if (!showFollow || npub === '') return '';
@@ -72,76 +72,86 @@ export function renderProfile(options: RenderProfileOptions): string {
   return `
     <div class="nostr-profile-container">
       <div class="profile-banner">
-        ${isLoading
-          ? '<div style="width: 100%; height: 100%;" class="skeleton"></div>'
-          : sanitizedBanner
-            ? `<img src="${sanitizedBanner}" width="524px"/>`
-            : '<div class="banner-placeholder"></div>'
+        ${
+          isLoading
+            ? '<div style="width: 100%; height: 100%;" class="skeleton"></div>'
+            : sanitizedBanner
+              ? `<img src="${sanitizedBanner}" width="524px" alt="Profile banner" loading="lazy" />`
+              : '<div class="banner-placeholder"></div>'
         }
 
         <div class="dp-container">
-          <div class="avatar" role="img" aria-label="${escapeHtml(displayName)}">
-            ${isLoading
-              ? '<div style="width: 100%; height: 100%; border-radius: 50%" class="skeleton"></div>'
-              : `<img
+          <div class="avatar" role="img" aria-label="${safeDisplayName}">
+            ${
+              isLoading
+                ? '<div style="width: 100%; height: 100%; border-radius: 50%" class="skeleton"></div>'
+                : sanitizedImage
+                  ? `<img
                   src="${sanitizedImage}"
-                  alt="${escapeHtml(displayName)}"
+                  alt="${safeDisplayName}"
                   width="142" height="142"
                   loading="lazy" decoding="async"
-                  onerror="this.onerror=null; this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 142 142%22%3E%3Crect width=%22142%22 height=%22142%22 fill=%22%23ccc%22/%3E%3C/svg%3E'"
                 />`
+                  : '<div class="avatar-placeholder"></div>'
             }
           </div>
         </div>
       </div>
 
       <div class="profile_actions">
-        ${showFollow ?
-          isLoading? '<div style="width: 100px; height: 36px; border-radius: 18px;" class="skeleton"></div>'
-            : renderFollowButton()
-          : ''
+        ${
+          showFollow
+            ? isLoading
+              ? '<div style="width: 100px; height: 36px; border-radius: 18px;" class="skeleton"></div>'
+              : renderFollowButton()
+            : ''
         }
       </div>
         
       <div class="profile_data">
-        ${isLoading
-          ? '<div style="width: 100px; height: 24px;" class="skeleton"></div>'
-          : renderName({ name: displayName })
+        ${
+          isLoading
+            ? '<div style="width: 100px; height: 24px;" class="skeleton"></div>'
+            : renderName({ name: displayName })
         }
           
-        ${isLoading
-          ? '<div style="width: 75px; height: 20px;" class="skeleton"></div>'
-          : renderNip05(nip05)
-        }
-
-        ${showNpub ?
+        ${
           isLoading
             ? '<div style="width: 75px; height: 20px;" class="skeleton"></div>'
-            : renderNpub(npub)
-          : ''
+            : renderNip05(nip05)
         }
 
-        <div class="margin-bottom-md"> </div>
-        
-        ${isLoading
-          ? `<div style="width: 100%; margin-bottom: 12px; height: 18px" class="skeleton"></div>`
-          : renderTextRow({ display: about, value: about })
-        }
-
-        <div class="margin-bottom-md"> </div>
-        
-        ${isLoading
-          ? '<div style="width: 150px" class="skeleton"></div>'
-          : sanitizedWebsite
-            ? `<div class="website">
-              <a target="_blank" href="${sanitizedWebsite}">${escapeHtml(website)}</a>
-              </div>`
+        ${
+          showNpub
+            ? isLoading
+              ? '<div style="width: 75px; height: 20px;" class="skeleton"></div>'
+              : renderNpub(npub)
             : ''
+        }
+
+        <div class="margin-bottom-md"> </div>
+        
+        ${
+          isLoading
+            ? `<div style="width: 100%; margin-bottom: 12px; height: 18px" class="skeleton"></div>`
+            : renderTextRow({ display: about, value: about })
+        }
+
+        <div class="margin-bottom-md"> </div>
+        
+        ${
+          isLoading
+            ? '<div style="width: 150px" class="skeleton"></div>'
+            : sanitizedWebsite
+              ? `<div class="website">
+              <a target="_blank" rel="noopener noreferrer" href="${sanitizedWebsite}">${escapeHtml(website)}</a>
+              </div>`
+              : ''
         }
       
         <div class="stats">
 
-          ${renderStats('Following', stats.follows, isStatsFollowsLoading)}
+          ${renderStats('Following', stats.follows, isStatsFollowersLoading)}
           
           ${renderStats('Followers', stats.followers, isStatsFollowersLoading)}
 

--- a/src/nostr-profile/style.ts
+++ b/src/nostr-profile/style.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-import { getComponentStyles } from "../common/base-styles";
+import { getComponentStyles } from '../common/base-styles';
 
 export function getProfileStyles(): string {
   const customStyles = `
@@ -124,6 +124,14 @@ export function getProfileStyles(): string {
       object-fit: cover;
     }
 
+    .avatar-placeholder {
+      inline-size: 100%;
+      block-size: 100%;
+      border-radius: var(--nostrc-border-radius-full);
+      background: var(--nostrc-color-border);
+      display: block;
+    }
+
     .profile_actions {
       height: 56px;
       align-self: flex-end;
@@ -210,7 +218,7 @@ export function getProfileStyles(): string {
     }
 
   `;
-  
+
   // Use component styles - includes design tokens + utilities + custom styles
   return getComponentStyles(customStyles);
 }

--- a/src/nostr-zap-button/__tests__/dialog-zappers.test.ts
+++ b/src/nostr-zap-button/__tests__/dialog-zappers.test.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+import { renderZapEntry } from '../render-zap-entry';
+
+describe('renderZapEntry', () => {
+  it('renders zap comments as escaped plain text with preserved line breaks', () => {
+    const html = renderZapEntry(
+      {
+        authorPubkey: 'f'.repeat(64),
+        authorName: 'Alice',
+        authorNpub: 'npub1invalid',
+        authorPicture: 'javascript:alert(1)',
+        amount: 21,
+        comment: `<img src=x onerror="alert('xss')">\nhello`,
+        date: new Date('2024-01-01T00:00:00.000Z'),
+      },
+      0,
+    );
+
+    expect(html).toContain(
+      '&lt;img src=x onerror=&quot;alert(&#39;xss&#39;)&quot;&gt;<br />hello',
+    );
+    expect(html).not.toContain('<img src=x onerror="alert(\'xss\')">');
+    expect(html).not.toContain('src="javascript:alert(1)"');
+  });
+});

--- a/src/nostr-zap-button/__tests__/dialog-zappers.test.ts
+++ b/src/nostr-zap-button/__tests__/dialog-zappers.test.ts
@@ -21,7 +21,26 @@ describe('renderZapEntry', () => {
     expect(html).toContain(
       '&lt;img src=x onerror=&quot;alert(&#39;xss&#39;)&quot;&gt;<br />hello',
     );
-    expect(html).not.toContain('<img src=x onerror="alert(\'xss\')">');
+    expect(html).not.toContain('<img src=x');
     expect(html).not.toContain('src="javascript:alert(1)"');
+  });
+
+  it('escapes author names and author pubkey attributes', () => {
+    const html = renderZapEntry(
+      {
+        authorPubkey: 'abc"<>def',
+        authorName: '<script>alert(1)</script>',
+        authorNpub: 'npub1invalid',
+        authorPicture: '',
+        amount: 21,
+        comment: '',
+        date: new Date('2024-01-01T00:00:00.000Z'),
+      },
+      0,
+    );
+
+    expect(html).toContain('data-author-pubkey="abc&quot;&lt;&gt;def"');
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(html).not.toContain('<script>alert(1)</script>');
   });
 });

--- a/src/nostr-zap-button/dialog-zappers.ts
+++ b/src/nostr-zap-button/dialog-zappers.ts
@@ -4,13 +4,17 @@
 import '../base/dialog-component/dialog-component';
 import type { DialogComponent } from '../base/dialog-component/dialog-component';
 import { getZappersDialogStyles } from './dialog-zappers-style';
-import { getBatchedProfileMetadata, extractProfileMetadataContent, ZapDetails } from './zap-utils';
-import { escapeHtml, formatRelativeTime, hexToNpub, isValidUrl } from '../common/utils';
-import { isValidPublicKey } from '../nostr-comment/utils';
+import {
+  getBatchedProfileMetadata,
+  extractProfileMetadataContent,
+  ZapDetails,
+} from './zap-utils';
+import { escapeHtml, formatRelativeTime, hexToNpub } from '../common/utils';
+import { renderZapEntry, type EnhancedZapDetails } from './render-zap-entry';
 
 /**
  * Modal dialog for displaying individual zap details (zappers).
- * 
+ *
  * Shows a list of all zaps received by a user with:
  * - Zap amount
  * - Zap date (relative time)
@@ -29,65 +33,31 @@ export interface OpenZappersModalParams {
  * Inject zappers dialog content styles into document head
  * Prevents duplicate injection by checking for existing styles
  */
-export const injectZappersDialogStyles = (theme: 'light' | 'dark' = 'light') => {
+export const injectZappersDialogStyles = (
+  theme: 'light' | 'dark' = 'light',
+) => {
   // Remove existing zappers dialog styles
-  const existingStyles = document.querySelectorAll('style[data-zappers-dialog-styles]');
-  existingStyles.forEach(style => style.remove());
-  
+  const existingStyles = document.querySelectorAll(
+    'style[data-zappers-dialog-styles]',
+  );
+  existingStyles.forEach((style) => style.remove());
+
   const style = document.createElement('style');
   style.setAttribute('data-zappers-dialog-styles', 'true');
   style.textContent = getZappersDialogStyles(theme);
   document.head.appendChild(style);
-}
-
-interface EnhancedZapDetails extends ZapDetails {
-  authorName?: string;
-  authorPicture?: string;
-  authorNpub?: string;
-}
-
-/**
- * Render individual zap entry HTML (with profile data)
- */
-function renderZapEntry(zap: EnhancedZapDetails, index: number): string {
-  const authorNameSafe = escapeHtml(zap.authorName || 'Unknown zapper');
-  const npubSafe = isValidPublicKey(zap.authorNpub || '') ? zap.authorNpub : '';
-  const njumpUrl = `https://njump.me/${npubSafe}`;
-  const profilePictureSafe = isValidUrl(zap.authorPicture || '') ? zap.authorPicture || '' : '';
-  
-
-  const profilePicture = zap.authorPicture 
-    ? `<img src="${profilePictureSafe}" alt="${authorNameSafe}" class="zap-author-picture" />`
-    : `<div class="zap-author-picture-default">👤</div>`;
-  
-  const commentHtml = zap.comment 
-    ? `<div class="zap-comment">${zap.comment}</div>`
-    : '';
-  
-  return `
-    <div class="zap-entry" data-zap-index="${index}" data-author-pubkey="${zap.authorPubkey}">
-      <div class="zap-author-info">
-        ${profilePicture}
-        <div class="zap-author-details">
-          <a href="${njumpUrl}" target="_blank" rel="noopener noreferrer" class="zap-author-link">
-            ${authorNameSafe}
-          </a>
-          ${commentHtml}
-          <div class="zap-amount-date">
-            ${zap.amount.toLocaleString()} ⚡ • ${formatRelativeTime(Math.floor(zap.date.getTime() / 1000))}
-          </div>
-        </div>
-      </div>
-    </div>
-  `;
-}
+};
 
 /**
  * Render skeleton zap entry HTML (with npub)
  */
-function renderSkeletonZapEntry(zap: ZapDetails, npub: string, index: number): string {
+function renderSkeletonZapEntry(
+  zap: ZapDetails,
+  npub: string,
+  index: number,
+): string {
   return `
-    <div class="zap-entry skeleton-entry" data-zap-index="${index}" data-author-pubkey="${zap.authorPubkey}">
+    <div class="zap-entry skeleton-entry" data-zap-index="${index}" data-author-pubkey="${escapeHtml(zap.authorPubkey)}">
       <div class="zap-author-info">
         <div class="skeleton-picture"></div>
         <div class="zap-author-details">
@@ -106,47 +76,55 @@ function renderSkeletonZapEntry(zap: ZapDetails, npub: string, index: number): s
 /**
  * Opens the zappers dialog showing individual zap details
  */
-export async function openZappersDialog(params: OpenZappersModalParams): Promise<DialogComponent> {
+export async function openZappersDialog(
+  params: OpenZappersModalParams,
+): Promise<DialogComponent> {
   const { zapDetails, theme = 'light', relays } = params;
-  
+
   // Inject styles
   injectZappersDialogStyles(theme);
-  
+
   // Ensure custom element is defined
   if (!customElements.get('dialog-component')) {
     await customElements.whenDefined('dialog-component');
   }
-  
+
   // Create dialog component (not added to DOM)
-  const dialogComponent = document.createElement('dialog-component') as DialogComponent;
+  const dialogComponent = document.createElement(
+    'dialog-component',
+  ) as DialogComponent;
   dialogComponent.setAttribute('header', 'Zappers');
   if (params.theme) {
     dialogComponent.setAttribute('data-theme', params.theme);
   }
-  
+
   // Initial content with skeleton loaders showing npubs
   const initialContent = await renderInitialContent(zapDetails);
   dialogComponent.innerHTML = initialContent;
-  
+
   // Show the dialog (this will create and append the actual dialog element)
   dialogComponent.showModal();
-  
+
   // Get the actual dialog element for progressive enhancement
   // The dialog is created synchronously by showModal() and appended to document.body
   // Try both shadow root and light DOM, then fall back to document.body
-  const dialogElement: HTMLDialogElement | null = 
+  const dialogElement: HTMLDialogElement | null =
     dialogComponent.querySelector('.nostr-base-dialog') ||
     dialogComponent.shadowRoot?.querySelector('.nostr-base-dialog') ||
     document.body.querySelector('.nostr-base-dialog');
-  
+
   if (!dialogElement) {
-    console.error('[showZappersDialog] Failed to find dialog element after showModal()');
-    throw new Error('Dialog element not found. The dialog may not have been created properly.');
+    console.error(
+      '[showZappersDialog] Failed to find dialog element after showModal()',
+    );
+    throw new Error(
+      'Dialog element not found. The dialog may not have been created properly.',
+    );
   }
-  
+
   // Type assertion: dialog is guaranteed to be non-null after the check above
   const dialog = dialogElement as HTMLDialogElement;
-  
+
   // Start progressive enhancement
   if (dialog && zapDetails.length > 0) {
     enhanceZapDetailsProgressively(dialog, zapDetails, relays);
@@ -170,11 +148,11 @@ async function renderInitialContent(zapDetails: ZapDetails[]): Promise<string> {
   }
 
   // Convert all pubkeys to npubs for immediate display
-  const npubs = zapDetails.map(zap => hexToNpub(zap.authorPubkey));
+  const npubs = zapDetails.map((zap) => hexToNpub(zap.authorPubkey));
 
-  const skeletonEntries = zapDetails.map((zap, index) => 
-    renderSkeletonZapEntry(zap, npubs[index], index)
-  ).join('');
+  const skeletonEntries = zapDetails
+    .map((zap, index) => renderSkeletonZapEntry(zap, npubs[index], index))
+    .join('');
 
   return `
     <div class="zappers-dialog-content">
@@ -188,27 +166,40 @@ async function renderInitialContent(zapDetails: ZapDetails[]): Promise<string> {
 /**
  * Progressively enhance zap details with profile information (batched approach)
  */
-async function enhanceZapDetailsProgressively(dialog: HTMLDialogElement, zapDetails: ZapDetails[], relays?: string[]): Promise<void> {
+async function enhanceZapDetailsProgressively(
+  dialog: HTMLDialogElement,
+  zapDetails: ZapDetails[],
+  relays?: string[],
+): Promise<void> {
   const zappersList = dialog.querySelector('.zappers-list') as HTMLElement;
   if (!zappersList) return;
 
   // Get unique author IDs
-  const uniqueAuthorIds = [...new Set(zapDetails.map(zap => zap.authorPubkey))];
-  console.log("Nostr-Components: Zappers dialog: Fetching profiles for", uniqueAuthorIds.length, "unique authors");
+  const uniqueAuthorIds = [
+    ...new Set(zapDetails.map((zap) => zap.authorPubkey)),
+  ];
+  console.log(
+    'Nostr-Components: Zappers dialog: Fetching profiles for',
+    uniqueAuthorIds.length,
+    'unique authors',
+  );
 
   try {
     // Fetch all profiles in a single batched call
-    const profileResults = await getBatchedProfileMetadata(uniqueAuthorIds, relays);
-    
+    const profileResults = await getBatchedProfileMetadata(
+      uniqueAuthorIds,
+      relays,
+    );
+
     // Create a map for quick lookup
     const profileMap = new Map<string, any>();
-    profileResults.forEach(result => {
+    profileResults.forEach((result) => {
       profileMap.set(result.id, result.profile);
     });
 
     // Convert all pubkeys to npubs for display
     const npubMap = new Map<string, string>();
-    uniqueAuthorIds.forEach(pubkey => {
+    uniqueAuthorIds.forEach((pubkey) => {
       npubMap.set(pubkey, hexToNpub(pubkey));
     });
 
@@ -217,14 +208,15 @@ async function enhanceZapDetailsProgressively(dialog: HTMLDialogElement, zapDeta
       const zap = zapDetails[index];
       const profile = profileMap.get(zap.authorPubkey);
       const npub = npubMap.get(zap.authorPubkey) || zap.authorPubkey;
-      
+
       let enhanced: EnhancedZapDetails;
-      
+
       if (profile) {
         const profileContent = extractProfileMetadataContent(profile);
         enhanced = {
           ...zap,
-          authorName: profileContent.display_name || profileContent.name || npub,
+          authorName:
+            profileContent.display_name || profileContent.name || npub,
           authorPicture: profileContent.picture,
           authorNpub: npub,
         };
@@ -238,19 +230,30 @@ async function enhanceZapDetailsProgressively(dialog: HTMLDialogElement, zapDeta
       }
 
       // Find the corresponding skeleton entry by index and replace it
-      const skeletonEntry = zappersList.querySelector(`[data-zap-index="${index}"]`);
+      const skeletonEntry = zappersList.querySelector(
+        `[data-zap-index="${index}"]`,
+      );
       if (skeletonEntry) {
         const enhancedEntry = renderZapEntry(enhanced, index);
         skeletonEntry.outerHTML = enhancedEntry;
       }
     }
 
-    console.log("Nostr-Components: Zappers dialog: Progressive enhancement completed for", zapDetails.length, "zap entries");
+    console.log(
+      'Nostr-Components: Zappers dialog: Progressive enhancement completed for',
+      zapDetails.length,
+      'zap entries',
+    );
   } catch (error) {
-    console.error("Nostr-Components: Zappers dialog: Error in batched profile enhancement", error);
-    
+    console.error(
+      'Nostr-Components: Zappers dialog: Error in batched profile enhancement',
+      error,
+    );
+
     // Fallback to individual processing if batched approach fails
-    console.log("Nostr-Components: Zappers dialog: Falling back to individual profile fetching");
+    console.log(
+      'Nostr-Components: Zappers dialog: Falling back to individual profile fetching',
+    );
     await enhanceZapDetailsIndividually(dialog, zapDetails, relays);
   }
 }
@@ -258,13 +261,17 @@ async function enhanceZapDetailsProgressively(dialog: HTMLDialogElement, zapDeta
 /**
  * Fallback: Enhance zap details individually (original approach)
  */
-async function enhanceZapDetailsIndividually(dialog: HTMLDialogElement, zapDetails: ZapDetails[], relays?: string[]): Promise<void> {
+async function enhanceZapDetailsIndividually(
+  dialog: HTMLDialogElement,
+  zapDetails: ZapDetails[],
+  relays?: string[],
+): Promise<void> {
   const zappersList = dialog.querySelector('.zappers-list') as HTMLElement;
   if (!zappersList) return;
 
   // Create a map to track which profiles we've already fetched
   const profileCache = new Map<string, EnhancedZapDetails>();
-  
+
   // Fetch all profile metadata in parallel
   const profilePromises = zapDetails.map(async (zap, index) => {
     // Check if we already have this profile cached
@@ -277,16 +284,19 @@ async function enhanceZapDetailsIndividually(dialog: HTMLDialogElement, zapDetai
           authorName: cachedProfile.authorName,
           authorPicture: cachedProfile.authorPicture,
           authorNpub: cachedProfile.authorNpub,
-        }
+        },
       };
     }
 
     try {
       const { getProfileMetadata } = await import('./zap-utils');
-      const profileMetadata = await getProfileMetadata(zap.authorPubkey, relays);
+      const profileMetadata = await getProfileMetadata(
+        zap.authorPubkey,
+        relays,
+      );
       const profileContent = extractProfileMetadataContent(profileMetadata);
       const npub = hexToNpub(zap.authorPubkey);
-      
+
       const enhanced = {
         ...zap,
         authorName: profileContent.display_name || profileContent.name || npub,
@@ -296,13 +306,17 @@ async function enhanceZapDetailsIndividually(dialog: HTMLDialogElement, zapDetai
 
       // Cache the profile for other entries from the same author
       profileCache.set(zap.authorPubkey, enhanced);
-      
+
       return {
         index,
-        enhanced
+        enhanced,
       };
     } catch (error) {
-      console.error("Nostr-Components: Zappers dialog: Error fetching profile for", zap.authorPubkey, error);
+      console.error(
+        'Nostr-Components: Zappers dialog: Error fetching profile for',
+        zap.authorPubkey,
+        error,
+      );
       // Fallback with just pubkey converted to npub
       const npub = hexToNpub(zap.authorPubkey);
       const enhanced = {
@@ -310,13 +324,13 @@ async function enhanceZapDetailsIndividually(dialog: HTMLDialogElement, zapDetai
         authorName: npub,
         authorNpub: npub,
       };
-      
+
       // Cache the fallback profile
       profileCache.set(zap.authorPubkey, enhanced);
-      
+
       return {
         index,
-        enhanced
+        enhanced,
       };
     }
   });
@@ -325,16 +339,20 @@ async function enhanceZapDetailsIndividually(dialog: HTMLDialogElement, zapDetai
   for (const promise of profilePromises) {
     try {
       const { index, enhanced } = await promise;
-      
+
       // Find the corresponding skeleton entry by index and replace it
-      const skeletonEntry = zappersList.querySelector(`[data-zap-index="${index}"]`);
+      const skeletonEntry = zappersList.querySelector(
+        `[data-zap-index="${index}"]`,
+      );
       if (skeletonEntry) {
         const enhancedEntry = renderZapEntry(enhanced, index);
         skeletonEntry.outerHTML = enhancedEntry;
       }
     } catch (error) {
-      console.error("Nostr-Components: Zappers dialog: Error processing profile enhancement", error);
+      console.error(
+        'Nostr-Components: Zappers dialog: Error processing profile enhancement',
+        error,
+      );
     }
   }
 }
-

--- a/src/nostr-zap-button/render-zap-entry.ts
+++ b/src/nostr-zap-button/render-zap-entry.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+
+import { ZapDetails } from './zap-utils';
+import { escapeHtml, formatRelativeTime } from '../common/utils';
+import { isValidPublicKey } from '../nostr-comment/utils';
+import { sanitizeHttpUrl, sanitizeMultilineText } from '../common/sanitize';
+
+export interface EnhancedZapDetails extends ZapDetails {
+  authorName?: string;
+  authorPicture?: string;
+  authorNpub?: string;
+}
+
+export function renderZapEntry(zap: EnhancedZapDetails, index: number): string {
+  const authorNameSafe = escapeHtml(zap.authorName || 'Unknown zapper');
+  const npubSafe = isValidPublicKey(zap.authorNpub || '') ? zap.authorNpub : '';
+  const njumpUrl = npubSafe
+    ? sanitizeHttpUrl(`https://njump.me/${npubSafe}`)
+    : '';
+  const profilePictureSafe = sanitizeHttpUrl(zap.authorPicture);
+  const authorPubkeySafe = escapeHtml(zap.authorPubkey);
+
+  const profilePicture = profilePictureSafe
+    ? `<img src="${profilePictureSafe}" alt="${authorNameSafe}" class="zap-author-picture" />`
+    : `<div class="zap-author-picture-default">👤</div>`;
+
+  const commentHtml = zap.comment
+    ? `<div class="zap-comment">${sanitizeMultilineText(zap.comment)}</div>`
+    : '';
+
+  const authorNameHtml = njumpUrl
+    ? `<a href="${njumpUrl}" target="_blank" rel="noopener noreferrer" class="zap-author-link">
+            ${authorNameSafe}
+          </a>`
+    : `<span class="zap-author-link">${authorNameSafe}</span>`;
+
+  return `
+    <div class="zap-entry" data-zap-index="${index}" data-author-pubkey="${authorPubkeySafe}">
+      <div class="zap-author-info">
+        ${profilePicture}
+        <div class="zap-author-details">
+          ${authorNameHtml}
+          ${commentHtml}
+          <div class="zap-amount-date">
+            ${zap.amount.toLocaleString()} ⚡ • ${formatRelativeTime(Math.floor(zap.date.getTime() / 1000))}
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+}


### PR DESCRIPTION
Closes #44 

## Summary

This PR implements a focused XSS hardening pass across the active/exported rendered surfaces, with the primary fix centered on `nostr-post` and extended to the other active components and dialogs that were still interpolating untrusted text or URLs too loosely.

The approach stays intentionally narrow:

- plain text fields now use escaping and URL validation
- the `nostr-post` inline content path uses a limited DOMPurify pass only for the small generated inline fragment
- no public API, attribute, event, or schema changes
- no docs, WordPress, or legacy-module refactors in this PR

## What Changed

### Shared sanitization layer

Added a shared sanitization module under `src/common` with:

- `sanitizeHttpUrl(url)`
  - allows only `http:` / `https:`
  - returns escaped, attribute-safe URL strings
  - returns `''` for invalid or disallowed URLs
- `sanitizeMultilineText(text)`
  - escapes HTML
  - preserves line breaks as `<br />`
- `sanitizePostInlineFragment(html)`
  - uses DOMPurify only for the narrow `nostr-post` inline fragment path
  - allows only:
    - tags: `a`, `span`, `br`
    - attrs: `href`, `target`, `rel`, `class`, `data-username`

Also updated `escapeHtml()` to a Node-safe string implementation so the helper and render tests can run cleanly in the current Vitest environment.

### `nostr-post` hardening

Re-secured the post parse/render flow so user text is never inserted raw:

- mention/display text is escaped before being reintroduced
- generated mention/link markup is passed through a tokenized inline-fragment renderer
- final inline fragment output is sanitized before render
- plain links/media now use validated URLs only
- embedded note placeholder attributes are escaped
- author display text and avatar URLs in post wrappers are now escaped/validated
- embedded post wrappers now escape author text and validate avatar/media URLs

This preserves intended behavior like:

- line breaks
- generated `njump.me` links
- username mentions
- media rendering
- embedded-post placeholders

while preventing raw injected markup/scripts from surviving.

### Other active surface hardening

Applied the same escape-or-validate rule to the remaining active renderers:

#### `nostr-profile`
- validates `banner`, `picture`, and `website`
- escapes display name in text/attributes
- escapes profile error output
- omits invalid website links
- falls back to a safe avatar placeholder when the image URL is invalid

#### `nostr-profile-badge`
- validates profile image URL instead of only escaping it

#### `nostr-follow-button`
- validates avatar URL before rendering
- falls back to the normal icon if the avatar URL is invalid

#### `nostr-zap-button` zappers dialog
- zap comments now render as escaped multiline text, not HTML
- author/profile URLs remain validated
- extracted the pure zap-entry renderer for focused testing

#### `nostr-like-button` likers dialog
- tightened author/profile URL handling to use validated URLs consistently

#### `nostr-livestream`
- validates author, participant, preview, stream, and recording URLs before rendering clickable/loadable elements

## Testing

Added targeted Node-safe tests for:

- shared sanitization helpers
- profile render escaping and invalid-URL omission
- zap comment escaping and multiline rendering

Commands run:

- `npm test -- --run`
- `npm run build`
- `npm run build-storybook`

## Verification Notes

The new tests passed.

`build` and `build-storybook` still surface pre-existing TypeScript/declaration warnings in untouched legacy/disabled areas such as:

- `src/nostr-comment/*`
- `src/nostr-dm/*`
- `src/nostr-live-chat/*`
- existing unused import noise in `src/nostr-zap-button/zap-utils.ts`

These warnings were already outside the scope of this issue and were not introduced by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Posts can optionally show direct replies with expand/collapse, including loading, empty, and error states.
  * Follow button supports an optional theme setting.

* **Improvements**
  * Inline mention rendering now preserves safe trusted markup and correctly renders profile/name/username mentions.
  * Safer rendering for avatars, banners, websites, and dialog entries with consistent placeholders and improved external-link behavior (including `rel` hardening).

* **Bug Fixes**
  * Stronger escaping and HTTP(S) URL sanitization across post, profile, livestream, and zap UIs.

* **Tests**
  * Added/expanded automated coverage for sanitization and rendering edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->