### PR TITLE
Fix Storybook follow-up cleanup and boolean attribute alignment

### DIFF
--- a/stories/common/code-generator.ts
+++ b/stories/common/code-generator.ts
@@ -15,7 +15,7 @@
  * - Type-safe configuration
  */
 
-import { ParameterDefinition } from './parameters';
+import { ParameterDefinition, getBooleanAttributeMode } from './parameters';
 import { escapeHtml } from '../../src/common/utils';
 
 export interface CodeGeneratorConfig {
@@ -28,6 +28,7 @@ export interface CodeGeneratorConfig {
 export interface GenerateCodeOptions {
   args: any;
   config: CodeGeneratorConfig;
+  parameters: ParameterDefinition[];
   cssVariables: ParameterDefinition[];
   forCodeGen?: boolean;
 }
@@ -37,6 +38,7 @@ export interface GenerateDashboardOptions {
   title: string;
   color: string;
   config: CodeGeneratorConfig;
+  parameters: ParameterDefinition[];
 }
 
 // Shared constants
@@ -49,12 +51,30 @@ export const generateBundleScript = (componentName: string): string => {
   return `<script type="module" src="/components/${componentName}.es.js"></script>`;
 };
 
+const serializeAttribute = (
+  key: string,
+  value: unknown,
+  parameters: ParameterDefinition[]
+): string => {
+  if (typeof value === 'boolean') {
+    const mode = getBooleanAttributeMode(parameters, key);
+
+    if (mode === 'explicit-false') {
+      return `${key}="${value ? 'true' : 'false'}"`;
+    }
+
+    return value ? `${key}="true"` : '';
+  }
+
+  return `${key}="${escapeHtml(String(value))}"`;
+};
+
 /**
  * Generates HTML code for a component with CSS variables and attributes
  */
 export function generateCode(options: GenerateCodeOptions): string {
-  const { args, config, cssVariables, forCodeGen = false } = options;
-  const { componentName, defaultWidth, eventHandlers } = config;
+  const { args, config, parameters, cssVariables } = options;
+  const { componentName, defaultWidth } = config;
   
   // Extract event handlers and other args
   const { width = defaultWidth, wrapperDataTheme, ...otherArgs } = args;
@@ -74,12 +94,7 @@ export function generateCode(options: GenerateCodeOptions): string {
       if (cssVarNames.includes(key)) return false;
       return value !== undefined && value !== null && value !== '';
     })
-    .map(([key, value]) => {
-      if (typeof value === 'boolean') {
-        return value ? `${key}="true"` : '';
-      }
-      return `${key}="${escapeHtml(String(value))}"`;
-    })
+    .map(([key, value]) => serializeAttribute(key, value, parameters))
     .filter(Boolean)
     .join('\n  ');
 
@@ -107,18 +122,13 @@ export function generateCodeWithScript(options: GenerateCodeOptions): string {
  * Generates dashboard HTML from test cases
  */
 export function generateDashboardHTML(options: GenerateDashboardOptions): string {
-  const { testCases, title, color, config } = options;
+  const { testCases, title, color, config, parameters } = options;
   const { componentName, gridColumns } = config;
   
   const testCaseHTML = testCases.map(testCase => {
     const attributes = Object.entries(testCase.args)
       .filter(([key, value]) => value !== undefined && value !== null && value !== '')
-      .map(([key, value]) => {
-        if (typeof value === 'boolean') {
-          return value ? `${key}="true"` : '';
-        }
-        return `${key}="${escapeHtml(String(value))}"`;
-      })
+      .map(([key, value]) => serializeAttribute(key, value, parameters))
       .filter(Boolean)
       .join(' ');
 

--- a/stories/common/comprehensive-dynamic.ts
+++ b/stories/common/comprehensive-dynamic.ts
@@ -16,9 +16,11 @@ import { registerStoryCleanup } from './play-cleanup';
  * - Multiple attribute cycling (inputs, data-theme, widths, boolean attributes)
  * - Cleanup on abort or re-run to prevent timer leaks
  * - Configurable update intervals
- * - Presence-based boolean attribute toggling
+ * - Mode-aware boolean attribute toggling (presence / explicit-false)
  * - Streamlined, easy-to-read implementation
  */
+
+import { BooleanAttributeMode } from './parameters';
 
 export interface ComprehensiveDynamicConfig {
   componentName: string;
@@ -26,6 +28,7 @@ export interface ComprehensiveDynamicConfig {
   testInputs: Array<{ type: string; value: string; name: string }>;
   widths?: number[];
   booleanAttributes?: string[];
+  booleanAttributeModes?: Record<string, BooleanAttributeMode>;
   updateInterval?: number;
 }
 
@@ -42,6 +45,7 @@ export function createComprehensiveDynamicPlay(config: ComprehensiveDynamicConfi
     testInputs,
     widths = [600, 500, 400, 700],
     booleanAttributes = [],
+    booleanAttributeModes = {},
     updateInterval = 5000
   } = config;
 
@@ -146,7 +150,18 @@ export function createComprehensiveDynamicPlay(config: ComprehensiveDynamicConfi
       // Update boolean attributes
       booleanAttributes.forEach((attr, index) => {
         booleanStates[index] = !booleanStates[index];
-        component.toggleAttribute(attr, booleanStates[index]);
+        const mode = booleanAttributeModes[attr] ?? 'presence';
+
+        if (mode === 'explicit-false') {
+          component.setAttribute(attr, booleanStates[index] ? 'true' : 'false');
+          return;
+        }
+
+        if (booleanStates[index]) {
+          component.setAttribute(attr, 'true');
+        } else {
+          component.removeAttribute(attr);
+        }
       });
 
       // Log and update display

--- a/stories/common/no-data.ts
+++ b/stories/common/no-data.ts
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+export const NO_DATA_FIXTURES = {
+  relay: 'wss://no.netsec.vip/',
+  profileNpub: 'npub1qsvv5ttv6mrlh38q8ydmw3gzwq360mdu8re2vr7rk68sqmhmsh4svhsft3',
+  postNoteId: 'note1kmf8n3c8fxfm3q26ys6vgrg306w05yrddt3txd4jtln47tunhscqp09muz',
+};

--- a/stories/common/parameters.ts
+++ b/stories/common/parameters.ts
@@ -10,12 +10,33 @@
 
 import { DEFAULT_RELAYS } from '../../src/common/constants';
 
+export type BooleanAttributeMode = 'presence' | 'explicit-false';
+
 export interface ParameterDefinition {
   variable: string;
   description: string;
   defaultValue: string;
   control: 'text' | 'boolean' | 'number' | 'color' | 'select';
+  booleanMode?: BooleanAttributeMode;
 }
+
+export const getBooleanAttributeMode = (
+  parameters: ParameterDefinition[],
+  variable: string
+): BooleanAttributeMode => {
+  const parameter = parameters.find((candidate) => candidate.variable === variable);
+  return parameter?.booleanMode ?? 'presence';
+};
+
+export const getBooleanAttributeModes = (
+  parameters: ParameterDefinition[]
+): Record<string, BooleanAttributeMode> => {
+  return Object.fromEntries(
+    parameters
+      .filter((parameter) => parameter.control === 'boolean')
+      .map((parameter) => [parameter.variable, getBooleanAttributeMode(parameters, parameter.variable)])
+  );
+};
 
 /**
  * Common parameters shared across all Nostr components

--- a/stories/common/testing.ts
+++ b/stories/common/testing.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+
+export interface TestingParametersOptions {
+  disableSnapshot?: boolean;
+}
+
+export const DYNAMIC_TEST_TAGS = ['test', 'dynamic'] as const;
+
+export const createTestingParameters = (
+  element: string,
+  options: TestingParametersOptions = {}
+) => {
+  const { disableSnapshot = false } = options;
+
+  return {
+    test: {
+      enabled: true,
+      a11y: {
+        element,
+        config: {
+          rules: {
+            'color-contrast': { enabled: true },
+          },
+        },
+      },
+    },
+    ...(disableSnapshot ? {
+      chromatic: {
+        disableSnapshot: true,
+      },
+    } : {}),
+  };
+};

--- a/stories/common/utils.ts
+++ b/stories/common/utils.ts
@@ -11,6 +11,23 @@
 import type { ArgTypes } from '@storybook/web-components-vite';
 import { ParameterDefinition } from './parameters';
 
+const getTypeName = (control: ParameterDefinition['control']) => {
+  switch (control) {
+    case 'boolean':
+      return 'boolean';
+    case 'number':
+      return 'number';
+    default:
+      return 'string';
+  }
+};
+
+const getControlType = (control: ParameterDefinition['control']) => {
+  return {
+    type: control,
+  };
+};
+
 /**
  * Generates Storybook argTypes from parameter and CSS variable definitions
  * 
@@ -28,13 +45,15 @@ export const generateArgTypes = (
   parameters.forEach(parameter => {
     argTypes[parameter.variable] = {
       description: parameter.description,
-      type: parameter.control as any,
+      type: {
+        name: getTypeName(parameter.control),
+      },
       table: {
         defaultValue: {
           summary: parameter.defaultValue,
         },
       },
-      control: parameter.control as any,
+      control: getControlType(parameter.control),
     };
   });
 
@@ -49,9 +68,7 @@ export const generateArgTypes = (
           summary: cssVariable.defaultValue,
         },
       },
-      control: {
-        type: cssVariable.control as any,
-      },
+      control: getControlType(cssVariable.control),
     };
   });
 

--- a/stories/nostr-follow-button/NostrFollowButton.testing.dashboard.stories.tsx
+++ b/stories/nostr-follow-button/NostrFollowButton.testing.dashboard.stories.tsx
@@ -1,27 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { generateCode, generateDashboardHTML, getArgTypes } from "./utils";
+import { generateCode, generateDashboardHTML, getArgTypes, getTestingParameters } from "./utils";
 import { TEST_CASES } from './test-cases-valid';
 import { INVALID_TEST_CASES } from './test-cases-invalid';
 
 const meta: Meta = {
-  title: 'Follow Button/Testing',
+  title: 'Follow Button/Testing/Dashboard',
   tags: ['test', 'dev'],
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-follow-button',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters(),
 };
 
 export default meta;

--- a/stories/nostr-follow-button/NostrFollowButton.testing.dynamic.stories.tsx
+++ b/stories/nostr-follow-button/NostrFollowButton.testing.dynamic.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { DEFAULT_WIDTH, generateCode, getArgTypes } from "./utils";
+import { BOOLEAN_ATTRIBUTE_MODES, DEFAULT_WIDTH, DYNAMIC_TEST_TAGS, generateCode, getArgTypes, getTestingParameters } from "./utils";
 import { PROFILE_DATA } from '../profile-data';
 import { INVALID_TEST_CASES } from './test-cases-invalid';
 import { createPrimaryAttributeChangesPlay } from '../common/primary-attribute-changes';
@@ -8,24 +8,11 @@ import { createFastSwitchingPlay } from '../common/fast-switching';
 
 const meta: Meta = {
   title: 'Follow Button/Testing/Dynamic',
-  tags: ['test', 'dynamic'],
+  tags: [...DYNAMIC_TEST_TAGS],
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    chromatic: { disableSnapshot: true },
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-follow-button',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters({ disableSnapshot: true }),
 };
 
 export default meta;
@@ -74,6 +61,8 @@ export const AllAttributes: Story = {
       { type: 'npub', value: INVALID_TEST_CASES.emptyInputs.args.npub, name: 'Empty NPub' },
     ],
     widths: [300, 250, 200, 400],
+    booleanAttributes: ['show-avatar'],
+    booleanAttributeModes: BOOLEAN_ATTRIBUTE_MODES,
     updateInterval: 6000
   }),
 };

--- a/stories/nostr-follow-button/NostrFollowButton.testing.invalid.stories.tsx
+++ b/stories/nostr-follow-button/NostrFollowButton.testing.invalid.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { DEFAULT_WIDTH, generateCode, getArgTypes } from "./utils";
+import { generateCode, getArgTypes, getTestingParameters } from "./utils";
 import { INVALID_TEST_CASES } from './test-cases-invalid';
 
 const meta: Meta = {
@@ -8,19 +8,7 @@ const meta: Meta = {
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-follow-button',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters(),
 };
 
 export default meta;

--- a/stories/nostr-follow-button/NostrFollowButton.testing.no-data.stories.tsx
+++ b/stories/nostr-follow-button/NostrFollowButton.testing.no-data.stories.tsx
@@ -1,33 +1,21 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { DEFAULT_WIDTH, generateCode, getArgTypes } from "./utils";
+import { generateCode, getArgTypes, getTestingParameters } from "./utils";
 import { NO_DATA_TEST_CASES } from './test-cases-no-data';
 
 const meta: Meta = {
-  title: 'Follow Button/Testing',
+  title: 'Follow Button/Testing/No Data',
   tags: ['test', 'no-data'],
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-follow-button',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters(),
 };
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const NoProfileData: Story = {
-  name: NO_DATA_TEST_CASES.noData.name,
+  name: NO_DATA_TEST_CASES.noDataRelay.name,
   tags: ['test', 'no-data', 'edge-cases'],
-  args: NO_DATA_TEST_CASES.noData.args,
+  args: NO_DATA_TEST_CASES.noDataRelay.args,
 };

--- a/stories/nostr-follow-button/NostrFollowButton.testing.valid.stories.tsx
+++ b/stories/nostr-follow-button/NostrFollowButton.testing.valid.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { generateCode, getArgTypes } from './utils';
+import { generateCode, getArgTypes, getTestingParameters } from './utils';
 import { TEST_CASES } from './test-cases-valid';
 
 const meta: Meta = {
@@ -8,19 +8,7 @@ const meta: Meta = {
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-follow-button',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters(),
 };
 
 export default meta;

--- a/stories/nostr-follow-button/test-cases-no-data.ts
+++ b/stories/nostr-follow-button/test-cases-no-data.ts
@@ -1,12 +1,13 @@
 import { DEFAULT_WIDTH } from "./utils";
+import { NO_DATA_FIXTURES } from '../common/no-data';
 
 export const NO_DATA_TEST_CASES = {
-  noData: {
-    name: 'No Data',
+  noDataRelay: {
+    name: 'Sai NPub - No Data in Relay',
     args: {
       width: DEFAULT_WIDTH,
-      npub: 'npub1qsvv5ttv6mrlh38q8ydmw3gzwq360mdu8re2vr7rk68sqmhmsh4svhsft3',
-      relays: 'wss://no.netsec.vip/',
+      npub: NO_DATA_FIXTURES.profileNpub,
+      relays: NO_DATA_FIXTURES.relay,
     },
   },
 };

--- a/stories/nostr-follow-button/utils.ts
+++ b/stories/nostr-follow-button/utils.ts
@@ -1,5 +1,7 @@
 import { FOLLOW_BUTTON_PARAMETERS as PARAMETERS } from './parameters';
 import { FOLLOW_BUTTON_CSS_VARIABLES as CSS_VARIABLES } from './css-variables';
+import { getBooleanAttributeModes } from '../common/parameters';
+import { DYNAMIC_TEST_TAGS, createTestingParameters, type TestingParametersOptions } from '../common/testing';
 import { generateArgTypes } from '../common/utils';
 import { generateCode as generateCodeShared, generateCodeWithScript as generateCodeWithScriptShared, generateDashboardHTML as generateDashboardHTMLShared, BUNDLE_SCRIPT, generateBundleScript, type CodeGeneratorConfig } from '../common/code-generator';
 
@@ -13,15 +15,19 @@ export const COMPONENT_CONFIG: CodeGeneratorConfig = {
 
 // Constants
 export const DEFAULT_WIDTH = COMPONENT_CONFIG.defaultWidth;
-export { BUNDLE_SCRIPT, generateBundleScript };
+export { BUNDLE_SCRIPT, generateBundleScript, DYNAMIC_TEST_TAGS };
 
 // Common function to generate argTypes for stories
 export const getArgTypes = () => generateArgTypes(PARAMETERS, CSS_VARIABLES);
+export const getTestingParameters = (options?: TestingParametersOptions) =>
+  createTestingParameters(COMPONENT_CONFIG.componentName, options);
+export const BOOLEAN_ATTRIBUTE_MODES = getBooleanAttributeModes(PARAMETERS);
 
 export const generateCode = (args: any, forCodeGen = false) => {
   return generateCodeShared({
     args,
     config: COMPONENT_CONFIG,
+    parameters: PARAMETERS,
     cssVariables: CSS_VARIABLES,
     forCodeGen
   });
@@ -31,6 +37,7 @@ export const generateCodeWithScript = (args: any) => {
   return generateCodeWithScriptShared({
     args,
     config: COMPONENT_CONFIG,
+    parameters: PARAMETERS,
     cssVariables: CSS_VARIABLES
   });
 };
@@ -41,6 +48,7 @@ export const generateDashboardHTML = (testCases: any[], title: string, color: st
     testCases,
     title,
     color,
-    config: COMPONENT_CONFIG
+    config: COMPONENT_CONFIG,
+    parameters: PARAMETERS,
   });
 };

--- a/stories/nostr-like/NostrLike.testing.dashboard.stories.tsx
+++ b/stories/nostr-like/NostrLike.testing.dashboard.stories.tsx
@@ -6,7 +6,7 @@ import { TEST_CASES } from './test-cases-valid';
 import { TEST_CASES as INVALID_TEST_CASES } from './test-cases-invalid';
 
 const meta: Meta = {
-  title: 'Like Button/Testing',
+  title: 'Like Button/Testing/Dashboard',
   tags: ['autodocs'],
   render: args => generateCode(args),
   argTypes: getArgTypes(),

--- a/stories/nostr-like/NostrLike.testing.dynamic.stories.tsx
+++ b/stories/nostr-like/NostrLike.testing.dynamic.stories.tsx
@@ -1,28 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { generateCode, getArgTypes } from './utils';
-import { TEST_CASES } from './test-cases-valid';
+import { DYNAMIC_TEST_TAGS, generateCode, getArgTypes, getTestingParameters } from './utils';
 import { TEST_CASES as INVALID_TEST_CASES } from './test-cases-invalid';
 import { createComprehensiveDynamicPlay } from '../common/comprehensive-dynamic';
 import { createFastSwitchingPlay } from '../common/fast-switching';
 
 const meta: Meta = {
   title: 'Like Button/Testing/Dynamic',
+  tags: [...DYNAMIC_TEST_TAGS],
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-like-button',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters({ disableSnapshot: true }),
 };
 
 export default meta;
@@ -94,4 +82,3 @@ export const FastSwitching: Story = {
     fastDelayMax: 200
   }),
 };
-

--- a/stories/nostr-like/utils.ts
+++ b/stories/nostr-like/utils.ts
@@ -2,6 +2,8 @@
 
 import { LIKE_BUTTON_PARAMETERS as PARAMETERS } from './parameters';
 import { LIKE_BUTTON_CSS_VARIABLES as CSS_VARIABLES } from './css-variables';
+import { getBooleanAttributeModes } from '../common/parameters';
+import { DYNAMIC_TEST_TAGS, createTestingParameters, type TestingParametersOptions } from '../common/testing';
 import { generateArgTypes } from '../common/utils';
 import { generateCode as generateCodeShared, generateCodeWithScript as generateCodeWithScriptShared, generateDashboardHTML as generateDashboardHTMLShared, BUNDLE_SCRIPT, generateBundleScript, type CodeGeneratorConfig } from '../common/code-generator';
 
@@ -15,15 +17,19 @@ export const COMPONENT_CONFIG: CodeGeneratorConfig = {
 
 // Constants
 export const DEFAULT_WIDTH = COMPONENT_CONFIG.defaultWidth;
-export { BUNDLE_SCRIPT, generateBundleScript };
+export { BUNDLE_SCRIPT, generateBundleScript, DYNAMIC_TEST_TAGS };
 
 // Common function to generate argTypes for stories
 export const getArgTypes = () => generateArgTypes(PARAMETERS, CSS_VARIABLES);
+export const getTestingParameters = (options?: TestingParametersOptions) =>
+  createTestingParameters(COMPONENT_CONFIG.componentName, options);
+export const BOOLEAN_ATTRIBUTE_MODES = getBooleanAttributeModes(PARAMETERS);
 
 export const generateCode = (args: any, forCodeGen = false) => {
   return generateCodeShared({
     args,
     config: COMPONENT_CONFIG,
+    parameters: PARAMETERS,
     cssVariables: CSS_VARIABLES,
     forCodeGen
   });
@@ -33,6 +39,7 @@ export const generateCodeWithScript = (args: any) => {
   return generateCodeWithScriptShared({
     args,
     config: COMPONENT_CONFIG,
+    parameters: PARAMETERS,
     cssVariables: CSS_VARIABLES
   });
 };
@@ -43,6 +50,7 @@ export const generateDashboardHTML = (testCases: any[], title: string, color: st
     testCases,
     title,
     color,
-    config: COMPONENT_CONFIG
+    config: COMPONENT_CONFIG,
+    parameters: PARAMETERS,
   });
 };

--- a/stories/nostr-livestream/NostrLivestream.testing.dashboard.stories.tsx
+++ b/stories/nostr-livestream/NostrLivestream.testing.dashboard.stories.tsx
@@ -1,27 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { generateCode, generateDashboardHTML, getArgTypes } from './utils';
+import { generateCode, generateDashboardHTML, getArgTypes, getTestingParameters } from './utils';
 import { TEST_CASES } from './test-cases-valid';
 import { INVALID_TEST_CASES } from './test-cases-invalid';
 
 const meta: Meta = {
-  title: 'Livestream/Testing',
+  title: 'Livestream/Testing/Dashboard',
   tags: ['test', 'dev'],
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-livestream',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters(),
 };
 
 export default meta;

--- a/stories/nostr-livestream/NostrLivestream.testing.dynamic.stories.tsx
+++ b/stories/nostr-livestream/NostrLivestream.testing.dynamic.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { DEFAULT_WIDTH, generateCode, getArgTypes } from "./utils";
+import { BOOLEAN_ATTRIBUTE_MODES, DEFAULT_WIDTH, DYNAMIC_TEST_TAGS, generateCode, getArgTypes, getTestingParameters } from "./utils";
 import { LIVESTREAM_DATA } from '../livestream-data';
 import { INVALID_TEST_CASES } from './test-cases-invalid';
 import { createPrimaryAttributeChangesPlay } from '../common/primary-attribute-changes';
@@ -8,23 +8,11 @@ import { createFastSwitchingPlay } from '../common/fast-switching';
 
 const meta: Meta = {
   title: 'Livestream/Testing/Dynamic',
-  tags: ['test', 'dynamic'],
+  tags: [...DYNAMIC_TEST_TAGS],
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-livestream',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters({ disableSnapshot: true }),
 };
 
 export default meta;
@@ -74,6 +62,7 @@ export const AllAttributes: Story = {
     ],
     widths: [800, 600, 500, 900],
     booleanAttributes: ['show-participants', 'show-participant-count', 'auto-play'],
+    booleanAttributeModes: BOOLEAN_ATTRIBUTE_MODES,
     updateInterval: 8000
   }),
 };

--- a/stories/nostr-livestream/NostrLivestream.testing.invalid.stories.tsx
+++ b/stories/nostr-livestream/NostrLivestream.testing.invalid.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { generateCode, getArgTypes } from './utils';
+import { generateCode, getArgTypes, getTestingParameters } from './utils';
 import { INVALID_TEST_CASES } from './test-cases-invalid';
 
 const meta: Meta = {
@@ -9,17 +9,7 @@ const meta: Meta = {
   argTypes: getArgTypes(),
   args: {},
   parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-livestream',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
+    ...getTestingParameters(),
     docs: {
       description: {
         component: 'Invalid test cases for the nostr-livestream component demonstrating error handling and validation.',

--- a/stories/nostr-livestream/NostrLivestream.testing.valid.stories.tsx
+++ b/stories/nostr-livestream/NostrLivestream.testing.valid.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { generateCode, getArgTypes } from './utils';
+import { generateCode, getArgTypes, getTestingParameters } from './utils';
 import { TEST_CASES } from './test-cases-valid';
 
 const meta: Meta = {
@@ -8,19 +8,7 @@ const meta: Meta = {
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-livestream',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters(),
 };
 
 export default meta;

--- a/stories/nostr-livestream/parameters.ts
+++ b/stories/nostr-livestream/parameters.ts
@@ -25,12 +25,14 @@ export const LIVESTREAM_PARAMETERS: ParameterDefinition[] = [
     description: 'Display participant list',
     defaultValue: 'true',
     control: 'boolean',
+    booleanMode: 'explicit-false',
   },
   {
     variable: 'show-participant-count',
     description: 'Display current/total participant counts',
     defaultValue: 'true',
     control: 'boolean',
+    booleanMode: 'explicit-false',
   },
   {
     variable: 'auto-play',

--- a/stories/nostr-livestream/utils.ts
+++ b/stories/nostr-livestream/utils.ts
@@ -1,5 +1,7 @@
 import { LIVESTREAM_PARAMETERS as PARAMETERS } from './parameters';
 import { LIVESTREAM_CSS_VARIABLES as CSS_VARIABLES } from './css-variables';
+import { getBooleanAttributeModes } from '../common/parameters';
+import { DYNAMIC_TEST_TAGS, createTestingParameters, type TestingParametersOptions } from '../common/testing';
 import { generateArgTypes } from '../common/utils';
 import { generateCode as generateCodeShared, generateCodeWithScript as generateCodeWithScriptShared, generateDashboardHTML as generateDashboardHTMLShared, BUNDLE_SCRIPT, generateBundleScript, type CodeGeneratorConfig } from '../common/code-generator';
 
@@ -13,15 +15,19 @@ export const COMPONENT_CONFIG: CodeGeneratorConfig = {
 
 // Constants
 export const DEFAULT_WIDTH = COMPONENT_CONFIG.defaultWidth;
-export { BUNDLE_SCRIPT, generateBundleScript };
+export { BUNDLE_SCRIPT, generateBundleScript, DYNAMIC_TEST_TAGS };
 
 // Common function to generate argTypes for stories
 export const getArgTypes = () => generateArgTypes(PARAMETERS, CSS_VARIABLES);
+export const getTestingParameters = (options?: TestingParametersOptions) =>
+  createTestingParameters(COMPONENT_CONFIG.componentName, options);
+export const BOOLEAN_ATTRIBUTE_MODES = getBooleanAttributeModes(PARAMETERS);
 
 export const generateCode = (args: any, forCodeGen = false) => {
   return generateCodeShared({
     args,
     config: COMPONENT_CONFIG,
+    parameters: PARAMETERS,
     cssVariables: CSS_VARIABLES,
     forCodeGen
   });
@@ -31,6 +37,7 @@ export const generateCodeWithScript = (args: any) => {
   return generateCodeWithScriptShared({
     args,
     config: COMPONENT_CONFIG,
+    parameters: PARAMETERS,
     cssVariables: CSS_VARIABLES
   });
 };
@@ -41,6 +48,7 @@ export const generateDashboardHTML = (testCases: any[], title: string, color: st
     testCases,
     title,
     color,
-    config: COMPONENT_CONFIG
+    config: COMPONENT_CONFIG,
+    parameters: PARAMETERS,
   });
 };

--- a/stories/nostr-post/NostrPost.stories.tsx
+++ b/stories/nostr-post/NostrPost.stories.tsx
@@ -1,4 +1,3 @@
-import { fn } from 'storybook/test';
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { generateCode, generateCodeWithScript, getArgTypes } from './utils';
 import { TEST_CASES } from './test-cases-valid';
@@ -15,7 +14,7 @@ const meta: Meta = {
         component: 'A web component that displays Nostr posts with content, metadata, optional stats, and a minimal expandable replies view. Supports note IDs, event IDs, and raw hex inputs.',
       },
       source: {
-        transform: (code, storyContext) =>
+        transform: (_code, storyContext) =>
           generateCodeWithScript(storyContext.args),
       },
       prepend: `

--- a/stories/nostr-post/NostrPost.styling.stories.tsx
+++ b/stories/nostr-post/NostrPost.styling.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { generateCode, getArgTypes } from './utils';
 import { POST_THEMES } from './theme';
-import { POST_DATA } from '../post-data';
 import { TEST_CASES } from './test-cases-valid';
 
 const meta: Meta = {
@@ -45,4 +44,3 @@ export const BitcoinOrange: Story = {
     ...POST_THEMES['bitcoin-orange'],
   },
 };
-

--- a/stories/nostr-post/NostrPost.testing.dashboard.stories.tsx
+++ b/stories/nostr-post/NostrPost.testing.dashboard.stories.tsx
@@ -1,27 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { generateCode, generateDashboardHTML, getArgTypes } from './utils';
+import { generateCode, generateDashboardHTML, getArgTypes, getTestingParameters } from './utils';
 import { TEST_CASES } from './test-cases-valid';
 import { INVALID_TEST_CASES } from './test-cases-invalid';
 
 const meta: Meta = {
-  title: 'Post/Testing',
+  title: 'Post/Testing/Dashboard',
   tags: ['test', 'dev'],
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-post',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters(),
 };
 
 export default meta;

--- a/stories/nostr-post/NostrPost.testing.dynamic.stories.tsx
+++ b/stories/nostr-post/NostrPost.testing.dynamic.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { DEFAULT_WIDTH, generateCode, getArgTypes } from "./utils";
+import { BOOLEAN_ATTRIBUTE_MODES, DEFAULT_WIDTH, DYNAMIC_TEST_TAGS, generateCode, getArgTypes, getTestingParameters } from "./utils";
 import { POST_DATA } from '../post-data';
 import { INVALID_TEST_CASES } from './test-cases-invalid';
 import { createPrimaryAttributeChangesPlay } from '../common/primary-attribute-changes';
@@ -8,24 +8,11 @@ import { createFastSwitchingPlay } from '../common/fast-switching';
 
 const meta: Meta = {
   title: 'Post/Testing/Dynamic',
-  tags: ['test', 'dynamic'],
+  tags: [...DYNAMIC_TEST_TAGS],
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    chromatic: { disableSnapshot: true },
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-post',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters({ disableSnapshot: true }),
 };
 
 export default meta;
@@ -75,6 +62,7 @@ export const AllAttributes: Story = {
     ],
     widths: [600, 500, 400, 700],
     booleanAttributes: ['show-stats', 'show-replies'],
+    booleanAttributeModes: BOOLEAN_ATTRIBUTE_MODES,
     updateInterval: 8000
   }),
 };

--- a/stories/nostr-post/NostrPost.testing.invalid.stories.tsx
+++ b/stories/nostr-post/NostrPost.testing.invalid.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { generateCode, getArgTypes } from './utils';
+import { generateCode, getArgTypes, getTestingParameters } from './utils';
 import { INVALID_TEST_CASES } from './test-cases-invalid';
 
 const meta: Meta = {
@@ -8,19 +8,7 @@ const meta: Meta = {
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-post',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters(),
 };
 
 export default meta;

--- a/stories/nostr-post/NostrPost.testing.no-data.stories.tsx
+++ b/stories/nostr-post/NostrPost.testing.no-data.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { generateCode, getArgTypes } from './utils';
+import { generateCode, getArgTypes, getTestingParameters } from './utils';
 import { NO_DATA_TEST_CASES } from './test-cases-no-data';
 
 const meta: Meta = {
@@ -8,25 +8,13 @@ const meta: Meta = {
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-post',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters(),
 };
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const ValidNoteIdNoDataRelay: Story = {
-  name: NO_DATA_TEST_CASES.validNoteIdNoDataRelay.name,
-  args: NO_DATA_TEST_CASES.validNoteIdNoDataRelay.args,
+  name: NO_DATA_TEST_CASES.noDataRelay.name,
+  args: NO_DATA_TEST_CASES.noDataRelay.args,
 };

--- a/stories/nostr-post/NostrPost.testing.valid.stories.tsx
+++ b/stories/nostr-post/NostrPost.testing.valid.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { generateCode, getArgTypes } from './utils';
+import { generateCode, getArgTypes, getTestingParameters } from './utils';
 import { TEST_CASES } from './test-cases-valid';
 
 const meta: Meta = {
@@ -8,19 +8,7 @@ const meta: Meta = {
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-post',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters(),
 };
 
 export default meta;

--- a/stories/nostr-post/parameters.ts
+++ b/stories/nostr-post/parameters.ts
@@ -17,13 +17,13 @@ export const POST_PARAMETERS: ParameterDefinition[] = [
   ...EVENT_PARAMETERS,
   {
     variable: 'show-stats',
-    description: `Whether to show post stats`,
+    description: 'Show the post stats',
     defaultValue: 'false',
     control: 'boolean',
   },
   {
     variable: 'show-replies',
-    description: `Whether replies should start expanded below the post`,
+    description: 'Whether replies should start expanded below the post',
     defaultValue: 'false',
     control: 'boolean',
   }

--- a/stories/nostr-post/test-cases-no-data.ts
+++ b/stories/nostr-post/test-cases-no-data.ts
@@ -1,12 +1,13 @@
 import { DEFAULT_WIDTH } from "./utils";
+import { NO_DATA_FIXTURES } from '../common/no-data';
 
 export const NO_DATA_TEST_CASES = {
-  validNoteIdNoDataRelay: {
+  noDataRelay: {
     name: 'Valid Note ID - No Data in Relay',
     args: {
       width: DEFAULT_WIDTH,
-      noteid: 'note1kmf8n3c8fxfm3q26ys6vgrg306w05yrddt3txd4jtln47tunhscqp09muz',
-      relays: 'wss://no.netsec.vip/',
+      noteid: NO_DATA_FIXTURES.postNoteId,
+      relays: NO_DATA_FIXTURES.relay,
       'show-stats': "true",
     },
   },

--- a/stories/nostr-post/utils.ts
+++ b/stories/nostr-post/utils.ts
@@ -1,9 +1,7 @@
-import type { ArgTypes, Meta } from '@storybook/web-components-vite';
-import { DEFAULT_RELAYS } from '../../src/common/constants';
-import { POST_DATA, getAllInputTypes } from '../post-data';
-import { POST_THEMES } from './theme';
 import { POST_PARAMETERS as PARAMETERS } from './parameters';
 import { POST_CSS_VARIABLES as CSS_VARIABLES } from './css-variables';
+import { getBooleanAttributeModes } from '../common/parameters';
+import { DYNAMIC_TEST_TAGS, createTestingParameters, type TestingParametersOptions } from '../common/testing';
 import { generateArgTypes } from '../common/utils';
 import { generateCode as generateCodeShared, generateCodeWithScript as generateCodeWithScriptShared, generateDashboardHTML as generateDashboardHTMLShared, BUNDLE_SCRIPT, generateBundleScript, type CodeGeneratorConfig } from '../common/code-generator';
 
@@ -17,15 +15,19 @@ export const COMPONENT_CONFIG: CodeGeneratorConfig = {
 
 // Constants
 export const DEFAULT_WIDTH = COMPONENT_CONFIG.defaultWidth;
-export { BUNDLE_SCRIPT, generateBundleScript };
+export { BUNDLE_SCRIPT, generateBundleScript, DYNAMIC_TEST_TAGS };
 
 // Common function to generate argTypes for stories
 export const getArgTypes = () => generateArgTypes(PARAMETERS, CSS_VARIABLES);
+export const getTestingParameters = (options?: TestingParametersOptions) =>
+  createTestingParameters(COMPONENT_CONFIG.componentName, options);
+export const BOOLEAN_ATTRIBUTE_MODES = getBooleanAttributeModes(PARAMETERS);
 
 export const generateCode = (args: any, forCodeGen = false) => {
   return generateCodeShared({
     args,
     config: COMPONENT_CONFIG,
+    parameters: PARAMETERS,
     cssVariables: CSS_VARIABLES,
     forCodeGen
   });
@@ -35,6 +37,7 @@ export const generateCodeWithScript = (args: any) => {
   return generateCodeWithScriptShared({
     args,
     config: COMPONENT_CONFIG,
+    parameters: PARAMETERS,
     cssVariables: CSS_VARIABLES
   });
 };
@@ -45,6 +48,7 @@ export const generateDashboardHTML = (testCases: any[], title: string, color: st
     testCases,
     title,
     color,
-    config: COMPONENT_CONFIG
+    config: COMPONENT_CONFIG,
+    parameters: PARAMETERS,
   });
 };

--- a/stories/nostr-profile-badge/NostrProfileBadge.testing.dashboard.stories.tsx
+++ b/stories/nostr-profile-badge/NostrProfileBadge.testing.dashboard.stories.tsx
@@ -1,28 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { generateCode, generateDashboardHTML, getArgTypes } from "./utils";
-
+import { generateCode, generateDashboardHTML, getArgTypes, getTestingParameters } from "./utils";
 import { TEST_CASES } from './test-cases-valid';
 import { INVALID_TEST_CASES } from './test-cases-invalid';
 
 const meta: Meta = {
-  title: 'Profile Badge/Testing',
+  title: 'Profile Badge/Testing/Dashboard',
   tags: ['test', 'dev'],
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-profile-badge',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters(),
 };
 
 export default meta;

--- a/stories/nostr-profile-badge/NostrProfileBadge.testing.dynamic.stories.tsx
+++ b/stories/nostr-profile-badge/NostrProfileBadge.testing.dynamic.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { DEFAULT_WIDTH, generateCode, getArgTypes } from "./utils";
+import { BOOLEAN_ATTRIBUTE_MODES, DEFAULT_WIDTH, DYNAMIC_TEST_TAGS, generateCode, getArgTypes, getTestingParameters } from "./utils";
 import { PROFILE_DATA } from '../profile-data';
 import { INVALID_TEST_CASES } from './test-cases-invalid';
 import { createPrimaryAttributeChangesPlay } from '../common/primary-attribute-changes';
@@ -8,23 +8,11 @@ import { createFastSwitchingPlay } from '../common/fast-switching';
 
 const meta: Meta = {
   title: 'Profile Badge/Testing/Dynamic',
+  tags: [...DYNAMIC_TEST_TAGS],
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    chromatic: { disableSnapshot: true },
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-profile-badge',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters({ disableSnapshot: true }),
 };
 
 export default meta;
@@ -77,6 +65,7 @@ export const AllAttributes: Story = {
     ],
     widths: [600, 500, 400, 700],
     booleanAttributes: ['show-follow', 'show-npub'],
+    booleanAttributeModes: BOOLEAN_ATTRIBUTE_MODES,
     updateInterval: 5000
   }),
 };

--- a/stories/nostr-profile-badge/NostrProfileBadge.testing.invalid.stories.tsx
+++ b/stories/nostr-profile-badge/NostrProfileBadge.testing.invalid.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { generateCode, getArgTypes } from "./utils";
+import { generateCode, getArgTypes, getTestingParameters } from "./utils";
 import { INVALID_TEST_CASES } from './test-cases-invalid';
 
 const meta: Meta = {
@@ -7,19 +7,7 @@ const meta: Meta = {
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-profile-badge',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters(),
 };
 
 export default meta;

--- a/stories/nostr-profile-badge/NostrProfileBadge.testing.no-data.stories.tsx
+++ b/stories/nostr-profile-badge/NostrProfileBadge.testing.no-data.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { generateCode, getArgTypes } from "./utils";
+import { generateCode, getArgTypes, getTestingParameters } from "./utils";
 import { NO_DATA_TEST_CASES } from './test-cases-no-data';
 
 const meta: Meta = {
@@ -8,25 +8,13 @@ const meta: Meta = {
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-profile-badge',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters(),
 };
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const NoData: Story = {
-  name: NO_DATA_TEST_CASES.saiNpubNoDataRelay.name,
-  args: NO_DATA_TEST_CASES.saiNpubNoDataRelay.args,
+  name: NO_DATA_TEST_CASES.noDataRelay.name,
+  args: NO_DATA_TEST_CASES.noDataRelay.args,
 };

--- a/stories/nostr-profile-badge/NostrProfileBadge.testing.valid.stories.tsx
+++ b/stories/nostr-profile-badge/NostrProfileBadge.testing.valid.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { generateCode, getArgTypes } from './utils';
+import { generateCode, getArgTypes, getTestingParameters } from './utils';
 import { TEST_CASES } from './test-cases-valid';
 
 const meta: Meta = {
@@ -8,19 +8,7 @@ const meta: Meta = {
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-profile-badge',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters(),
 };
 
 export default meta;

--- a/stories/nostr-profile-badge/parameters.ts
+++ b/stories/nostr-profile-badge/parameters.ts
@@ -17,13 +17,13 @@ export const PROFILE_BADGE_PARAMETERS: ParameterDefinition[] = [
   ...USER_PARAMETERS,
   {
     variable: 'show-npub',
-    description: `Whether to show the npub in the profile badge`,
+    description: 'Show the npub in the profile badge',
     defaultValue: 'false',
     control: 'boolean',
   },
   {
     variable: 'show-follow',
-    description: `Whether to show the follow button in the profile badge`,
+    description: 'Show the follow button in the profile badge',
     defaultValue: 'false',
     control: 'boolean',
   },

--- a/stories/nostr-profile-badge/test-cases-no-data.ts
+++ b/stories/nostr-profile-badge/test-cases-no-data.ts
@@ -1,12 +1,13 @@
 import { DEFAULT_WIDTH } from "./utils";
+import { NO_DATA_FIXTURES } from '../common/no-data';
 
 export const NO_DATA_TEST_CASES = {
-  saiNpubNoDataRelay: {
-    name: 'Sai NPub - No Data in relay',
+  noDataRelay: {
+    name: 'Sai NPub - No Data in Relay',
     args: {
       width: DEFAULT_WIDTH,
-      npub: 'npub1qsvv5ttv6mrlh38q8ydmw3gzwq360mdu8re2vr7rk68sqmhmsh4svhsft3',
-      relays: 'wss://no.netsec.vip/', // wss://nostr.wine',
+      npub: NO_DATA_FIXTURES.profileNpub,
+      relays: NO_DATA_FIXTURES.relay,
     },
   },
 };

--- a/stories/nostr-profile-badge/utils.ts
+++ b/stories/nostr-profile-badge/utils.ts
@@ -1,5 +1,7 @@
 import { PROFILE_BADGE_PARAMETERS as PARAMETERS } from './parameters';
 import { PROFILE_BADGE_CSS_VARIABLES as CSS_VARIABLES } from './css-variables';
+import { getBooleanAttributeModes } from '../common/parameters';
+import { DYNAMIC_TEST_TAGS, createTestingParameters, type TestingParametersOptions } from '../common/testing';
 import { generateArgTypes } from '../common/utils';
 import { generateCode as generateCodeShared, generateCodeWithScript as generateCodeWithScriptShared, generateDashboardHTML as generateDashboardHTMLShared, BUNDLE_SCRIPT, generateBundleScript, type CodeGeneratorConfig } from '../common/code-generator';
 
@@ -13,15 +15,19 @@ export const COMPONENT_CONFIG: CodeGeneratorConfig = {
 
 // Constants
 export const DEFAULT_WIDTH = COMPONENT_CONFIG.defaultWidth;
-export { BUNDLE_SCRIPT, generateBundleScript };
+export { BUNDLE_SCRIPT, generateBundleScript, DYNAMIC_TEST_TAGS };
 
 // Common function to generate argTypes for stories
 export const getArgTypes = () => generateArgTypes(PARAMETERS, CSS_VARIABLES);
+export const getTestingParameters = (options?: TestingParametersOptions) =>
+  createTestingParameters(COMPONENT_CONFIG.componentName, options);
+export const BOOLEAN_ATTRIBUTE_MODES = getBooleanAttributeModes(PARAMETERS);
 
 export const generateCode = (args: any, forCodeGen = false) => {
   return generateCodeShared({
     args,
     config: COMPONENT_CONFIG,
+    parameters: PARAMETERS,
     cssVariables: CSS_VARIABLES,
     forCodeGen
   });
@@ -31,6 +37,7 @@ export const generateCodeWithScript = (args: any) => {
   return generateCodeWithScriptShared({
     args,
     config: COMPONENT_CONFIG,
+    parameters: PARAMETERS,
     cssVariables: CSS_VARIABLES
   });
 };
@@ -41,6 +48,7 @@ export const generateDashboardHTML = (testCases: any[], title: string, color: st
     testCases,
     title,
     color,
-    config: COMPONENT_CONFIG
+    config: COMPONENT_CONFIG,
+    parameters: PARAMETERS,
   });
 };

--- a/stories/nostr-profile/NostrProfile.stories.tsx
+++ b/stories/nostr-profile/NostrProfile.stories.tsx
@@ -44,7 +44,7 @@ export const RawPubkey: Story = {
   args: TEST_CASES.rawPubkey.args,
 };
 
-export const FollowButton: Story = {
+export const ShowFollow: Story = {
   name: TEST_CASES.showFollow.name,
   args: TEST_CASES.showFollow.args,
 };

--- a/stories/nostr-profile/NostrProfile.testing.dashboard.stories.tsx
+++ b/stories/nostr-profile/NostrProfile.testing.dashboard.stories.tsx
@@ -1,27 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { generateCode, generateDashboardHTML, getArgTypes } from "./utils";
+import { generateCode, generateDashboardHTML, getArgTypes, getTestingParameters } from "./utils";
 import { TEST_CASES } from './test-cases-valid';
 import { INVALID_TEST_CASES } from './test-cases-invalid';
 
 const meta: Meta = {
-  title: 'Profile/Testing',
+  title: 'Profile/Testing/Dashboard',
   tags: ['test', 'dev'],
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-profile',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters(),
 };
 
 export default meta;

--- a/stories/nostr-profile/NostrProfile.testing.dynamic.stories.tsx
+++ b/stories/nostr-profile/NostrProfile.testing.dynamic.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { DEFAULT_WIDTH, generateCode, getArgTypes } from "./utils";
+import { BOOLEAN_ATTRIBUTE_MODES, DEFAULT_WIDTH, DYNAMIC_TEST_TAGS, generateCode, getArgTypes, getTestingParameters } from "./utils";
 import { PROFILE_DATA } from '../profile-data';
 import { INVALID_TEST_CASES } from './test-cases-invalid';
 import { createPrimaryAttributeChangesPlay } from '../common/primary-attribute-changes';
@@ -8,23 +8,11 @@ import { createFastSwitchingPlay } from '../common/fast-switching';
 
 const meta: Meta = {
   title: 'Profile/Testing/Dynamic',
+  tags: [...DYNAMIC_TEST_TAGS],
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    chromatic: { disableSnapshot: true },
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-profile',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters({ disableSnapshot: true }),
 };
 
 export default meta;
@@ -77,6 +65,7 @@ export const AllAttributes: Story = {
     ],
     widths: [600, 500, 400, 700],
     booleanAttributes: ['show-follow', 'show-npub'],
+    booleanAttributeModes: BOOLEAN_ATTRIBUTE_MODES,
     updateInterval: 5000
   }),
 };

--- a/stories/nostr-profile/NostrProfile.testing.invalid.stories.tsx
+++ b/stories/nostr-profile/NostrProfile.testing.invalid.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { generateCode, getArgTypes } from "./utils";
+import { generateCode, getArgTypes, getTestingParameters } from "./utils";
 import { INVALID_TEST_CASES } from './test-cases-invalid';
 
 const meta: Meta = {
@@ -8,19 +8,7 @@ const meta: Meta = {
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-profile',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters(),
 };
 
 export default meta;

--- a/stories/nostr-profile/NostrProfile.testing.no-data.stories.tsx
+++ b/stories/nostr-profile/NostrProfile.testing.no-data.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { generateCode, getArgTypes } from "./utils";
+import { generateCode, getArgTypes, getTestingParameters } from "./utils";
 import { NO_DATA_TEST_CASES } from './test-cases-no-data';
 
 const meta: Meta = {
@@ -8,19 +8,7 @@ const meta: Meta = {
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-profile',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters(),
 };
 
 export default meta;
@@ -28,6 +16,6 @@ type Story = StoryObj<typeof meta>;
 
 // Individual story exports for better organization
 export const SaiNpubNoDataRelay: Story = {
-  name: NO_DATA_TEST_CASES.saiNpubNoDataRelay.name,
-  args: NO_DATA_TEST_CASES.saiNpubNoDataRelay.args,
+  name: NO_DATA_TEST_CASES.noDataRelay.name,
+  args: NO_DATA_TEST_CASES.noDataRelay.args,
 };

--- a/stories/nostr-profile/NostrProfile.testing.valid.stories.tsx
+++ b/stories/nostr-profile/NostrProfile.testing.valid.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { generateCode, getArgTypes } from "./utils";
+import { generateCode, getArgTypes, getTestingParameters } from "./utils";
 import { TEST_CASES } from './test-cases-valid';
 
 const meta: Meta = {
@@ -8,19 +8,7 @@ const meta: Meta = {
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-profile',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters(),
 };
 
 export default meta;

--- a/stories/nostr-profile/parameters.ts
+++ b/stories/nostr-profile/parameters.ts
@@ -17,13 +17,13 @@ export const PROFILE_PARAMETERS: ParameterDefinition[] = [
   ...USER_PARAMETERS,
   {
     variable: 'show-npub',
-    description: `Whether to show the npub in the profile`,
+    description: 'Show the npub in the profile',
     defaultValue: 'false',
     control: 'boolean',
   },
   {
     variable: 'show-follow',
-    description: `Whether to show the follow button in the profile`,
+    description: 'Show the follow button in the profile',
     defaultValue: 'false',
     control: 'boolean',
   },

--- a/stories/nostr-profile/test-cases-no-data.ts
+++ b/stories/nostr-profile/test-cases-no-data.ts
@@ -1,12 +1,13 @@
 import { DEFAULT_WIDTH } from "./utils";
+import { NO_DATA_FIXTURES } from '../common/no-data';
 
 export const NO_DATA_TEST_CASES = {
-  saiNpubNoDataRelay: {
-    name: 'Sai NPub - No Data in relay',
+  noDataRelay: {
+    name: 'Sai NPub - No Data in Relay',
     args: {
       width: DEFAULT_WIDTH,
-      npub: 'npub1qsvv5ttv6mrlh38q8ydmw3gzwq360mdu8re2vr7rk68sqmhmsh4svhsft3',
-      relays: 'wss://no.netsec.vip/', // wss://nostr.wine',
+      npub: NO_DATA_FIXTURES.profileNpub,
+      relays: NO_DATA_FIXTURES.relay,
     },
   },
 };

--- a/stories/nostr-profile/utils.ts
+++ b/stories/nostr-profile/utils.ts
@@ -1,8 +1,7 @@
-import type { ArgTypes, Meta } from '@storybook/web-components-vite';
-import { DEFAULT_RELAYS } from '../../src/common/constants';
-import { PROFILE_THEMES } from './theme';
 import { PROFILE_PARAMETERS as PARAMETERS } from './parameters';
 import { PROFILE_CSS_VARIABLES as CSS_VARIABLES } from './css-variables';
+import { getBooleanAttributeModes } from '../common/parameters';
+import { DYNAMIC_TEST_TAGS, createTestingParameters, type TestingParametersOptions } from '../common/testing';
 import { generateArgTypes } from '../common/utils';
 import { generateCode as generateCodeShared, generateCodeWithScript as generateCodeWithScriptShared, generateDashboardHTML as generateDashboardHTMLShared, BUNDLE_SCRIPT, generateBundleScript, type CodeGeneratorConfig } from '../common/code-generator';
 
@@ -16,15 +15,19 @@ export const COMPONENT_CONFIG: CodeGeneratorConfig = {
 
 // Constants
 export const DEFAULT_WIDTH = COMPONENT_CONFIG.defaultWidth;
-export { BUNDLE_SCRIPT, generateBundleScript };
+export { BUNDLE_SCRIPT, generateBundleScript, DYNAMIC_TEST_TAGS };
 
 // Common function to generate argTypes for stories
 export const getArgTypes = () => generateArgTypes(PARAMETERS, CSS_VARIABLES);
+export const getTestingParameters = (options?: TestingParametersOptions) =>
+  createTestingParameters(COMPONENT_CONFIG.componentName, options);
+export const BOOLEAN_ATTRIBUTE_MODES = getBooleanAttributeModes(PARAMETERS);
 
 export const generateCode = (args: any, forCodeGen = false) => {
   return generateCodeShared({
     args,
     config: COMPONENT_CONFIG,
+    parameters: PARAMETERS,
     cssVariables: CSS_VARIABLES,
     forCodeGen
   });
@@ -34,6 +37,7 @@ export const generateCodeWithScript = (args: any) => {
   return generateCodeWithScriptShared({
     args,
     config: COMPONENT_CONFIG,
+    parameters: PARAMETERS,
     cssVariables: CSS_VARIABLES
   });
 };
@@ -44,6 +48,7 @@ export const generateDashboardHTML = (testCases: any[], title: string, color: st
     testCases,
     title,
     color,
-    config: COMPONENT_CONFIG
+    config: COMPONENT_CONFIG,
+    parameters: PARAMETERS,
   });
 };

--- a/stories/nostr-zap/NostrZap.testing.dashboard.stories.tsx
+++ b/stories/nostr-zap/NostrZap.testing.dashboard.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { generateCode, generateDashboardHTML, getArgTypes } from "./utils";
+import { generateCode, generateDashboardHTML, getArgTypes, getTestingParameters } from "./utils";
 import { TEST_CASES } from './test-cases-valid';
 import { INVALID_TEST_CASES } from './test-cases-invalid';
 
@@ -9,19 +9,7 @@ const meta: Meta = {
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-zap-button',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters(),
 };
 
 export default meta;

--- a/stories/nostr-zap/NostrZap.testing.invalid.stories.tsx
+++ b/stories/nostr-zap/NostrZap.testing.invalid.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { DEFAULT_WIDTH, generateCode, getArgTypes } from "./utils";
+import { generateCode, getArgTypes, getTestingParameters } from "./utils";
 import { INVALID_TEST_CASES } from './test-cases-invalid';
 
 const meta: Meta = {
@@ -8,19 +8,7 @@ const meta: Meta = {
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-zap-button',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters(),
 };
 
 export default meta;

--- a/stories/nostr-zap/NostrZap.testing.no-data.stories.tsx
+++ b/stories/nostr-zap/NostrZap.testing.no-data.stories.tsx
@@ -1,26 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { DEFAULT_WIDTH, generateCode, getArgTypes } from "./utils";
+import { generateCode, getArgTypes, getTestingParameters } from "./utils";
 import { NO_DATA_TEST_CASES } from './test-cases-no-data';
 
 const meta: Meta = {
-  title: 'Zap Button/Testing',
+  title: 'Zap Button/Testing/No Data',
   tags: ['test', 'no-data'],
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-zap-button',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters(),
 };
 
 export default meta;

--- a/stories/nostr-zap/NostrZap.testing.valid.stories.tsx
+++ b/stories/nostr-zap/NostrZap.testing.valid.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
-import { generateCode, getArgTypes } from './utils';
+import { generateCode, getArgTypes, getTestingParameters } from './utils';
 import { TEST_CASES } from './test-cases-valid';
 
 const meta: Meta = {
@@ -8,19 +8,7 @@ const meta: Meta = {
   render: args => generateCode(args),
   argTypes: getArgTypes(),
   args: {},
-  parameters: {
-    test: {
-      enabled: true,
-      a11y: {
-        element: 'nostr-zap-button',
-        config: {
-          rules: {
-            'color-contrast': { enabled: true },
-          },
-        },
-      },
-    },
-  },
+  parameters: getTestingParameters(),
 };
 
 export default meta;

--- a/stories/nostr-zap/utils.ts
+++ b/stories/nostr-zap/utils.ts
@@ -1,5 +1,7 @@
 import { ZAP_BUTTON_PARAMETERS as PARAMETERS } from './parameters';
 import { ZAP_BUTTON_CSS_VARIABLES as CSS_VARIABLES } from './css-variables';
+import { getBooleanAttributeModes } from '../common/parameters';
+import { DYNAMIC_TEST_TAGS, createTestingParameters, type TestingParametersOptions } from '../common/testing';
 import { generateArgTypes } from '../common/utils';
 import { generateCode as generateCodeShared, generateCodeWithScript as generateCodeWithScriptShared, generateDashboardHTML as generateDashboardHTMLShared, BUNDLE_SCRIPT, generateBundleScript, type CodeGeneratorConfig } from '../common/code-generator';
 
@@ -13,15 +15,19 @@ export const COMPONENT_CONFIG: CodeGeneratorConfig = {
 
 // Constants
 export const DEFAULT_WIDTH = COMPONENT_CONFIG.defaultWidth;
-export { BUNDLE_SCRIPT, generateBundleScript };
+export { BUNDLE_SCRIPT, generateBundleScript, DYNAMIC_TEST_TAGS };
 
 // Common function to generate argTypes for stories
 export const getArgTypes = () => generateArgTypes(PARAMETERS, CSS_VARIABLES);
+export const getTestingParameters = (options?: TestingParametersOptions) =>
+  createTestingParameters(COMPONENT_CONFIG.componentName, options);
+export const BOOLEAN_ATTRIBUTE_MODES = getBooleanAttributeModes(PARAMETERS);
 
 export const generateCode = (args: any, forCodeGen = false) => {
   return generateCodeShared({
     args,
     config: COMPONENT_CONFIG,
+    parameters: PARAMETERS,
     cssVariables: CSS_VARIABLES,
     forCodeGen
   });
@@ -31,6 +37,7 @@ export const generateCodeWithScript = (args: any) => {
   return generateCodeWithScriptShared({
     args,
     config: COMPONENT_CONFIG,
+    parameters: PARAMETERS,
     cssVariables: CSS_VARIABLES
   });
 };
@@ -41,6 +48,7 @@ export const generateDashboardHTML = (testCases: any[], title: string, color: st
     testCases,
     title,
     color,
-    config: COMPONENT_CONFIG
+    config: COMPONENT_CONFIG,
+    parameters: PARAMETERS,
   });
 };

--- a/stories/post-data.ts
+++ b/stories/post-data.ts
@@ -75,8 +75,8 @@ export const POST_DATA: Record<string, Post> = {
 };
 
 export const getRandomProfile = (): Post => {
-  const profiles = Object.values(POST_DATA);
-  return profiles[Math.floor(Math.random() * profiles.length)];
+  const posts = Object.values(POST_DATA);
+  return posts[Math.floor(Math.random() * posts.length)];
 };
 
 export const getProfilesByType = (type: 'hex' | 'noteid' | 'eventid'): InputType[] => {
@@ -90,10 +90,10 @@ export const getProfilesByType = (type: 'hex' | 'noteid' | 'eventid'): InputType
 };
 
 export const getAllInputTypes = (): InputType[] => {
-  const profiles = Object.values(POST_DATA);
+  const posts = Object.values(POST_DATA);
   const inputs: InputType[] = [];
   
-  profiles.forEach(post => {
+  posts.forEach(post => {
     if (post.hex) {
       inputs.push({ type: 'hex', value: post.hex, name: post.name });
     }


### PR DESCRIPTION
## Summary

This PR completes the focused Storybook follow-up cleanup for issue #57 without widening into unrelated refactors.

It cleans up Storybook testing taxonomy, removes repeated testing config, aligns boolean-attribute handling between Storybook and runtime behavior, and deduplicates shared no-data fixtures.

Closes #57.

## What Changed

### Shared Storybook cleanup
- added a shared testing-parameters helper for Storybook test/a11y config
- added shared dynamic-story tags and disabled Chromatic snapshots for dynamic stories
- replaced repeated testing config across Follow, Profile, Profile Badge, Post, Zap, Livestream, and Like stories
- replaced `StoryObj<any>` usages with `StoryObj<typeof meta>`

### Boolean attribute alignment
- extended Storybook parameter metadata with boolean handling modes
- updated shared code generation to serialize boolean attributes correctly
- updated shared dynamic-story behavior so it no longer writes `"false"` for presence-style booleans
- preserved livestream’s explicit `"false"` semantics for:
  - `show-participants`
  - `show-participant-count`

### Targeted runtime consistency fixes
- `nostr-profile` now uses shared boolean parsing for:
  - `show-npub`
  - `show-follow`
- `nostr-post` now uses shared boolean parsing for:
  - `show-stats`
- `nostr-follow-button` now uses shared boolean parsing for:
  - `show-avatar`

### Storybook taxonomy and story cleanup
- normalized testing titles to use:
  - `Component/Testing/Valid`
  - `Component/Testing/Invalid`
  - `Component/Testing/No Data`
  - `Component/Testing/Dynamic`
  - `Component/Testing/Dashboard`
- fixed the follow-button fast-switching story to update `data-theme` instead of `theme`
- added missing dynamic-story tags
- cleaned up small naming and import issues in stories
- improved parameter description wording for current boolean controls

### Shared no-data fixtures
- extracted duplicated no-data values into a shared Storybook fixture module
- updated profile, profile-badge, follow-button, and post no-data stories to use the shared fixtures

## Verification

Ran:
- `npm test -- --run`
- `npm run build-storybook`

Results:
- tests passed
- Storybook build completed successfully
