### PR TITLE
Add relay directory crawler

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+storybook-static
+saiy2k-nostr-components
+sob-proposal-review/relay-directory-output.json
+.git
+.codex
+.agents
+npm-debug.log*

--- a/Dockerfile.relay-directory-crawler
+++ b/Dockerfile.relay-directory-crawler
@@ -5,12 +5,13 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev --legacy-peer-deps
 
-COPY scripts/relay-directory-crawler.mjs ./scripts/relay-directory-crawler.mjs
+COPY --chown=node:node scripts/relay-directory-crawler.mjs ./scripts/relay-directory-crawler.mjs
 
 ENV NODE_ENV=production
 ENV GOOGLE_CLOUD_PROJECT=gr-prod
 ENV FIRESTORE_PROJECT=gr-prod
 ENV WRITE_FIRESTORE=1
 
+USER node
 ENTRYPOINT ["node"]
 CMD ["scripts/relay-directory-crawler.mjs", "--project-directory", "--firestore-project", "gr-prod", "--no-json"]

--- a/Dockerfile.relay-directory-crawler
+++ b/Dockerfile.relay-directory-crawler
@@ -1,0 +1,16 @@
+FROM node:22-slim
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --legacy-peer-deps
+
+COPY scripts/relay-directory-crawler.mjs ./scripts/relay-directory-crawler.mjs
+
+ENV NODE_ENV=production
+ENV GOOGLE_CLOUD_PROJECT=gr-prod
+ENV FIRESTORE_PROJECT=gr-prod
+ENV WRITE_FIRESTORE=1
+
+ENTRYPOINT ["node"]
+CMD ["scripts/relay-directory-crawler.mjs", "--project-directory", "--firestore-project", "gr-prod", "--no-json"]

--- a/cloudbuild.relay-directory-crawler.yaml
+++ b/cloudbuild.relay-directory-crawler.yaml
@@ -1,0 +1,11 @@
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - -f
+      - Dockerfile.relay-directory-crawler
+      - -t
+      - ${_IMAGE}
+      - .
+images:
+  - ${_IMAGE}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,42 +1,44 @@
 {
   "name": "nostr-components",
-  "version": "0.0.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nostr-components",
-      "version": "0.0.0",
+      "version": "0.6.1",
+      "license": "MIT",
       "dependencies": {
         "@glidejs/glide": "^3.7.1",
+        "@google-cloud/firestore": "^8.6.0",
         "@nostr-dev-kit/ndk": "^2.10.0",
         "@types/dompurify": "^3.0.5",
         "@types/qrcode": "^1.5.5",
         "dompurify": "^3.2.6",
+        "hls-video-element": "^1.5.10",
         "light-bolt11-decoder": "^3.2.0",
         "nostr-tools": "^2.7.2",
-        "npm": "^11.3.0",
         "qrcode": "^1.5.4"
       },
       "devDependencies": {
-        "@chromatic-com/storybook": "^3.2.3",
-        "@storybook/addon-docs": "^8.5.6",
-        "@storybook/addon-essentials": "^8.4.7",
+        "@chromatic-com/storybook": "^4.1.1",
+        "@storybook/addon-docs": "^9.1.8",
         "@storybook/addons": "^7.6.17",
-        "@storybook/blocks": "^8.5.8",
-        "@storybook/test": "^8.4.7",
-        "@storybook/web-components": "^8.4.7",
-        "@storybook/web-components-vite": "^8.4.7",
+        "@storybook/web-components-vite": "^9.1.8",
         "@types/glidejs__glide": "^3.6.6",
         "@types/htmlparser2": "^3.10.7",
         "@types/node": "^22.15.21",
+        "@vitest/coverage-v8": "^4.0.17",
+        "cross-env": "^7.0.3",
         "esbuild": "0.23.1",
         "htmlparser2": "^10.0.0",
-        "lit": "^3.2.1",
+        "lit": "^3.3.1",
         "prettier": "^3.5.3",
-        "storybook": "^8.4.7",
+        "storybook": "^9.1.8",
         "typescript": "^5.8.3",
-        "vite": "^5.4.1"
+        "vite": "^5.4.1",
+        "vite-plugin-dts": "^4.5.4",
+        "vitest": "^4.0.17"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -46,25 +48,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -72,9 +59,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -82,13 +69,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
-      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -97,52 +84,83 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
-      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "regenerator-runtime": "^0.14.0"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/types": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
-      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
-      },
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">=18"
       }
     },
     "node_modules/@chromatic-com/storybook": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@chromatic-com/storybook/-/storybook-3.2.6.tgz",
-      "integrity": "sha512-FDmn5Ry2DzQdik+eq2sp/kJMMT36Ewe7ONXUXM2Izd97c7r6R/QyGli8eyh/F0iyqVvbLveNYFyF0dBOJNwLqw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@chromatic-com/storybook/-/storybook-4.1.3.tgz",
+      "integrity": "sha512-hc0HO9GAV9pxqDE6fTVOV5KeLpTiCfV8Jrpk5ogKLiIgeq2C+NPjpt74YnrZTjiK8E19fYcMP+2WY9ZtX7zHmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chromatic": "^11.15.0",
+        "@neoconfetti/react": "^1.0.0",
+        "chromatic": "^13.3.3",
         "filesize": "^10.0.12",
         "jsonfile": "^6.1.0",
-        "react-confetti": "^6.1.0",
         "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=16.0.0",
+        "node": ">=20.0.0",
         "yarn": ">=1.22.18"
       },
       "peerDependencies": {
-        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
+        "storybook": "^0.0.0-0 || ^9.0.0 || ^9.1.0-0 || ^9.2.0-0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
@@ -569,28 +587,254 @@
       "integrity": "sha512-8he0pZpLSqTesSFYiuWdhBmtdlYSPWxfPUCKtkkiX6ZmT8UdMdmoFPtJaOwLBXv4p2JiGxqbuPdiRGGo2e/htQ==",
       "license": "MIT"
     },
+    "node_modules/@google-cloud/firestore": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-8.6.0.tgz",
+      "integrity": "sha512-TdvZHfwQj5B5CSDEgDqyrhdVqtOSupmBXDQPasMAJiC64tjsGvyMooNiC43fdk1TsUHeklyoZ6/vQ1TjWKVMbg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "fast-deep-equal": "^3.1.3",
+        "functional-red-black-tree": "^1.0.1",
+        "google-gax": "^5.0.1",
+        "protobufjs": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/@lit-labs/ssr-dom-shim": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz",
-      "integrity": "sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@lit/reactive-element": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
-      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0"
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
     },
     "node_modules/@mdx-js/react": {
@@ -610,6 +854,141 @@
         "@types/react": ">=16",
         "react": ">=16"
       }
+    },
+    "node_modules/@microsoft/api-extractor": {
+      "version": "7.58.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.58.9.tgz",
+      "integrity": "sha512-S2UF4yza5GoxCmf7hJQNxJNZN9ltOVuOQv8Dy+Z21aol5ERoBNMdWcQHm4MJMPPItW4H/4rZD906iaf4mUojJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/api-extractor-model": "7.33.8",
+        "@microsoft/tsdoc": "~0.16.0",
+        "@microsoft/tsdoc-config": "~0.18.1",
+        "@rushstack/node-core-library": "5.23.1",
+        "@rushstack/rig-package": "0.7.3",
+        "@rushstack/terminal": "0.24.0",
+        "@rushstack/ts-command-line": "5.3.10",
+        "diff": "~8.0.2",
+        "minimatch": "10.2.3",
+        "resolve": "~1.22.1",
+        "semver": "~7.7.4",
+        "source-map": "~0.6.1",
+        "typescript": "5.9.3"
+      },
+      "bin": {
+        "api-extractor": "bin/api-extractor"
+      }
+    },
+    "node_modules/@microsoft/api-extractor-model": {
+      "version": "7.33.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.8.tgz",
+      "integrity": "sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "~0.16.0",
+        "@microsoft/tsdoc-config": "~0.18.1",
+        "@rushstack/node-core-library": "5.23.1"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/minimatch": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
+      "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@microsoft/tsdoc-config": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.18.1.tgz",
+      "integrity": "sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "ajv": "~8.18.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.2"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@neoconfetti/react": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@neoconfetti/react/-/react-1.0.0.tgz",
+      "integrity": "sha512-klcSooChXXOzIm+SE5IISIAn3bYzYfPjbX7D7HoqZL84oAfgREeSg5vSIaSFH+DaGzzvImTyWe1OyrJ67vik4A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@noble/ciphers": {
       "version": "0.5.3",
@@ -677,6 +1056,404 @@
       "peerDependencies": {
         "nostr-tools": "^2"
       }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.39.0",
@@ -958,6 +1735,134 @@
         "win32"
       ]
     },
+    "node_modules/@rushstack/node-core-library": {
+      "version": "5.23.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.23.1.tgz",
+      "integrity": "sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "~8.18.0",
+        "ajv-draft-04": "~1.0.0",
+        "ajv-formats": "~3.0.1",
+        "fs-extra": "~11.3.0",
+        "import-lazy": "~4.0.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.1",
+        "semver": "~7.7.4"
+      },
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rushstack/node-core-library/node_modules/fs-extra": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@rushstack/node-core-library/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@rushstack/problem-matcher": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/problem-matcher/-/problem-matcher-0.2.1.tgz",
+      "integrity": "sha512-gulfhBs6n+I5b7DvjKRfhMGyUejtSgOHTclF/eONr8hcgF1APEDjhxIsfdUYYMzC3rvLwGluqLjbwCFZ8nxrog==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rushstack/rig-package": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.7.3.tgz",
+      "integrity": "sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jju": "~1.4.0",
+        "resolve": "~1.22.1"
+      }
+    },
+    "node_modules/@rushstack/terminal": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.24.0.tgz",
+      "integrity": "sha512-8ZQS4MMaGsv27EXCBiH7WMPkRZrffeDoIevs6z9TM5dzqiY6+Hn4evfK/G+gvgBTjfvfkHIZPQQmalmI2sM4TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rushstack/node-core-library": "5.23.1",
+        "@rushstack/problem-matcher": "0.2.1",
+        "supports-color": "~8.1.1"
+      },
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rushstack/terminal/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@rushstack/ts-command-line": {
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.10.tgz",
+      "integrity": "sha512-fwI076HYknC0IrMXdY6UmjDv+PH7NHhNJX3/pY2UblSE5XrXgndXZPiOe/6ZtuFpn6DvVDVNhtkIzQ+Qu/MhVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rushstack/terminal": "0.24.0",
+        "@types/argparse": "1.0.38",
+        "argparse": "~1.0.9",
+        "string-argv": "~0.3.1"
+      }
+    },
     "node_modules/@scure/base": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
@@ -1060,76 +1965,24 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@storybook/addon-actions": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-8.6.12.tgz",
-      "integrity": "sha512-B5kfiRvi35oJ0NIo53CGH66H471A3XTzrfaa6SxXEJsgxxSeKScG5YeXcCvLiZfvANRQ7QDsmzPUgg0o3hdMXw==",
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/global": "^5.0.0",
-        "@types/uuid": "^9.0.1",
-        "dequal": "^2.0.2",
-        "polished": "^4.2.2",
-        "uuid": "^9.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.6.12"
-      }
-    },
-    "node_modules/@storybook/addon-backgrounds": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-8.6.12.tgz",
-      "integrity": "sha512-lmIAma9BiiCTbJ8YfdZkXjpnAIrOUcgboLkt1f6XJ78vNEMnLNzD9gnh7Tssz1qrqvm34v9daDjIb+ggdiKp3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/global": "^5.0.0",
-        "memoizerific": "^1.11.3",
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.6.12"
-      }
-    },
-    "node_modules/@storybook/addon-controls": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-8.6.12.tgz",
-      "integrity": "sha512-9VSRPJWQVb9wLp21uvpxDGNctYptyUX0gbvxIWOHMH3R2DslSoq41lsC/oQ4l4zSHVdL+nq8sCTkhBxIsjKqdQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/global": "^5.0.0",
-        "dequal": "^2.0.2",
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.6.12"
-      }
+      "license": "MIT"
     },
     "node_modules/@storybook/addon-docs": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-8.6.12.tgz",
-      "integrity": "sha512-kEezQjAf/p3SpDzLABgg4fbT48B6dkT2LiZCKTRmCrJVtuReaAr4R9MMM6Jsph6XjbIj/SvOWf3CMeOPXOs9sg==",
+      "version": "9.1.20",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.20.tgz",
+      "integrity": "sha512-eUIOd4u/p9994Nkv8Avn6r/xmS7D+RNmhmu6KGROefN3myLe3JfhSdimal2wDFe/h/OUNZ/LVVKMZrya9oEfKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/blocks": "8.6.12",
-        "@storybook/csf-plugin": "8.6.12",
-        "@storybook/react-dom-shim": "8.6.12",
+        "@storybook/csf-plugin": "9.1.20",
+        "@storybook/icons": "^1.4.0",
+        "@storybook/react-dom-shim": "9.1.20",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "ts-dedent": "^2.0.0"
@@ -1139,117 +1992,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.6.12"
-      }
-    },
-    "node_modules/@storybook/addon-essentials": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-8.6.12.tgz",
-      "integrity": "sha512-Y/7e8KFlttaNfv7q2zoHMPdX6hPXHdsuQMAjYl5NG9HOAJREu4XBy4KZpbcozRe4ApZ78rYsN/MO1EuA+bNMIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/addon-actions": "8.6.12",
-        "@storybook/addon-backgrounds": "8.6.12",
-        "@storybook/addon-controls": "8.6.12",
-        "@storybook/addon-docs": "8.6.12",
-        "@storybook/addon-highlight": "8.6.12",
-        "@storybook/addon-measure": "8.6.12",
-        "@storybook/addon-outline": "8.6.12",
-        "@storybook/addon-toolbars": "8.6.12",
-        "@storybook/addon-viewport": "8.6.12",
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.6.12"
-      }
-    },
-    "node_modules/@storybook/addon-highlight": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-8.6.12.tgz",
-      "integrity": "sha512-9FITVxdoycZ+eXuAZL9ElWyML/0fPPn9UgnnAkrU7zkMi+Segq/Tx7y+WWanC5zfWZrXAuG6WTOYEXeWQdm//w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/global": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.6.12"
-      }
-    },
-    "node_modules/@storybook/addon-measure": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-8.6.12.tgz",
-      "integrity": "sha512-tACmwqqOvutaQSduw8SMb62wICaT1rWaHtMN3vtWXuxgDPSdJQxLP+wdVyRYMAgpxhLyIO7YRf++Hfha9RHgFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/global": "^5.0.0",
-        "tiny-invariant": "^1.3.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.6.12"
-      }
-    },
-    "node_modules/@storybook/addon-outline": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-outline/-/addon-outline-8.6.12.tgz",
-      "integrity": "sha512-1ylwm+n1s40S91No0v9T4tCjZORu3GbnjINlyjYTDLLhQHyBQd3nWR1Y1eewU4xH4cW9SnSLcMQFS/82xHqU6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/global": "^5.0.0",
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.6.12"
-      }
-    },
-    "node_modules/@storybook/addon-toolbars": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-8.6.12.tgz",
-      "integrity": "sha512-HEcSzo1DyFtIu5/ikVOmh5h85C1IvK9iFKSzBR6ice33zBOaehVJK+Z5f487MOXxPsZ63uvWUytwPyViGInj+g==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.6.12"
-      }
-    },
-    "node_modules/@storybook/addon-viewport": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-8.6.12.tgz",
-      "integrity": "sha512-EXK2LArAnABsPP0leJKy78L/lbMWow+EIJfytEP5fHaW4EhMR6h7Hzaqzre6U0IMMr/jVFa1ci+m0PJ0eQc2bw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "memoizerific": "^1.11.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.6.12"
+        "storybook": "^9.1.20"
       }
     },
     "node_modules/@storybook/addons": {
@@ -1268,43 +2011,14 @@
         "url": "https://opencollective.com/storybook"
       }
     },
-    "node_modules/@storybook/blocks": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-8.6.12.tgz",
-      "integrity": "sha512-DohlTq6HM1jDbHYiXL4ZvZ00VkhpUp5uftzj/CZDLY1fYHRjqtaTwWm2/OpceivMA8zDitLcq5atEZN+f+siTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/icons": "^1.2.12",
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^8.6.12"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@storybook/builder-vite": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-8.6.12.tgz",
-      "integrity": "sha512-Gju21ud/3Qw4v2vLNaa5SuJECsI9ICNRr2G0UyCCzRvCHg8jpA9lDReu2NqhLDyFIuDG+ZYT38gcaHEUoNQ8KQ==",
+      "version": "9.1.20",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.20.tgz",
+      "integrity": "sha512-cdU3Q2/wEaT8h+mApFToRiF/0hYKH1eAkD0scQn67aODgp7xnkr0YHcdA+8w0Uxd2V7U8crV/cmT/HD0ELVOGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf-plugin": "8.6.12",
-        "browser-assert": "^1.2.1",
+        "@storybook/csf-plugin": "9.1.20",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -1312,8 +2026,8 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.6.12",
-        "vite": "^4.0.0 || ^5.0.0 || ^6.0.0"
+        "storybook": "^9.1.20",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@storybook/channels": {
@@ -1349,52 +2063,6 @@
         "url": "https://opencollective.com/storybook"
       }
     },
-    "node_modules/@storybook/components": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-8.6.12.tgz",
-      "integrity": "sha512-FiaE8xvCdvKC2arYusgtlDNZ77b8ysr8njAYQZwwaIHjy27TbR2tEpLDCmUwSbANNmivtc/xGEiDDwcNppMWlQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
-      }
-    },
-    "node_modules/@storybook/core": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.6.12.tgz",
-      "integrity": "sha512-t+ZuDzAlsXKa6tLxNZT81gEAt4GNwsKP/Id2wluhmUWD/lwYW0uum1JiPUuanw8xD6TdakCW/7ULZc7aQUBLCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/theming": "8.6.12",
-        "better-opn": "^3.0.2",
-        "browser-assert": "^1.2.1",
-        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0",
-        "esbuild-register": "^3.5.0",
-        "jsdoc-type-pratt-parser": "^4.0.0",
-        "process": "^0.11.10",
-        "recast": "^0.23.5",
-        "semver": "^7.6.2",
-        "util": "^0.12.5",
-        "ws": "^8.2.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "prettier": "^2 || ^3"
-      },
-      "peerDependenciesMeta": {
-        "prettier": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@storybook/core-events": {
       "version": "7.6.17",
       "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.6.17.tgz",
@@ -1420,9 +2088,9 @@
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.6.12.tgz",
-      "integrity": "sha512-6s8CnP1aoKPb3XtC0jRLUp8M5vTA8RhGAwQDKUsFpCC7g89JR9CaKs9FY2ZSzsNbjR15uASi7b3K8BzeYumYQg==",
+      "version": "9.1.20",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.20.tgz",
+      "integrity": "sha512-HHgk50YQhML7mT01Mzf9N7lNMFHWN4HwwRP90kPT9Ct+Jhx7h3LBDbdmWjI96HwujcpY7eoYdTfpB1Sw8Z7nBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1433,7 +2101,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.6.12"
+        "storybook": "^9.1.20"
       }
     },
     "node_modules/@storybook/global": {
@@ -1444,9 +2112,9 @@
       "license": "MIT"
     },
     "node_modules/@storybook/icons": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-1.4.0.tgz",
-      "integrity": "sha512-Td73IeJxOyalzvjQL+JXx72jlIYHgs+REaHiREOqfpo3A2AYYG71AUbcv+lg7mEDIweKVCxsMQ0UKo634c8XeA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-1.6.0.tgz",
+      "integrity": "sha512-hcFZIjW8yQz8O8//2WTIXylm5Xsgc+lW9ISLgUk1xGmptIJQRdlhVIXCpSyLrQaaRiyhQRaVg7l3BD9S216BHw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1455,24 +2123,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta"
-      }
-    },
-    "node_modules/@storybook/instrumenter": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/instrumenter/-/instrumenter-8.6.12.tgz",
-      "integrity": "sha512-VK5fYAF8jMwWP/u3YsmSwKGh+FeSY8WZn78flzRUwirp2Eg1WWjsqPRubAk7yTpcqcC/km9YMF3KbqfzRv2s/A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/global": "^5.0.0",
-        "@vitest/utils": "^2.1.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.6.12"
       }
     },
     "node_modules/@storybook/manager-api": {
@@ -1523,46 +2173,6 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/@storybook/manager-api/node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@storybook/manager-api/node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "node_modules/@storybook/manager-api/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
     "node_modules/@storybook/preview-api": {
       "version": "7.6.17",
       "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-7.6.17.tgz",
@@ -1591,9 +2201,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-8.6.12.tgz",
-      "integrity": "sha512-51QvoimkBzYs8s3rCYnY5h0cFqLz/Mh0vRcughwYaXckWzDBV8l67WBO5Xf5nBsukCbWyqBVPpEQLww8s7mrLA==",
+      "version": "9.1.20",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.20.tgz",
+      "integrity": "sha512-UYdZavfPwHEqCKMqPssUOlyFVZiJExLxnSHwkICSZBmw3gxXJcp1aXWs7PvoZdWz2K4ztl3IcKErXXHeiY6w+A==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1603,7 +2213,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^8.6.12"
+        "storybook": "^9.1.20"
       }
     },
     "node_modules/@storybook/router": {
@@ -1620,43 +2230,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/test": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/test/-/test-8.6.12.tgz",
-      "integrity": "sha512-0BK1Eg+VD0lNMB1BtxqHE3tP9FdkUmohtvWG7cq6lWvMrbCmAmh3VWai3RMCCDOukPFpjabOr8BBRLVvhNpv2w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/global": "^5.0.0",
-        "@storybook/instrumenter": "8.6.12",
-        "@testing-library/dom": "10.4.0",
-        "@testing-library/jest-dom": "6.5.0",
-        "@testing-library/user-event": "14.5.2",
-        "@vitest/expect": "2.0.5",
-        "@vitest/spy": "2.0.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.6.12"
-      }
-    },
-    "node_modules/@storybook/theming": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.6.12.tgz",
-      "integrity": "sha512-6VjZg8HJ2Op7+KV7ihJpYrDnFtd9D1jrQnUS8LckcpuBXrIEbaut5+34ObY8ssQnSqkk2GwIZBBBQYQBCVvkOw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
       }
     },
     "node_modules/@storybook/types": {
@@ -1677,22 +2250,18 @@
       }
     },
     "node_modules/@storybook/web-components": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/web-components/-/web-components-8.6.12.tgz",
-      "integrity": "sha512-j+609VT8abBlpV+tB/vqSRO/fKA1QpnKWlbE0JpolzmEbgla//pAZomPysoOnvTLL3lSX3conjiAAaTpwbjyLg==",
+      "version": "9.1.20",
+      "resolved": "https://registry.npmjs.org/@storybook/web-components/-/web-components-9.1.20.tgz",
+      "integrity": "sha512-pDQ9ED5wIhPQeOJYv0RPCgLkGiDIKyX+YofQmjqAPIRSs5ewtK8W/ug3HqzggWnx7Fi3L04H81TGALtOU1LQiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/components": "8.6.12",
         "@storybook/global": "^5.0.0",
-        "@storybook/manager-api": "8.6.12",
-        "@storybook/preview-api": "8.6.12",
-        "@storybook/theming": "8.6.12",
         "tiny-invariant": "^1.3.1",
         "ts-dedent": "^2.0.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1700,139 +2269,45 @@
       },
       "peerDependencies": {
         "lit": "^2.0.0 || ^3.0.0",
-        "storybook": "^8.6.12"
+        "storybook": "^9.1.20"
       }
     },
     "node_modules/@storybook/web-components-vite": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/web-components-vite/-/web-components-vite-8.6.12.tgz",
-      "integrity": "sha512-1YVnkk7O9zPF5xTeWD5AxpmfCx9M7C9Du8pIwcypjHQLnb34PwiyjMRztYm/JKh5kCl4BZg187r2j3Q258ytHQ==",
+      "version": "9.1.20",
+      "resolved": "https://registry.npmjs.org/@storybook/web-components-vite/-/web-components-vite-9.1.20.tgz",
+      "integrity": "sha512-HssqrkgQgpTRaCOXmUTyeseEn7b9XJ296bXnJOcSZ5mQ6uxGAZm4AG0gmalHIbFRNdMncHtfX3jXmZznISttXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/builder-vite": "8.6.12",
-        "@storybook/web-components": "8.6.12",
-        "magic-string": "^0.30.0"
+        "@storybook/builder-vite": "9.1.20",
+        "@storybook/web-components": "9.1.20"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^8.6.12"
+        "storybook": "^9.1.20"
       }
     },
-    "node_modules/@storybook/web-components/node_modules/@storybook/manager-api": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.6.12.tgz",
-      "integrity": "sha512-O0SpISeJLNTQvhSBOsWzzkCgs8vCjOq1578rwqHlC6jWWm4QmtfdyXqnv7rR1Hk08kQ+Dzqh0uhwHx0nfwy4nQ==",
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
-      }
-    },
-    "node_modules/@storybook/web-components/node_modules/@storybook/preview-api": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.6.12.tgz",
-      "integrity": "sha512-84FE3Hrs0AYKHqpDZOwx1S/ffOfxBdL65lhCoeI8GoWwCkzwa9zEP3kvXBo/BnEDO7nAfxvMhjASTZXbKRJh5Q==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
-      }
-    },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
-      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
-      "dev": true,
-      "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@testing-library/jest-dom": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.5.0.tgz",
-      "integrity": "sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@adobe/css-tools": "^4.4.0",
-        "aria-query": "^5.0.0",
-        "chalk": "^3.0.0",
-        "css.escape": "^1.5.1",
-        "dom-accessibility-api": "^0.6.3",
-        "lodash": "^4.17.21",
-        "redent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6",
-        "yarn": ">=1"
-      }
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
-      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@testing-library/user-event": {
-      "version": "14.5.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
-      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": ">=7.21.4"
-      }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+    "node_modules/@types/argparse": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
+      "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1892,6 +2367,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -1901,6 +2387,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/domhandler": {
       "version": "2.4.5",
@@ -2034,17 +2527,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.0.2"
-      }
-    },
     "node_modules/@types/send": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
@@ -2074,103 +2556,352 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
     },
-    "node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.9",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@vitest/expect": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.0.5.tgz",
-      "integrity": "sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==",
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "2.0.5",
-        "@vitest/utils": "2.0.5",
-        "chai": "^5.1.1",
-        "tinyrainbow": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
       }
     },
-    "node_modules/@vitest/expect/node_modules/@vitest/pretty-format": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.0.5.tgz",
-      "integrity": "sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==",
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.38.tgz",
+      "integrity": "sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.38",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
       }
     },
-    "node_modules/@vitest/expect/node_modules/@vitest/utils": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.0.5.tgz",
-      "integrity": "sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==",
+    "node_modules/@vue/compiler-core/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "2.0.5",
-        "estree-walker": "^3.0.3",
-        "loupe": "^3.1.1",
-        "tinyrainbow": "^1.2.0"
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
       },
       "funding": {
-        "url": "https://opencollective.com/vitest"
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/@vitest/pretty-format": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
-      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+    "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.38.tgz",
+      "integrity": "sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
+        "@vue/compiler-core": "3.5.38",
+        "@vue/shared": "3.5.38"
       }
     },
-    "node_modules/@vitest/spy": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.0.5.tgz",
-      "integrity": "sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==",
+    "node_modules/@vue/compiler-vue2": {
+      "version": "2.7.16",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
+      "integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyspy": "^3.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
+        "de-indent": "^1.0.2",
+        "he": "^1.2.0"
       }
     },
-    "node_modules/@vitest/utils": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
-      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+    "node_modules/@vue/language-core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.0.tgz",
+      "integrity": "sha512-O1ZZFaaBGkKbsRfnVH1ifOK1/1BUkyK+3SQsfnh6PmMmD4qJcTU8godCeA96jjDRTL6zgnK7YzCHfaUlH2r0Mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.9",
-        "loupe": "^3.1.2",
-        "tinyrainbow": "^1.2.0"
+        "@volar/language-core": "~2.4.11",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/compiler-vue2": "^2.7.16",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^0.4.9",
+        "minimatch": "^9.0.3",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1"
       },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.38.tgz",
+      "integrity": "sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2179,6 +2910,72 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/alien-signals": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-0.4.14.tgz",
+      "integrity": "sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -2202,6 +2999,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/aria-query": {
@@ -2237,21 +3044,50 @@
         "node": ">=4"
       }
     },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "possible-typed-array-names": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
       }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/better-opn": {
       "version": "3.0.2",
@@ -2266,30 +3102,29 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/browser-assert": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz",
-      "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==",
-      "dev": true
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
-    "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "dev": true,
+    "node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "balanced-match": "^1.0.0"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -2348,23 +3183,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/check-error": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
@@ -2376,9 +3194,9 @@
       }
     },
     "node_modules/chromatic": {
-      "version": "11.28.0",
-      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-11.28.0.tgz",
-      "integrity": "sha512-Xy3907MXY5UP7LoMksmsT02xCUsoLZpcC6sRITjd+KiXBteOxPF7J+QsFqy/VzQCEN6fpt/R2bOIpE+PwPfcZA==",
+      "version": "13.3.5",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-13.3.5.tgz",
+      "integrity": "sha512-MzPhxpl838qJUo0A55osCF2ifwPbjcIPeElr1d4SHcjnHoIcg7l1syJDrAYK/a+PcCBrOGi06jPNpQAln5hWgw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2440,6 +3258,60 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -2447,13 +3319,27 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+    "node_modules/custom-media-element": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.4.6.tgz",
+      "integrity": "sha512-/HRYqJOa1ob5ik4q7FIJVYxTJCFs/FL3+cQPAJjUf2uiqrDEzbTgB315gQ2rG8oK3w094W9m5tcB8S5Qah+caA==",
+      "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "license": "MIT",
-      "peer": true
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -2491,24 +3377,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -2529,17 +3397,30 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
       "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
-      "license": "MIT"
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dom-serializer": {
@@ -2684,11 +3565,47 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/entities": {
       "version": "6.0.0",
@@ -2722,6 +3639,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -2789,6 +3713,15 @@
         "esbuild": ">=0.12 <1"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -2811,6 +3744,93 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/file-system-cache": {
@@ -2847,20 +3867,32 @@
         "node": ">=8"
       }
     },
-    "node_modules/for-each": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "dev": true,
-      "license": "MIT",
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
       "dependencies": {
-        "is-callable": "^1.2.7"
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": ">= 0.4"
+        "node": ">=14"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fs-extra": {
@@ -2901,6 +3933,55 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "license": "MIT"
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+      "integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.3.tgz",
+      "integrity": "sha512-ziTrzUhhpL9Zk5k0HHzgP/KIpWDJT0VMBC/ynt/QIBvTW+UUcSivQRl6VlwTf/EilDxtSWklHoRsKy1c4k+59w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "7.1.3",
+        "google-logging-utils": "1.1.3",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/get-caller-file": {
@@ -2951,6 +4032,76 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^8.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.7.tgz",
+      "integrity": "sha512-EhiqaWWJ+9h7sCcKJTsoo6tMcjokVHhWsbSuWCnZJT4vIBP3y4mAoFLnt9SzgkVZeq24ZsFaArr06nnYYku2yA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.12.6",
+        "@grpc/proto-loader": "^0.8.0",
+        "duplexify": "^4.1.3",
+        "google-auth-library": "10.5.0",
+        "google-logging-utils": "1.1.3",
+        "node-fetch": "^3.3.2",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "3.0.4",
+        "protobufjs": "^7.5.4",
+        "retry-request": "^8.0.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2971,6 +4122,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2979,19 +4143,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -3007,26 +4158,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3035,6 +4170,40 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/hls-video-element": {
+      "version": "1.5.11",
+      "resolved": "https://registry.npmjs.org/hls-video-element/-/hls-video-element-1.5.11.tgz",
+      "integrity": "sha512-tJJ65/52CDxj8XFyIve6zT9nVVdUIc6mqvKR25X0ycPKHk07rpjp4xxVteeCefDUBSf/tFLhlICFmn3KWj37xA==",
+      "license": "MIT",
+      "dependencies": {
+        "custom-media-element": "^1.4.6",
+        "hls.js": "^1.6.5",
+        "media-tracks": "^0.3.5"
+      }
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/htmlparser2": {
       "version": "10.0.0",
@@ -3085,6 +4254,42 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/import-lazy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -3099,32 +4304,17 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
-    "node_modules/is-arguments": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
+        "hasown": "^2.0.3"
       },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -3157,60 +4347,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-generator-function": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
-      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "get-proto": "^1.0.0",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-regex": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -3224,22 +4360,88 @@
         "node": ">=8"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jsdoc-type-pratt-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.1.0.tgz",
-      "integrity": "sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==",
-      "dev": true,
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -3253,6 +4455,34 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/kolorist": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/light-bolt11-decoder": {
       "version": "3.2.0",
@@ -3275,38 +4505,329 @@
       ],
       "license": "MIT"
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lit": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
-      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^2.0.4",
-        "lit-element": "^4.1.0",
-        "lit-html": "^3.2.0"
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
       }
     },
     "node_modules/lit-element": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
-      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0",
-        "@lit/reactive-element": "^2.0.4",
-        "lit-html": "^3.2.0"
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
       }
     },
     "node_modules/lit-html": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
-      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/local-pkg": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
+      "integrity": "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.4",
+        "pkg-types": "^2.3.0",
+        "quansync": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/locate-path": {
@@ -3328,45 +4849,67 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/loupe": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
-      "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/map-or-similar": {
@@ -3385,6 +4928,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/media-tracks": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/media-tracks/-/media-tracks-0.3.5.tgz",
+      "integrity": "sha512-l54rkKXlLBt3ob3zOLWHcnjvwUmX5bNEZ70igyapOZZC9imzqBmq1oz8p2roiV04KhjblFIi2hetLPF1oYVLRA==",
+      "license": "MIT"
     },
     "node_modules/memoizerific": {
       "version": "1.11.3",
@@ -3406,16 +4955,79 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mlly/node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -3429,6 +5041,44 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/nostr-tools": {
@@ -3511,2469 +5161,14 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/npm": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.3.0.tgz",
-      "integrity": "sha512-luthFIP0nFX3+nTfYbWI3p4hP4CiVnKOZ5jdxnF2x7B+Shz8feiSJCLLzgJUNxQ2cDdTaVUiH6RRsMT++vIMZg==",
-      "bundleDependencies": [
-        "@isaacs/string-locale-compare",
-        "@npmcli/arborist",
-        "@npmcli/config",
-        "@npmcli/fs",
-        "@npmcli/map-workspaces",
-        "@npmcli/package-json",
-        "@npmcli/promise-spawn",
-        "@npmcli/redact",
-        "@npmcli/run-script",
-        "@sigstore/tuf",
-        "abbrev",
-        "archy",
-        "cacache",
-        "chalk",
-        "ci-info",
-        "cli-columns",
-        "fastest-levenshtein",
-        "fs-minipass",
-        "glob",
-        "graceful-fs",
-        "hosted-git-info",
-        "ini",
-        "init-package-json",
-        "is-cidr",
-        "json-parse-even-better-errors",
-        "libnpmaccess",
-        "libnpmdiff",
-        "libnpmexec",
-        "libnpmfund",
-        "libnpmorg",
-        "libnpmpack",
-        "libnpmpublish",
-        "libnpmsearch",
-        "libnpmteam",
-        "libnpmversion",
-        "make-fetch-happen",
-        "minimatch",
-        "minipass",
-        "minipass-pipeline",
-        "ms",
-        "node-gyp",
-        "nopt",
-        "normalize-package-data",
-        "npm-audit-report",
-        "npm-install-checks",
-        "npm-package-arg",
-        "npm-pick-manifest",
-        "npm-profile",
-        "npm-registry-fetch",
-        "npm-user-validate",
-        "p-map",
-        "pacote",
-        "parse-conflict-json",
-        "proc-log",
-        "qrcode-terminal",
-        "read",
-        "semver",
-        "spdx-expression-parse",
-        "ssri",
-        "supports-color",
-        "tar",
-        "text-table",
-        "tiny-relative-date",
-        "treeverse",
-        "validate-npm-package-name",
-        "which"
-      ],
-      "license": "Artistic-2.0",
-      "workspaces": [
-        "docs",
-        "smoke-tests",
-        "mock-globals",
-        "mock-registry",
-        "workspaces/*"
-      ],
-      "dependencies": {
-        "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.0.2",
-        "@npmcli/config": "^10.2.0",
-        "@npmcli/fs": "^4.0.0",
-        "@npmcli/map-workspaces": "^4.0.2",
-        "@npmcli/package-json": "^6.1.1",
-        "@npmcli/promise-spawn": "^8.0.2",
-        "@npmcli/redact": "^3.1.1",
-        "@npmcli/run-script": "^9.1.0",
-        "@sigstore/tuf": "^3.0.0",
-        "abbrev": "^3.0.0",
-        "archy": "~1.0.0",
-        "cacache": "^19.0.1",
-        "chalk": "^5.4.1",
-        "ci-info": "^4.2.0",
-        "cli-columns": "^4.0.0",
-        "fastest-levenshtein": "^1.0.16",
-        "fs-minipass": "^3.0.3",
-        "glob": "^10.4.5",
-        "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^8.0.2",
-        "ini": "^5.0.0",
-        "init-package-json": "^8.0.0",
-        "is-cidr": "^5.1.1",
-        "json-parse-even-better-errors": "^4.0.0",
-        "libnpmaccess": "^10.0.0",
-        "libnpmdiff": "^8.0.2",
-        "libnpmexec": "^10.1.1",
-        "libnpmfund": "^7.0.2",
-        "libnpmorg": "^8.0.0",
-        "libnpmpack": "^9.0.2",
-        "libnpmpublish": "^11.0.0",
-        "libnpmsearch": "^9.0.0",
-        "libnpmteam": "^8.0.0",
-        "libnpmversion": "^8.0.0",
-        "make-fetch-happen": "^14.0.3",
-        "minimatch": "^9.0.5",
-        "minipass": "^7.1.1",
-        "minipass-pipeline": "^1.2.4",
-        "ms": "^2.1.2",
-        "node-gyp": "^11.2.0",
-        "nopt": "^8.1.0",
-        "normalize-package-data": "^7.0.0",
-        "npm-audit-report": "^6.0.0",
-        "npm-install-checks": "^7.1.1",
-        "npm-package-arg": "^12.0.2",
-        "npm-pick-manifest": "^10.0.0",
-        "npm-profile": "^11.0.1",
-        "npm-registry-fetch": "^18.0.2",
-        "npm-user-validate": "^3.0.0",
-        "p-map": "^7.0.3",
-        "pacote": "^21.0.0",
-        "parse-conflict-json": "^4.0.0",
-        "proc-log": "^5.0.0",
-        "qrcode-terminal": "^0.12.0",
-        "read": "^4.1.0",
-        "semver": "^7.7.1",
-        "spdx-expression-parse": "^4.0.0",
-        "ssri": "^12.0.0",
-        "supports-color": "^10.0.0",
-        "tar": "^6.2.1",
-        "text-table": "~0.2.0",
-        "tiny-relative-date": "^1.3.0",
-        "treeverse": "^3.0.0",
-        "validate-npm-package-name": "^6.0.0",
-        "which": "^5.0.0"
-      },
-      "bin": {
-        "npm": "bin/npm-cli.js",
-        "npx": "bin/npx-cli.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
-      "version": "1.1.0",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/@npmcli/agent": {
+    "node_modules/object-hash": {
       "version": "3.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.1",
-        "lru-cache": "^10.0.1",
-        "socks-proxy-agent": "^8.0.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/fs": "^4.0.0",
-        "@npmcli/installed-package-contents": "^3.0.0",
-        "@npmcli/map-workspaces": "^4.0.1",
-        "@npmcli/metavuln-calculator": "^9.0.0",
-        "@npmcli/name-from-folder": "^3.0.0",
-        "@npmcli/node-gyp": "^4.0.0",
-        "@npmcli/package-json": "^6.0.1",
-        "@npmcli/query": "^4.0.0",
-        "@npmcli/redact": "^3.0.0",
-        "@npmcli/run-script": "^9.0.1",
-        "bin-links": "^5.0.0",
-        "cacache": "^19.0.1",
-        "common-ancestor-path": "^1.0.1",
-        "hosted-git-info": "^8.0.0",
-        "json-stringify-nice": "^1.1.4",
-        "lru-cache": "^10.2.2",
-        "minimatch": "^9.0.4",
-        "nopt": "^8.0.0",
-        "npm-install-checks": "^7.1.0",
-        "npm-package-arg": "^12.0.0",
-        "npm-pick-manifest": "^10.0.0",
-        "npm-registry-fetch": "^18.0.1",
-        "pacote": "^21.0.0",
-        "parse-conflict-json": "^4.0.0",
-        "proc-log": "^5.0.0",
-        "proggy": "^3.0.0",
-        "promise-all-reject-late": "^1.0.0",
-        "promise-call-limit": "^3.0.1",
-        "read-package-json-fast": "^4.0.0",
-        "semver": "^7.3.7",
-        "ssri": "^12.0.0",
-        "treeverse": "^3.0.0",
-        "walk-up-path": "^4.0.0"
-      },
-      "bin": {
-        "arborist": "bin/index.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.2.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/map-workspaces": "^4.0.1",
-        "@npmcli/package-json": "^6.0.1",
-        "ci-info": "^4.0.0",
-        "ini": "^5.0.0",
-        "nopt": "^8.1.0",
-        "proc-log": "^5.0.0",
-        "semver": "^7.3.5",
-        "walk-up-path": "^4.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/fs": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "6.0.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/promise-spawn": "^8.0.0",
-        "ini": "^5.0.0",
-        "lru-cache": "^10.0.1",
-        "npm-pick-manifest": "^10.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
-        "semver": "^7.3.5",
-        "which": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-bundled": "^4.0.0",
-        "npm-normalize-package-bin": "^4.0.0"
-      },
-      "bin": {
-        "installed-package-contents": "bin/index.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/name-from-folder": "^3.0.0",
-        "@npmcli/package-json": "^6.0.0",
-        "glob": "^10.2.2",
-        "minimatch": "^9.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-      "version": "9.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "cacache": "^19.0.0",
-        "json-parse-even-better-errors": "^4.0.0",
-        "pacote": "^21.0.0",
-        "proc-log": "^5.0.0",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/name-from-folder": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/node-gyp": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "6.1.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/git": "^6.0.0",
-        "glob": "^10.2.2",
-        "hosted-git-info": "^8.0.0",
-        "json-parse-even-better-errors": "^4.0.0",
-        "proc-log": "^5.0.0",
-        "semver": "^7.5.3",
-        "validate-npm-package-license": "^3.0.4"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/promise-spawn": {
-      "version": "8.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "which": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/query": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "postcss-selector-parser": "^6.1.2"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/redact": {
-      "version": "3.1.1",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "9.1.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/node-gyp": "^4.0.0",
-        "@npmcli/package-json": "^6.0.0",
-        "@npmcli/promise-spawn": "^8.0.0",
-        "node-gyp": "^11.0.0",
-        "proc-log": "^5.0.0",
-        "which": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/bundle": {
-      "version": "3.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/protobuf-specs": "^0.4.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.4.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/sign": {
-      "version": "3.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/bundle": "^3.1.0",
-        "@sigstore/core": "^2.0.0",
-        "@sigstore/protobuf-specs": "^0.4.0",
-        "make-fetch-happen": "^14.0.2",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "3.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/protobuf-specs": "^0.4.0",
-        "tuf-js": "^3.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/verify": {
-      "version": "2.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/bundle": "^3.1.0",
-        "@sigstore/core": "^2.0.0",
-        "@sigstore/protobuf-specs": "^0.4.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@tufjs/canonical-json": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@tufjs/models": {
-      "version": "3.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tufjs/canonical-json": "2.0.0",
-        "minimatch": "^9.0.5"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/abbrev": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/agent-base": {
-      "version": "7.1.3",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/aproba": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/archy": {
-      "version": "1.0.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/bin-links": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "cmd-shim": "^7.0.0",
-        "npm-normalize-package-bin": "^4.0.0",
-        "proc-log": "^5.0.0",
-        "read-cmd-shim": "^5.0.0",
-        "write-file-atomic": "^6.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/binary-extensions": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/cacache": {
-      "version": "19.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^4.0.0",
-        "fs-minipass": "^3.0.0",
-        "glob": "^10.2.2",
-        "lru-cache": "^10.0.1",
-        "minipass": "^7.0.3",
-        "minipass-collect": "^2.0.1",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "p-map": "^7.0.2",
-        "ssri": "^12.0.0",
-        "tar": "^7.4.3",
-        "unique-filename": "^4.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/cacache/node_modules/chownr": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/cacache/node_modules/minizlib": {
-      "version": "3.0.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/npm/node_modules/cacache/node_modules/mkdirp": {
-      "version": "3.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/cacache/node_modules/tar": {
-      "version": "7.4.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/cacache/node_modules/yallist": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/chalk": {
-      "version": "5.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/chownr": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/ci-info": {
-      "version": "4.2.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/cidr-regex": {
-      "version": "4.1.3",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "ip-regex": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/npm/node_modules/cli-columns": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/npm/node_modules/cmd-shim": {
-      "version": "7.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/color-convert": {
-      "version": "2.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/color-name": {
-      "version": "1.1.4",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/common-ancestor-path": {
-      "version": "1.0.1",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
-      "version": "2.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/cssesc": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm/node_modules/debug": {
-      "version": "4.4.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/npm/node_modules/diff": {
-      "version": "7.0.0",
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/npm/node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/encoding": {
-      "version": "0.1.13",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/npm/node_modules/env-paths": {
-      "version": "2.2.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/npm/node_modules/err-code": {
-      "version": "2.0.3",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/exponential-backoff": {
-      "version": "3.1.2",
-      "inBundle": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/npm/node_modules/fastest-levenshtein": {
-      "version": "1.0.16",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.9.1"
-      }
-    },
-    "node_modules/npm/node_modules/foreground-child": {
-      "version": "3.3.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/fs-minipass": {
-      "version": "3.0.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/glob": {
-      "version": "10.4.5",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "8.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^10.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/http-cache-semantics": {
-      "version": "4.1.1",
-      "inBundle": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/npm/node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm/node_modules/ignore-walk": {
-      "version": "7.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minimatch": "^9.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
-    "node_modules/npm/node_modules/ini": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/init-package-json": {
-      "version": "8.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/package-json": "^6.1.0",
-        "npm-package-arg": "^12.0.0",
-        "promzard": "^2.0.0",
-        "read": "^4.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4",
-        "validate-npm-package-name": "^6.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/ip-address": {
-      "version": "9.0.5",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/npm/node_modules/ip-regex": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/is-cidr": {
-      "version": "5.1.1",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "cidr-regex": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/npm/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/isexe": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/npm/node_modules/jsbn": {
-      "version": "1.1.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/json-parse-even-better-errors": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/json-stringify-nice": {
-      "version": "1.1.4",
-      "inBundle": true,
-      "license": "ISC",
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/jsonparse": {
-      "version": "1.3.1",
-      "engines": [
-        "node >= 0.2.0"
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/just-diff": {
-      "version": "6.0.2",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/just-diff-apply": {
-      "version": "5.5.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/libnpmaccess": {
-      "version": "10.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-package-arg": "^12.0.0",
-        "npm-registry-fetch": "^18.0.1"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^9.0.2",
-        "@npmcli/installed-package-contents": "^3.0.0",
-        "binary-extensions": "^3.0.0",
-        "diff": "^7.0.0",
-        "minimatch": "^9.0.4",
-        "npm-package-arg": "^12.0.0",
-        "pacote": "^21.0.0",
-        "tar": "^6.2.1"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.1.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^9.0.2",
-        "@npmcli/package-json": "^6.1.1",
-        "@npmcli/run-script": "^9.0.1",
-        "ci-info": "^4.0.0",
-        "npm-package-arg": "^12.0.0",
-        "pacote": "^21.0.0",
-        "proc-log": "^5.0.0",
-        "read": "^4.0.0",
-        "read-package-json-fast": "^4.0.0",
-        "semver": "^7.3.7",
-        "walk-up-path": "^4.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^9.0.2"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmorg": {
-      "version": "8.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^18.0.1"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^9.0.2",
-        "@npmcli/run-script": "^9.0.1",
-        "npm-package-arg": "^12.0.0",
-        "pacote": "^21.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "11.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "ci-info": "^4.0.0",
-        "normalize-package-data": "^7.0.0",
-        "npm-package-arg": "^12.0.0",
-        "npm-registry-fetch": "^18.0.1",
-        "proc-log": "^5.0.0",
-        "semver": "^7.3.7",
-        "sigstore": "^3.0.0",
-        "ssri": "^12.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmsearch": {
-      "version": "9.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-registry-fetch": "^18.0.1"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmteam": {
-      "version": "8.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^18.0.1"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmversion": {
-      "version": "8.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/git": "^6.0.1",
-        "@npmcli/run-script": "^9.0.1",
-        "json-parse-even-better-errors": "^4.0.0",
-        "proc-log": "^5.0.0",
-        "semver": "^7.3.7"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "14.0.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/agent": "^3.0.0",
-        "cacache": "^19.0.1",
-        "http-cache-semantics": "^4.1.1",
-        "minipass": "^7.0.2",
-        "minipass-fetch": "^4.0.0",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^1.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
-        "ssri": "^12.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/make-fetch-happen/node_modules/negotiator": {
-      "version": "1.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/npm/node_modules/minimatch": {
-      "version": "9.0.5",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/minipass": {
-      "version": "7.1.2",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-collect": {
-      "version": "2.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "4.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.0.3",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^3.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.13"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-fetch/node_modules/minizlib": {
-      "version": "3.0.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.5",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-pipeline": {
-      "version": "1.2.4",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
-      "version": "3.3.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-sized": {
-      "version": "1.0.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
-      "version": "3.3.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minizlib": {
-      "version": "2.1.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/ms": {
-      "version": "2.1.3",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/mute-stream": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp": {
-      "version": "11.2.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.0",
-        "exponential-backoff": "^3.1.1",
-        "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^14.0.3",
-        "nopt": "^8.0.0",
-        "proc-log": "^5.0.0",
-        "semver": "^7.3.5",
-        "tar": "^7.4.3",
-        "tinyglobby": "^0.2.12",
-        "which": "^5.0.0"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/chownr": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/minizlib": {
-      "version": "3.0.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/mkdirp": {
-      "version": "3.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/tar": {
-      "version": "7.4.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/yallist": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/nopt": {
-      "version": "8.1.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "^3.0.0"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/normalize-package-data": {
-      "version": "7.0.0",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^8.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-audit-report": {
-      "version": "6.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-bundled": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-normalize-package-bin": "^4.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-install-checks": {
-      "version": "7.1.1",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "semver": "^7.1.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-normalize-package-bin": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-package-arg": {
-      "version": "12.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "hosted-git-info": "^8.0.0",
-        "proc-log": "^5.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-name": "^6.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-packlist": {
-      "version": "10.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "ignore-walk": "^7.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-pick-manifest": {
-      "version": "10.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-install-checks": "^7.1.0",
-        "npm-normalize-package-bin": "^4.0.0",
-        "npm-package-arg": "^12.0.0",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-profile": {
-      "version": "11.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-registry-fetch": "^18.0.0",
-        "proc-log": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "18.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/redact": "^3.0.0",
-        "jsonparse": "^1.3.1",
-        "make-fetch-happen": "^14.0.0",
-        "minipass": "^7.0.2",
-        "minipass-fetch": "^4.0.0",
-        "minizlib": "^3.0.1",
-        "npm-package-arg": "^12.0.0",
-        "proc-log": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-registry-fetch/node_modules/minizlib": {
-      "version": "3.0.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/npm/node_modules/npm-user-validate": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/p-map": {
-      "version": "7.0.3",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "inBundle": true,
-      "license": "BlueOak-1.0.0"
-    },
-    "node_modules/npm/node_modules/pacote": {
-      "version": "21.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/git": "^6.0.0",
-        "@npmcli/installed-package-contents": "^3.0.0",
-        "@npmcli/package-json": "^6.0.0",
-        "@npmcli/promise-spawn": "^8.0.0",
-        "@npmcli/run-script": "^9.0.0",
-        "cacache": "^19.0.0",
-        "fs-minipass": "^3.0.0",
-        "minipass": "^7.0.2",
-        "npm-package-arg": "^12.0.0",
-        "npm-packlist": "^10.0.0",
-        "npm-pick-manifest": "^10.0.0",
-        "npm-registry-fetch": "^18.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
-        "sigstore": "^3.0.0",
-        "ssri": "^12.0.0",
-        "tar": "^6.1.11"
-      },
-      "bin": {
-        "pacote": "bin/index.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/parse-conflict-json": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "json-parse-even-better-errors": "^4.0.0",
-        "just-diff": "^6.0.0",
-        "just-diff-apply": "^5.2.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/path-key": {
-      "version": "3.1.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm/node_modules/proc-log": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/proggy": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/promise-all-reject-late": {
-      "version": "1.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/promise-call-limit": {
-      "version": "3.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/promise-retry": {
-      "version": "2.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/promzard": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "read": "^4.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/qrcode-terminal": {
-      "version": "0.12.0",
-      "inBundle": true,
-      "bin": {
-        "qrcode-terminal": "bin/qrcode-terminal.js"
-      }
-    },
-    "node_modules/npm/node_modules/read": {
-      "version": "4.1.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "mute-stream": "^2.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/read-cmd-shim": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/read-package-json-fast": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "json-parse-even-better-errors": "^4.0.0",
-        "npm-normalize-package-bin": "^4.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/retry": {
-      "version": "0.12.0",
-      "inBundle": true,
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/npm/node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/npm/node_modules/semver": {
-      "version": "7.7.1",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/sigstore": {
-      "version": "3.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/bundle": "^3.1.0",
-        "@sigstore/core": "^2.0.0",
-        "@sigstore/protobuf-specs": "^0.4.0",
-        "@sigstore/sign": "^3.1.0",
-        "@sigstore/tuf": "^3.1.0",
-        "@sigstore/verify": "^2.1.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/socks": {
-      "version": "2.8.4",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^9.0.5",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/socks-proxy-agent": {
-      "version": "8.0.5",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "socks": "^2.8.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-exceptions": {
-      "version": "2.5.0",
-      "inBundle": true,
-      "license": "CC-BY-3.0"
-    },
-    "node_modules/npm/node_modules/spdx-expression-parse": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.21",
-      "inBundle": true,
-      "license": "CC0-1.0"
-    },
-    "node_modules/npm/node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "inBundle": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/npm/node_modules/ssri": {
-      "version": "12.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/string-width": {
-      "version": "4.2.3",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/supports-color": {
-      "version": "10.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/tar": {
-      "version": "6.2.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/text-table": {
-      "version": "0.2.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/tiny-relative-date": {
-      "version": "1.3.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.12",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "fdir": "^6.4.3",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.3",
-      "inBundle": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/npm/node_modules/treeverse": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/tuf-js": {
-      "version": "3.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tufjs/models": "3.0.1",
-        "debug": "^4.3.6",
-        "make-fetch-happen": "^14.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/unique-filename": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/unique-slug": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "6.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/walk-up-path": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/npm/node_modules/which": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/which/node_modules/isexe": {
-      "version": "3.1.1",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "5.1.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/write-file-atomic": {
-      "version": "6.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^4.0.1"
-      },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": ">= 6"
       }
-    },
-    "node_modules/npm/node_modules/yallist": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -5986,6 +5181,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/open": {
@@ -6042,6 +5260,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6050,6 +5281,45 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pathval": {
       "version": "2.0.0",
@@ -6068,6 +5338,31 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
+        "pathe": "^2.0.3"
+      }
+    },
     "node_modules/pngjs": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
@@ -6077,33 +5372,10 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/polished": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-4.3.1.tgz",
-      "integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.17.8"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/possible-typed-array-names": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -6121,7 +5393,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6145,42 +5417,39 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
+    "node_modules/proto3-json-serializer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
+      "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
+        "protobufjs": "^7.4.0"
       },
       "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "node": ">=18"
       }
     },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
+    "node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
       },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">= 0.6.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/qrcode": {
@@ -6216,6 +5485,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/quansync": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/ramda": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.0.tgz",
@@ -6237,22 +5523,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-confetti": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/react-confetti/-/react-confetti-6.4.0.tgz",
-      "integrity": "sha512-5MdGUcqxrTU26I2EU7ltkWPwxvucQTuqMm8dUz72z2YMqTD6s9vMcDUysk7n9jnC+lXuCPeJJ7Knf98VEYE9Rg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tween-functions": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.1 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
@@ -6266,12 +5536,19 @@
         "react": "^19.1.0"
       }
     },
-    "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT"
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/recast": {
       "version": "0.23.11",
@@ -6304,17 +5581,20 @@
         "node": ">=8"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6325,6 +5605,90 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "license": "ISC"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/retry-request": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.3.tgz",
+      "integrity": "sha512-qqoc4kkGgP9cmQDWELlOpAmfgJOg0Yi7MT82ZjiPWu451ayju4itwomjM4/dBEliify8C1b3tSaeCOldugtwPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
     },
     "node_modules/rollup": {
       "version": "4.39.0",
@@ -6366,23 +5730,25 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/safe-regex-test": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-regex": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.26.0",
@@ -6392,9 +5758,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -6410,22 +5776,25 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC"
     },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "license": "MIT",
       "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
+        "shebang-regex": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.4"
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/side-channel": {
@@ -6504,6 +5873,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -6524,6 +5912,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/store2": {
       "version": "2.14.4",
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.14.4.tgz",
@@ -6532,17 +5941,26 @@
       "license": "MIT"
     },
     "node_modules/storybook": {
-      "version": "8.6.12",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.6.12.tgz",
-      "integrity": "sha512-Z/nWYEHBTLK1ZBtAWdhxC0l5zf7ioJ7G4+zYqtTdYeb67gTnxNj80gehf8o8QY9L2zA2+eyMRGLC2V5fI7Z3Tw==",
+      "version": "9.1.20",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.20.tgz",
+      "integrity": "sha512-6rME2tww6PFhm96iG2Xx44yzwLDWBiDWy+kJ2ub6x90werSTOiuo+tZJ94BgCfFutR0tEfLRIq59s+Zg6YyChA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/core": "8.6.12"
+        "@storybook/global": "^5.0.0",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/user-event": "^14.6.1",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "better-opn": "^3.0.2",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0",
+        "esbuild-register": "^3.5.0",
+        "recast": "^0.23.5",
+        "semver": "^7.6.2",
+        "ws": "^8.18.0"
       },
       "bin": {
-        "getstorybook": "bin/index.cjs",
-        "sb": "bin/index.cjs",
         "storybook": "bin/index.cjs"
       },
       "funding": {
@@ -6558,6 +5976,159 @@
         }
       }
     },
+    "node_modules/storybook/node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/storybook/node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/storybook/node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/storybook/node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/storybook/node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/storybook/node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/storybook/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/storybook/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/storybook/node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "license": "MIT",
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -6567,6 +6138,33 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -6588,7 +6186,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -6600,11 +6197,23 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi/node_modules/ansi-regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6626,6 +6235,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6639,12 +6254,40 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/synchronous-promise": {
       "version": "2.0.17",
       "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.17.tgz",
       "integrity": "sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/teeny-request": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.3.tgz",
+      "integrity": "sha512-5yDliI1uWkYPo7W+Zvrxg6YmoWuj5iC5EydewqrRTvc68nyMTZhlPPlLg6cptUGfbQAb+N9XDPDPzF6N081lug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/telejson": {
       "version": "7.2.0",
@@ -6663,24 +6306,38 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/tinyrainbow": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
-      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18"
       }
     },
-    "node_modules/tinyspy": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
-      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
     "node_modules/ts-dedent": {
@@ -6706,13 +6363,6 @@
       "dev": true,
       "license": "0BSD"
     },
-    "node_modules/tween-functions": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tween-functions/-/tween-functions-1.2.0.tgz",
-      "integrity": "sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==",
-      "dev": true,
-      "license": "BSD"
-    },
     "node_modules/type-fest": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
@@ -6727,10 +6377,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "devOptional": true,
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -6744,6 +6394,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/typescript-lru-cache/-/typescript-lru-cache-2.0.0.tgz",
       "integrity": "sha512-Jp57Qyy8wXeMkdNuZiglE6v2Cypg13eDA1chHwDG6kq51X7gk4K7P7HaDdzZKCxkegXkVHNcPD0n5aW6OZH3aA==",
+      "license": "MIT"
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/undici-types": {
@@ -6776,40 +6433,11 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/vite": {
       "version": "5.4.18",
@@ -6867,6 +6495,33 @@
           "optional": true
         },
         "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-dts": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-4.5.4.tgz",
+      "integrity": "sha512-d4sOM8M/8z7vRXHHq/ebbblfaxENjogAAekcfcDCCwAyvGqnPrc7f4NZbvItS+g4WTgerW0xDwSz5qz11JT3vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/api-extractor": "^7.50.1",
+        "@rollup/pluginutils": "^5.1.4",
+        "@volar/typescript": "^2.4.11",
+        "@vue/language-core": "2.2.0",
+        "compare-versions": "^6.1.1",
+        "debug": "^4.4.0",
+        "kolorist": "^1.8.0",
+        "local-pkg": "^1.0.0",
+        "magic-string": "^0.30.17"
+      },
+      "peerDependencies": {
+        "typescript": "*",
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
           "optional": true
         }
       }
@@ -7301,6 +6956,293 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
@@ -7308,32 +7250,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/which-module": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "license": "ISC"
     },
-    "node_modules/which-typed-array": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "for-each": "^0.3.5",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2"
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
       },
       "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {
@@ -7345,6 +7297,36 @@
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -7362,10 +7344,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -101,6 +101,10 @@
     "build:assets": "node scripts/copy-assets.js",
     "build": "npm run build:esm && npm run build:umd && npm run build:themes && npm run build:assets",
     "crawl:directory": "node scripts/relay-directory-crawler.mjs",
+    "crawl:directory:gcloud": "node scripts/relay-directory-crawler.mjs --project-directory --firestore-project gr-prod --no-json",
+    "crawl:directory:backfill": "node scripts/relay-directory-crawler.mjs --backfill --firestore-project gr-prod",
+    "crawl:directory:live": "node scripts/relay-directory-crawler.mjs --live-listen --firestore-project gr-prod",
+    "crawl:directory:project": "node scripts/relay-directory-crawler.mjs --project-directory --firestore-project gr-prod",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "cross-env STORYBOOK_ENV=production storybook build && npm run build:themes",
@@ -134,6 +138,7 @@
   },
   "dependencies": {
     "@glidejs/glide": "^3.7.1",
+    "@google-cloud/firestore": "^8.6.0",
     "@nostr-dev-kit/ndk": "^2.10.0",
     "@types/dompurify": "^3.0.5",
     "@types/qrcode": "^1.5.5",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "build:themes": "node scripts/build-themes.js",
     "build:assets": "node scripts/copy-assets.js",
     "build": "npm run build:esm && npm run build:umd && npm run build:themes && npm run build:assets",
+    "crawl:directory": "node scripts/relay-directory-crawler.mjs",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "cross-env STORYBOOK_ENV=production storybook build && npm run build:themes",

--- a/problems-to-tackle-on-upgrade.txt
+++ b/problems-to-tackle-on-upgrade.txt
@@ -1,0 +1,287 @@
+i think nextuntil = oldest,  is best option, with de-dupe wvnt, and detect stuck page, ,,, but again i see a problem, when we do nextuntil = oldest with 100 limit, but actual are 500 at that time, and on every nextuntil = oldest, we get same 100?, what we do for that, and also how we detect stuck page and how we resolve it
+
+
+/// learn 
+
+1. how zap works
+
+
+/// staged rollout for relay directory system
+
+Stage 0 - Local proof
+- Goal: prove crawler logic and Firestore write shapes locally.
+- Runtime: local CLI.
+- Done when:
+  - unit tests pass
+  - smoke collections receive test docs
+  - raw event shape is Firestore-safe
+
+Stage 1 - Historical backfill seed
+- Goal: seed old valid signed Nostr identity/profile events.
+- Runtime: Cloud Run Job.
+- Reads: public Nostr relays.
+- Writes:
+  - nostrIdentityEvents
+  - relayCrawlerState
+  - relayCrawlerGaps
+- Key risks:
+  - relay timeout
+  - same-timestamp pagination gaps
+  - duplicate events across relays
+
+Stage 2 - Projection worker
+- Goal: turn raw events into clean directory records.
+- Runtime: scheduled Cloud Run Job first.
+- Reads:
+  - nostrIdentityEvents
+- Writes:
+  - nostrDirectoryEntries
+  - nostrDirectoryHandles
+  - processing/identity status fields on raw events
+- Later upgrade:
+  - process queue.status pending/retry_later docs in batches
+  - add locks
+  - add concurrency
+  - add candidate records per handle/pubkey
+
+Stage 3 - Browser/API lookup
+- Goal: serve fast answers to the extension.
+- Runtime: Cloud Run Service or direct secure API layer.
+- Reads:
+  - nostrDirectoryHandles
+- Must not query relays in user path.
+
+Stage 4 - Live relay listener
+- Goal: ingest new events after backfill.
+- Runtime: Cloud Run Worker Pool or long-running Cloud Run service with min instances.
+- Reads: public Nostr relays over wss.
+- Writes:
+  - nostrIdentityEvents with pending queue state when not already terminal
+- Key risks:
+  - reconnect handling
+  - relay outages
+  - duplicate events
+
+Stage 5 - Queue/concurrency hardening
+- Goal: keep projection queue draining at scale.
+- Runtime: Cloud Run Job or worker service.
+- Design:
+  - query queue.status pending/retry_later events
+  - claim docs with processing.status = processing
+  - process with bounded concurrency
+  - retry temporary failures with nextRetryAt
+  - release expired locks
+
+Stage 6 - Retention and cleanup
+- Goal: control Firestore size/cost while keeping useful evidence.
+- Keep longer:
+  - verified kind:10011 proof events
+  - current useful kind:0 metadata
+  - conflict evidence
+  - gap records
+- Delete/archive later:
+  - ignored no-identity events after retention window
+  - old superseded kind:0 raw events
+  - permanent rejected low-value records after audit window
+
+Stage 7 - Event-driven wakeup optimization
+- Goal: reduce projection delay without creating trigger storms.
+- Avoid:
+  - one Firestore trigger per raw event
+- Prefer:
+  - wakeup doc
+  - Pub/Sub
+  - Cloud Tasks
+  - scheduled worker as fallback
+
+
+/// monitoring strategy
+
+First implementation
+- Write one summary document per job run.
+- Also log the same summary as structured JSON.
+- Do not write one metric document per event.
+
+Run summary collections
+- relayBackfillRuns: historical backfill run summaries
+- relayProjectionRuns: Firestore projection run summaries
+- relayLiveListenerRuns: live listener run/heartbeat summaries
+
+Run summary fields
+- runId
+- component
+- startedAt
+- finishedAt
+- durationMs
+- memoryRssMb
+- avgProcessingMs
+- p95ProcessingMs
+- counters
+- stats
+- firestore
+- relays
+
+Backfill metrics
+- pagesProcessed
+- relayEventsSeen
+- validEventsSeen
+- invalidEventsDropped
+- eventsWritten
+- cursorUntil
+- oldestSeenAt
+- gapsWritten
+- timeouts
+- relayErrors
+- durationMs
+
+Live listener metrics
+- connectedRelays
+- reconnectCount
+- eventsReceivedPerMinute
+- validEventsWrittenPerMinute
+- duplicateEvents
+- invalidEvents
+- lastEventAt
+- relayDisconnects
+
+Projection metrics
+- pendingCount
+- retryLaterCount
+- processingCount
+- processedCount
+- ignoredCount
+- verifiedCount
+- rejectedCount
+- claimedCount
+- conflictedCount
+- avgProcessingMs
+- p95ProcessingMs
+- externalFetchFailures
+- xProofTimeouts
+- lnurlFailures
+- queueDrainRate
+
+Firestore/cost metrics
+- documentReads
+- documentWrites
+- documentDeletes
+- storageBytes
+- index count
+- collection sizes
+- estimated daily cost
+
+Product/API metrics
+- lookupRequests
+- lookupHitRate
+- verifiedHitRate
+- claimedOnlyRate
+- notFoundRate
+- apiLatencyP50
+- apiLatencyP95
+- autoZapAllowedRate
+
+Alerts
+- pendingCount keeps increasing
+- projection job fails repeatedly
+- live listener receives no events for too long
+- backfill cursor stops moving
+- gapsWritten spikes
+- Firestore errors spike
+- X proof failures spike
+- API p95 latency too high
+- daily cost exceeds budget
+
+
+///////////////////////////////////////
+
+Live listener offline
+If listener is down, relays may emit events we miss.
+
+Backfill overlap strategy implemented in code
+Use short scheduled backfill windows with --backfill-state-prefix overlap,
+--no-backfill-resume, --backfill-until now, and --backfill-since now-window.
+This recovers missed live events without overwriting historical backfill state.
+First deploy setting: run every 30 minutes with a 45 minute window, giving a
+15 minute safety margin beyond the normal interval. Still need to enable/deploy
+Cloud Scheduler or another scheduler in GCP.
+
+Queue claiming implemented in code
+Projection now transactionally claims queue docs with status=processing,
+lockedBy, and lockExpiresAt before reading raw events. Expired processing locks
+can be reclaimed by a later projection run.
+
+Retry timing implemented in claim check
+retry_later queue docs are claimed only when nextAttemptAt <= now.
+
+Projection concurrency not implemented
+Projection still processes the selected batch as one batch, not a bounded worker pool.
+
+Missing raw event for queue doc
+If a queue doc exists but raw event doc is missing/corrupt, we need a clear failure state.
+
+Monitoring alerts not deployed
+We write summaries/heartbeats, but alerts are not configured yet.
+
+Firestore cost/backlog unknown
+Partially implemented in projection summaries. Projection now records queue
+status counts before the run and counters for claimed/read/valid/missing/invalid
+docs. Still need Cloud Monitoring dashboard and billing alerts.
+
+X/Twitter verification reliability
+Retry classification implemented in code for proof fetching. HTTP 429 and other
+temporary external failures schedule retry_later instead of permanent rejection;
+429 also stops further proof checks in that projection run. Still need observe
+real failure rates after deploy.
+
+Retention cleanup
+Ignored/rejected/old raw events can grow Firestore storage if we never clean them.
+
+
+/// deploy today safety checklist
+
+Goal
+- Deploy only after the system can ingest, recover missed live windows, drain the
+  projection queue safely, and show enough metrics that we can see harm early.
+
+Already implemented in code
+- Historical backfill paging with checkpoints and gap recording.
+- Live listener with reconnects, bounded in-memory dedupe, buffering, and
+  heartbeat docs.
+- Raw event storage in nostrIdentityEvents.
+- Projection queue docs in nostrProjectionQueue, created only if missing.
+- Overlap backfill state prefix so recovery windows use overlap:* state instead
+  of overwriting historical backfill:* state.
+- Projection queue claiming with lockedBy and lockExpiresAt.
+- retry_later claim check using nextAttemptAt <= now.
+
+Must understand before deploy
+- How overlap backfill recovers missed live events.
+- Why overlap state must be separate from historical backfill state.
+- How a queue doc can exist while its raw event doc is missing/corrupt.
+- What Firestore reads/writes/backlog/drain rate tell us.
+- Why X/Twitter verification must classify temporary vs permanent failures.
+
+Must solve or explicitly accept before deploy
+- Missing/corrupt raw event for queue doc gets a clear terminal or retry state.
+  DONE in code: queue docs become failed with missing_raw_event/invalid_raw_event.
+- Projection run summary includes enough backlog/cost counters to inspect after
+  deploy. PARTIAL in code: queue status counts and projection counters are
+  written; dashboard/alerts still not deployed.
+- X/Twitter temporary failures do not permanently reject good identity proofs.
+  DONE in code: retryable fetch failures become retry_later.
+- Cloud Run, Cloud Scheduler, Cloud Build, and Artifact Registry APIs are
+  enabled only when ready to deploy.
+- Billing budget/alerts are configured before any long-running worker is left on.
+
+Deploy order
+- Run unit tests.
+- Run smoke backfill into CodexSmoke collections.
+- Run smoke live listener into CodexSmoke collections.
+- Run smoke projection against CodexSmoke queue.
+- Inspect Firestore counts and run summaries.
+- Enable required GCP APIs.
+- Deploy scheduled projection job.
+- Deploy historical backfill job.
+- Deploy live listener.
+- Add overlap backfill schedule.
+- Watch first run summaries, backlog, errors, and billing.

--- a/scripts/deploy-relay-directory-backfill.sh
+++ b/scripts/deploy-relay-directory-backfill.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-gr-prod}"
+REGION="${REGION:-us-central1}"
+JOB_NAME="${JOB_NAME:-relay-directory-backfill}"
+IMAGE_JOB_NAME="${IMAGE_JOB_NAME:-relay-directory-crawler}"
+IMAGE="gcr.io/${PROJECT_ID}/${IMAGE_JOB_NAME}:latest"
+SERVICE_ACCOUNT="${SERVICE_ACCOUNT:-relay-directory-crawler@${PROJECT_ID}.iam.gserviceaccount.com}"
+BACKFILL_MAX_PAGES="${BACKFILL_MAX_PAGES:-200}"
+BACKFILL_PAGE_LIMIT="${BACKFILL_PAGE_LIMIT:-500}"
+BACKFILL_MAX_PAGE_LIMIT="${BACKFILL_MAX_PAGE_LIMIT:-2000}"
+BACKFILL_SINCE="${BACKFILL_SINCE:-0}"
+
+gcloud config set project "${PROJECT_ID}"
+gcloud services enable run.googleapis.com firestore.googleapis.com cloudbuild.googleapis.com
+
+if ! gcloud iam service-accounts describe "${SERVICE_ACCOUNT}" >/dev/null 2>&1; then
+  gcloud iam service-accounts create relay-directory-crawler \
+    --display-name="Relay Directory Crawler"
+fi
+
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+  --member="serviceAccount:${SERVICE_ACCOUNT}" \
+  --role="roles/datastore.user" \
+  --condition=None >/dev/null
+
+gcloud builds submit \
+  --config cloudbuild.relay-directory-crawler.yaml \
+  --substitutions "_IMAGE=${IMAGE}" .
+
+gcloud run jobs deploy "${JOB_NAME}" \
+  --image "${IMAGE}" \
+  --region "${REGION}" \
+  --service-account "${SERVICE_ACCOUNT}" \
+  --set-env-vars "GOOGLE_CLOUD_PROJECT=${PROJECT_ID},FIRESTORE_PROJECT=${PROJECT_ID}" \
+  --args "scripts/relay-directory-crawler.mjs,--backfill,--firestore-project,${PROJECT_ID},--backfill-max-pages,${BACKFILL_MAX_PAGES},--backfill-page-limit,${BACKFILL_PAGE_LIMIT},--backfill-max-page-limit,${BACKFILL_MAX_PAGE_LIMIT},--backfill-since,${BACKFILL_SINCE}" \
+  --max-retries 1 \
+  --task-timeout 3600
+
+gcloud run jobs execute "${JOB_NAME}" --region "${REGION}"

--- a/scripts/deploy-relay-directory-crawler.sh
+++ b/scripts/deploy-relay-directory-crawler.sh
@@ -56,4 +56,6 @@ gcloud scheduler jobs update http "${SCHEDULE_NAME}" \
   --oauth-token-scope "https://www.googleapis.com/auth/cloud-platform" \
   --attempt-deadline 1800s
 
-gcloud run jobs execute "${JOB_NAME}" --region "${REGION}"
+if [ "${RUN_AFTER_DEPLOY:-false}" = "true" ]; then
+  gcloud run jobs execute "${JOB_NAME}" --region "${REGION}"
+fi

--- a/scripts/deploy-relay-directory-crawler.sh
+++ b/scripts/deploy-relay-directory-crawler.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-gr-prod}"
+REGION="${REGION:-us-central1}"
+JOB_NAME="${JOB_NAME:-relay-directory-projector}"
+SCHEDULE_NAME="${SCHEDULE_NAME:-relay-directory-projector-hourly}"
+IMAGE="gcr.io/${PROJECT_ID}/${JOB_NAME}:latest"
+SERVICE_ACCOUNT="${SERVICE_ACCOUNT:-relay-directory-crawler@${PROJECT_ID}.iam.gserviceaccount.com}"
+
+gcloud config set project "${PROJECT_ID}"
+gcloud services enable run.googleapis.com cloudscheduler.googleapis.com firestore.googleapis.com cloudbuild.googleapis.com
+
+if ! gcloud iam service-accounts describe "${SERVICE_ACCOUNT}" >/dev/null 2>&1; then
+  gcloud iam service-accounts create relay-directory-crawler \
+    --display-name="Relay Directory Crawler"
+fi
+
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+  --member="serviceAccount:${SERVICE_ACCOUNT}" \
+  --role="roles/datastore.user" \
+  --condition=None >/dev/null
+
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+  --member="serviceAccount:${SERVICE_ACCOUNT}" \
+  --role="roles/run.developer" \
+  --condition=None >/dev/null
+
+gcloud builds submit \
+  --config cloudbuild.relay-directory-crawler.yaml \
+  --substitutions "_IMAGE=${IMAGE}" .
+
+gcloud run jobs deploy "${JOB_NAME}" \
+  --image "${IMAGE}" \
+  --region "${REGION}" \
+  --service-account "${SERVICE_ACCOUNT}" \
+  --set-env-vars "GOOGLE_CLOUD_PROJECT=${PROJECT_ID},FIRESTORE_PROJECT=${PROJECT_ID},WRITE_FIRESTORE=1" \
+  --args "scripts/relay-directory-crawler.mjs,--project-directory,--firestore-project,${PROJECT_ID},--no-json" \
+  --max-retries 1 \
+  --task-timeout 1800
+
+gcloud scheduler jobs create http "${SCHEDULE_NAME}" \
+  --location "${REGION}" \
+  --schedule "0 * * * *" \
+  --uri "https://run.googleapis.com/v2/projects/${PROJECT_ID}/locations/${REGION}/jobs/${JOB_NAME}:run" \
+  --http-method POST \
+  --oauth-service-account-email "${SERVICE_ACCOUNT}" \
+  --oauth-token-scope "https://www.googleapis.com/auth/cloud-platform" \
+  --attempt-deadline 1800s || \
+gcloud scheduler jobs update http "${SCHEDULE_NAME}" \
+  --location "${REGION}" \
+  --schedule "0 * * * *" \
+  --uri "https://run.googleapis.com/v2/projects/${PROJECT_ID}/locations/${REGION}/jobs/${JOB_NAME}:run" \
+  --http-method POST \
+  --oauth-service-account-email "${SERVICE_ACCOUNT}" \
+  --oauth-token-scope "https://www.googleapis.com/auth/cloud-platform" \
+  --attempt-deadline 1800s
+
+gcloud run jobs execute "${JOB_NAME}" --region "${REGION}"

--- a/scripts/deploy-relay-directory-live-listener.sh
+++ b/scripts/deploy-relay-directory-live-listener.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-gr-prod}"
+REGION="${REGION:-us-central1}"
+WORKER_POOL_NAME="${WORKER_POOL_NAME:-relay-directory-live-listener}"
+IMAGE_JOB_NAME="${IMAGE_JOB_NAME:-relay-directory-crawler}"
+IMAGE="gcr.io/${PROJECT_ID}/${IMAGE_JOB_NAME}:latest"
+SERVICE_ACCOUNT="${SERVICE_ACCOUNT:-relay-directory-crawler@${PROJECT_ID}.iam.gserviceaccount.com}"
+INSTANCE_COUNT="${INSTANCE_COUNT:-1}"
+LIVE_FLUSH_LIMIT="${LIVE_FLUSH_LIMIT:-25}"
+LIVE_FLUSH_INTERVAL_MS="${LIVE_FLUSH_INTERVAL_MS:-5000}"
+LIVE_HEARTBEAT_INTERVAL_MS="${LIVE_HEARTBEAT_INTERVAL_MS:-30000}"
+
+gcloud config set project "${PROJECT_ID}"
+gcloud services enable run.googleapis.com firestore.googleapis.com cloudbuild.googleapis.com
+
+if ! gcloud iam service-accounts describe "${SERVICE_ACCOUNT}" >/dev/null 2>&1; then
+  gcloud iam service-accounts create relay-directory-crawler \
+    --display-name="Relay Directory Crawler"
+fi
+
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+  --member="serviceAccount:${SERVICE_ACCOUNT}" \
+  --role="roles/datastore.user" \
+  --condition=None >/dev/null
+
+gcloud builds submit \
+  --config cloudbuild.relay-directory-crawler.yaml \
+  --substitutions "_IMAGE=${IMAGE}" .
+
+gcloud run worker-pools deploy "${WORKER_POOL_NAME}" \
+  --image "${IMAGE}" \
+  --region "${REGION}" \
+  --service-account "${SERVICE_ACCOUNT}" \
+  --instances "${INSTANCE_COUNT}" \
+  --set-env-vars "GOOGLE_CLOUD_PROJECT=${PROJECT_ID},FIRESTORE_PROJECT=${PROJECT_ID},LIVE_FLUSH_LIMIT=${LIVE_FLUSH_LIMIT},LIVE_FLUSH_INTERVAL_MS=${LIVE_FLUSH_INTERVAL_MS},LIVE_HEARTBEAT_INTERVAL_MS=${LIVE_HEARTBEAT_INTERVAL_MS}" \
+  --args "scripts/relay-directory-crawler.mjs,--live-listen,--firestore-project,${PROJECT_ID},--no-json"

--- a/scripts/relay-directory-crawler.mjs
+++ b/scripts/relay-directory-crawler.mjs
@@ -1,0 +1,717 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { nip19, validateEvent, verifyEvent } from 'nostr-tools';
+
+const DEFAULT_RELAYS = [
+  'wss://purplepag.es',
+  'wss://relay.damus.io',
+  'wss://relay.primal.net',
+  'wss://relay.nostr.band',
+];
+
+const DEFAULT_OUT = 'sob-proposal-review/relay-directory-output.json';
+const TWITTER_TAG = /^(?:twitter|x|com\.twitter):(.+)$/i;
+const X_PROFILE_LINK = /(?:https?:\/\/)?(?:www\.)?(?:x\.com|twitter\.com)\/(@?[A-Za-z0-9_]{1,15})\b/i;
+const TWEET_ID = /(\d{10,25})/;
+const RESERVED_X_PATHS = new Set([
+  'compose',
+  'explore',
+  'hashtag',
+  'home',
+  'i',
+  'intent',
+  'messages',
+  'notifications',
+  'search',
+  'share',
+  'settings',
+]);
+
+function parseArgs(argv) {
+  const args = {
+    relays: DEFAULT_RELAYS,
+    out: DEFAULT_OUT,
+    timeoutMs: 12000,
+    kind10011Limit: 1000,
+    kind0Limit: 1500,
+    maxProofs: 250,
+    verifyTweets: true,
+    checkZaps: true,
+    includeWot: true,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => argv[++i];
+    if (arg === '--relays') args.relays = next().split(',').map((s) => s.trim()).filter(Boolean);
+    else if (arg === '--out') args.out = next();
+    else if (arg === '--timeout-ms') args.timeoutMs = Number(next());
+    else if (arg === '--kind10011-limit') args.kind10011Limit = Number(next());
+    else if (arg === '--kind0-limit') args.kind0Limit = Number(next());
+    else if (arg === '--max-proofs') args.maxProofs = Number(next());
+    else if (arg === '--no-tweet-verify') args.verifyTweets = false;
+    else if (arg === '--no-zap-check') args.checkZaps = false;
+    else if (arg === '--no-wot') args.includeWot = false;
+    else if (arg === '--help' || arg === '-h') {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!args.relays.length) throw new Error('At least one relay is required.');
+  if (!Number.isFinite(args.timeoutMs) || args.timeoutMs <= 0) throw new Error('--timeout-ms must be positive.');
+  if (!Number.isFinite(args.maxProofs) || args.maxProofs < 0) throw new Error('--max-proofs must be >= 0.');
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage: npm run crawl:directory -- [options]
+
+Build a verified X/Twitter -> Nostr directory from relay data.
+
+Options:
+  --relays <csv>             Relays to query. Default: ${DEFAULT_RELAYS.join(',')}
+  --out <file>               JSON output path. Default: ${DEFAULT_OUT}
+  --timeout-ms <n>           Per-relay timeout. Default: 12000
+  --kind10011-limit <n>      Per-relay kind:10011 limit. Default: 1000
+  --kind0-limit <n>          Per-relay kind:0 limit. Default: 1500
+  --max-proofs <n>           Max proof tweets to verify; 0 means all. Default: 250
+  --no-tweet-verify          Extract candidates only; do not fetch X/Twitter.
+  --no-zap-check             Skip LNURL/NIP-57 zappability checks.
+  --no-wot                   Skip Web-of-Trust/risk scoring.
+`);
+}
+
+function queryRelay(url, filter, { timeoutMs, max }) {
+  return new Promise((resolve) => {
+    const events = [];
+    const sub = `nc-${Math.random().toString(36).slice(2, 10)}`;
+    let done = false;
+    let ws;
+
+    const finish = (reason) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      try {
+        ws?.close();
+      } catch {}
+      resolve({ relay: url, events, reason });
+    };
+
+    const timer = setTimeout(() => finish('timeout'), timeoutMs);
+
+    try {
+      ws = new WebSocket(url);
+    } catch (error) {
+      finish(`constructor-error:${error.message}`);
+      return;
+    }
+
+    ws.addEventListener('open', () => {
+      ws.send(JSON.stringify(['REQ', sub, { ...filter, limit: max }]));
+    });
+    ws.addEventListener('message', (ev) => {
+      let msg;
+      try {
+        msg = JSON.parse(ev.data);
+      } catch {
+        return;
+      }
+      if (msg[0] === 'EVENT' && msg[1] === sub && msg[2]?.id) {
+        events.push(msg[2]);
+        if (events.length >= max) finish('max');
+      } else if (msg[0] === 'EOSE' && msg[1] === sub) {
+        finish('eose');
+      } else if (msg[0] === 'CLOSED' && msg[1] === sub) {
+        finish(`closed:${msg[2] || ''}`);
+      }
+    });
+    ws.addEventListener('error', () => finish('ws-error'));
+    ws.addEventListener('close', () => finish('close'));
+  });
+}
+
+async function queryPool(relays, filter, opts) {
+  const results = await Promise.all(relays.map((relay) => queryRelay(relay, filter, opts)));
+  const byId = new Map();
+  for (const result of results) {
+    for (const event of result.events) byId.set(event.id, event);
+  }
+  return { results, events: [...byId.values()] };
+}
+
+function latestReplaceable(events) {
+  const latest = new Map();
+  for (const event of events) {
+    if (!isValidSignedEvent(event)) continue;
+    const key = `${event.kind}:${event.pubkey}`;
+    const previous = latest.get(key);
+    if (!previous || event.created_at > previous.created_at) latest.set(key, event);
+  }
+  return [...latest.values()];
+}
+
+function isValidSignedEvent(event) {
+  try {
+    return validateEvent(event) && verifyEvent(event);
+  } catch {
+    return false;
+  }
+}
+
+function normalizeTwitterHandle(value) {
+  if (!value) return null;
+  let handle = String(value).trim();
+  const urlMatch = handle.match(X_PROFILE_LINK);
+  if (urlMatch) handle = urlMatch[1];
+  handle = handle.replace(/^@/, '').split(/[/?#\s]/)[0];
+  if (!/^[A-Za-z0-9_]{1,15}$/.test(handle)) return null;
+  if (RESERVED_X_PATHS.has(handle.toLowerCase())) return null;
+  return handle.toLowerCase();
+}
+
+function extractTweetId(value) {
+  const match = String(value || '').match(TWEET_ID);
+  return match ? match[1] : null;
+}
+
+function safeJson(content) {
+  try {
+    return JSON.parse(content || '{}');
+  } catch {
+    return {};
+  }
+}
+
+function hexToNpub(hex) {
+  return nip19.npubEncode(hex);
+}
+
+function extractDirectoryInputs(events) {
+  const candidatesByKey = new Map();
+  const claimedByKey = new Map();
+  const metadataByPubkey = new Map();
+
+  for (const event of events) {
+    const metadata = event.kind === 0 ? safeJson(event.content) : null;
+    if (metadata) {
+      metadataByPubkey.set(event.pubkey, {
+        pubkey: event.pubkey,
+        npub: hexToNpub(event.pubkey),
+        name: metadata.name || metadata.display_name || null,
+        nip05: metadata.nip05 || null,
+        lud16: metadata.lud16 || null,
+        lud06: metadata.lud06 || null,
+        website: metadata.website || null,
+        about: metadata.about || null,
+      });
+    }
+
+    for (const tag of event.tags || []) {
+      if (tag[0] !== 'i' || !tag[1]) continue;
+      const tagMatch = String(tag[1]).match(TWITTER_TAG);
+      if (!tagMatch) continue;
+
+      const handle = normalizeTwitterHandle(tagMatch[1]);
+      const proofTweetId = extractTweetId(tag[2]);
+      if (!handle || !proofTweetId) continue;
+
+      const key = `${handle}:${event.pubkey}:${proofTweetId}`;
+      candidatesByKey.set(key, {
+        platform: 'twitter',
+        handle,
+        pubkey: event.pubkey,
+        npub: hexToNpub(event.pubkey),
+        proofTweetId,
+        sourceKind: event.kind,
+        sourceEventId: event.id,
+        sourceCreatedAt: event.created_at,
+      });
+    }
+
+    if (!metadata) continue;
+    for (const field of ['website', 'about']) {
+      const match = String(metadata[field] || '').match(X_PROFILE_LINK);
+      const handle = normalizeTwitterHandle(match?.[1]);
+      if (!handle) continue;
+      const key = `${handle}:${event.pubkey}:${field}`;
+      claimedByKey.set(key, {
+        platform: 'twitter',
+        handle,
+        pubkey: event.pubkey,
+        npub: hexToNpub(event.pubkey),
+        source: `kind0.${field}`,
+        identityStatus: 'claimed',
+      });
+    }
+  }
+
+  return {
+    candidates: [...candidatesByKey.values()].sort(sortCandidate),
+    claimed: [...claimedByKey.values()].sort(sortClaim),
+    metadataByPubkey,
+  };
+}
+
+function mergeMetadata(metadataByPubkey, events) {
+  for (const event of events) {
+    if (event.kind !== 0) continue;
+    const metadata = safeJson(event.content);
+    metadataByPubkey.set(event.pubkey, {
+      pubkey: event.pubkey,
+      npub: hexToNpub(event.pubkey),
+      name: metadata.name || metadata.display_name || null,
+      nip05: metadata.nip05 || null,
+      lud16: metadata.lud16 || null,
+      lud06: metadata.lud06 || null,
+      website: metadata.website || null,
+      about: metadata.about || null,
+    });
+  }
+}
+
+function sortCandidate(a, b) {
+  return a.handle.localeCompare(b.handle) || a.pubkey.localeCompare(b.pubkey);
+}
+
+function sortClaim(a, b) {
+  return a.handle.localeCompare(b.handle) || a.source.localeCompare(b.source);
+}
+
+function syndicationToken(tweetId) {
+  try {
+    return ((Number(tweetId) / 1e15) * Math.PI).toString(36).replace(/(0+|\.)/g, '') || 'a';
+  } catch {
+    return 'a';
+  }
+}
+
+async function fetchTweet(tweetId, handleHint, timeoutMs) {
+  const bearerToken = process.env.X_BEARER_TOKEN || process.env.TWITTER_BEARER_TOKEN;
+  if (bearerToken) {
+    const official = await fetchTweetViaXApi(tweetId, bearerToken, timeoutMs);
+    if (official) return official;
+  }
+
+  const syndication = await fetchTweetViaSyndication(tweetId, timeoutMs);
+  if (syndication) return syndication;
+
+  return fetchTweetViaOembed(tweetId, handleHint, timeoutMs);
+}
+
+async function fetchTweetViaXApi(tweetId, bearerToken, timeoutMs) {
+  try {
+    const params = new URLSearchParams({
+      expansions: 'author_id',
+      'tweet.fields': 'author_id,text',
+      'user.fields': 'username',
+    });
+    const response = await fetch(`https://api.twitter.com/2/tweets/${tweetId}?${params}`, {
+      headers: { Authorization: `Bearer ${bearerToken}` },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) return null;
+    const json = await response.json();
+    const user = json.includes?.users?.find((candidate) => candidate.id === json.data?.author_id);
+    if (!json.data?.text || !user?.username) return null;
+    return {
+      text: json.data.text,
+      handle: user.username,
+      userId: user.id,
+      source: 'x-api',
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function fetchTweetViaSyndication(tweetId, timeoutMs) {
+  for (const token of [syndicationToken(tweetId), 'a']) {
+    try {
+      const url = `https://cdn.syndication.twimg.com/tweet-result?id=${tweetId}&token=${token}&lang=en`;
+      const response = await fetch(url, {
+        headers: { 'User-Agent': 'Mozilla/5.0' },
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (!response.ok) continue;
+      const json = await response.json();
+      if (!json?.text || !json.user?.screen_name) continue;
+      return {
+        text: json.text,
+        handle: json.user.screen_name,
+        userId: json.user.id_str || json.user.id || null,
+        source: 'syndication',
+      };
+    } catch {}
+  }
+  return null;
+}
+
+async function fetchTweetViaOembed(tweetId, handleHint, timeoutMs) {
+  try {
+    const tweetUrl = `https://twitter.com/${handleHint || 'i'}/status/${tweetId}`;
+    const url = `https://publish.x.com/oembed?omit_script=1&url=${encodeURIComponent(tweetUrl)}`;
+    const response = await fetch(url, { redirect: 'follow', signal: AbortSignal.timeout(timeoutMs) });
+    if (!response.ok) return null;
+    const json = await response.json();
+    const handle = normalizeTwitterHandle(json.author_url);
+    const text = stripHtml(json.html || '');
+    if (!handle || !text) return null;
+    return {
+      text,
+      handle,
+      userId: null,
+      source: 'oembed',
+    };
+  } catch {
+    return null;
+  }
+}
+
+function stripHtml(html) {
+  return String(html)
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, '&')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+async function verifyCandidate(candidate, timeoutMs) {
+  const tweet = await fetchTweet(candidate.proofTweetId, candidate.handle, timeoutMs);
+  if (!tweet) return { ...candidate, identityStatus: 'rejected', rejectionReason: 'proof-tweet-unavailable' };
+
+  const tweetHandle = normalizeTwitterHandle(tweet.handle);
+  if (tweetHandle !== candidate.handle) {
+    return {
+      ...candidate,
+      identityStatus: 'rejected',
+      rejectionReason: 'proof-author-mismatch',
+      proofAuthor: tweetHandle,
+      proofSource: tweet.source,
+      xUserId: tweet.userId,
+    };
+  }
+
+  if (!tweet.text.includes(candidate.npub)) {
+    return {
+      ...candidate,
+      identityStatus: 'rejected',
+      rejectionReason: 'npub-not-in-proof-tweet',
+      proofAuthor: tweetHandle,
+      proofSource: tweet.source,
+      xUserId: tweet.userId,
+    };
+  }
+
+  return {
+    ...candidate,
+    identityStatus: 'verified',
+    proofAuthor: tweetHandle,
+    proofSource: tweet.source,
+    xUserId: tweet.userId,
+    verifiedAt: new Date().toISOString(),
+  };
+}
+
+function getMetadata(metadataByPubkey, pubkey) {
+  return metadataByPubkey.get(pubkey) || {
+    pubkey,
+    npub: hexToNpub(pubkey),
+    name: null,
+    nip05: null,
+    lud16: null,
+    lud06: null,
+    website: null,
+    about: null,
+  };
+}
+
+async function checkZapSupport(record, metadata, timeoutMs) {
+  const lightningAddress = metadata.lud16 || null;
+  if (!lightningAddress) {
+    return { ...record, lud16: null, zappable: false, zapReason: 'missing-lud16' };
+  }
+
+  const lnurlp = lightningAddressToLnurlp(lightningAddress);
+  if (!lnurlp) {
+    return { ...record, lud16: lightningAddress, zappable: false, zapReason: 'invalid-lud16' };
+  }
+
+  try {
+    const response = await fetch(lnurlp, { signal: AbortSignal.timeout(timeoutMs) });
+    if (!response.ok) {
+      return { ...record, lud16: lightningAddress, zappable: false, zapReason: `lnurl-http-${response.status}` };
+    }
+    const json = await response.json();
+    const zappable = json.allowsNostr === true && isHexPubkey(json.nostrPubkey);
+    return {
+      ...record,
+      lud16: lightningAddress,
+      lnurlp,
+      zappable,
+      zapReason: zappable ? 'nip57-ready' : 'lnurl-does-not-allow-nostr',
+      lnurlAllowsNostr: json.allowsNostr === true,
+      lnurlNostrPubkey: isHexPubkey(json.nostrPubkey) ? json.nostrPubkey : null,
+    };
+  } catch {
+    return { ...record, lud16: lightningAddress, lnurlp, zappable: false, zapReason: 'lnurl-fetch-failed' };
+  }
+}
+
+function lightningAddressToLnurlp(lud16) {
+  const parts = String(lud16 || '').trim().split('@');
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+  return `https://${parts[1]}/.well-known/lnurlp/${encodeURIComponent(parts[0])}`;
+}
+
+function isHexPubkey(value) {
+  return /^[0-9a-f]{64}$/i.test(String(value || ''));
+}
+
+function computeWotScores(records, allEvents) {
+  const followers = new Map();
+  const reports = new Map();
+  const assertions = new Map();
+
+  for (const event of allEvents) {
+    if (!isValidSignedEvent(event)) continue;
+
+    if (event.kind === 3) {
+      for (const tag of event.tags || []) {
+        if (tag[0] !== 'p' || !isHexPubkey(tag[1])) continue;
+        followers.set(tag[1], (followers.get(tag[1]) || 0) + 1);
+      }
+    }
+
+    if (event.kind === 1984) {
+      for (const tag of event.tags || []) {
+        if (tag[0] !== 'p' || !isHexPubkey(tag[1])) continue;
+        reports.set(tag[1], (reports.get(tag[1]) || 0) + 1);
+      }
+    }
+
+    if (event.kind === 30382) {
+      const target = event.tags?.find((tag) => tag[0] === 'd' && isHexPubkey(tag[1]))?.[1];
+      if (!target) continue;
+      const rank = numericTag(event.tags, 'rank');
+      const followerCount = numericTag(event.tags, 'followers');
+      const current = assertions.get(target) || { rank: null, followers: null, assertionCount: 0 };
+      assertions.set(target, {
+        rank: Math.max(current.rank || 0, rank || 0) || null,
+        followers: Math.max(current.followers || 0, followerCount || 0) || null,
+        assertionCount: current.assertionCount + 1,
+      });
+    }
+  }
+
+  return records.map((record) => {
+    const followerCount = followers.get(record.pubkey) || 0;
+    const reportCount = reports.get(record.pubkey) || 0;
+    const assertion = assertions.get(record.pubkey) || { rank: null, followers: null, assertionCount: 0 };
+    const followScore = Math.min(35, Math.log10(followerCount + 1) * 18);
+    const assertionScore = assertion.rank ? Math.min(35, assertion.rank * 0.35) : 0;
+    const activityScore = assertion.followers ? Math.min(20, Math.log10(assertion.followers + 1) * 7) : 0;
+    const proofScore = record.identityStatus === 'verified' ? 10 : 0;
+    const penalty = Math.min(40, reportCount * 10);
+    const score = Math.max(0, Math.min(100, Math.round(followScore + assertionScore + activityScore + proofScore - penalty)));
+
+    return {
+      ...record,
+      wot: {
+        score,
+        followerGraphMentions: followerCount,
+        nip85Rank: assertion.rank,
+        nip85Followers: assertion.followers,
+        nip85AssertionCount: assertion.assertionCount,
+        reportCount,
+        note: 'WoT is a ranking/risk signal only; it is not identity proof.',
+      },
+    };
+  });
+}
+
+function numericTag(tags, name) {
+  const value = tags?.find((tag) => tag[0] === name)?.[1];
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+async function runCrawler(args) {
+  console.log(`Crawling ${args.relays.length} relays for kind:10011 and kind:0 identity data...`);
+
+  const [kind10011, kind0] = await Promise.all([
+    queryPool(args.relays, { kinds: [10011] }, { timeoutMs: args.timeoutMs, max: args.kind10011Limit }),
+    queryPool(args.relays, { kinds: [0] }, { timeoutMs: args.timeoutMs, max: args.kind0Limit }),
+  ]);
+
+  const profileEvents = latestReplaceable([...kind10011.events, ...kind0.events]);
+  const { candidates, claimed, metadataByPubkey } = extractDirectoryInputs(profileEvents);
+  const proofLimit = args.maxProofs === 0 ? candidates.length : Math.min(args.maxProofs, candidates.length);
+
+  console.log(`Found ${profileEvents.length} latest profile/identity events.`);
+  console.log(`Detected ${candidates.length} verifiable Twitter proof candidates and ${claimed.length} claimed-only leads.`);
+
+  const verifiedOrRejected = [];
+  if (args.verifyTweets) {
+    console.log(`Verifying ${proofLimit}/${candidates.length} proof tweets...`);
+    for (const candidate of candidates.slice(0, proofLimit)) {
+      verifiedOrRejected.push(await verifyCandidate(candidate, args.timeoutMs));
+    }
+  } else {
+    verifiedOrRejected.push(...candidates.map((candidate) => ({ ...candidate, identityStatus: 'candidate' })));
+  }
+
+  let verified = verifiedOrRejected.filter((record) => record.identityStatus === 'verified');
+  const rejected = verifiedOrRejected.filter((record) => record.identityStatus === 'rejected');
+
+  if (verified.length) {
+    console.log(`Fetching latest kind:0 metadata for ${verified.length} verified authors...`);
+    const verifiedPubkeys = [...new Set(verified.map((record) => record.pubkey))];
+    const verifiedMetadata = await queryPool(
+      args.relays,
+      { kinds: [0], authors: verifiedPubkeys },
+      { timeoutMs: args.timeoutMs, max: Math.max(verifiedPubkeys.length * 2, 50) }
+    );
+    mergeMetadata(metadataByPubkey, latestReplaceable(verifiedMetadata.events));
+  }
+
+  verified = verified.map((record) => ({
+    ...record,
+    metadata: getMetadata(metadataByPubkey, record.pubkey),
+  }));
+
+  if (args.checkZaps && verified.length) {
+    console.log(`Checking NIP-57 zappability for ${verified.length} verified records...`);
+    const checked = [];
+    for (const record of verified) {
+      checked.push(await checkZapSupport(record, record.metadata, args.timeoutMs));
+    }
+    verified = checked;
+  }
+
+  let allDirectoryRecords = [
+    ...verified.map((record) => ({
+      ...record,
+      directoryStatus: record.zappable ? 'verified_zappable' : 'verified_not_zappable',
+    })),
+    ...claimed.map((record) => ({
+      ...record,
+      metadata: getMetadata(metadataByPubkey, record.pubkey),
+      directoryStatus: 'claimed_unverified',
+      zappable: false,
+      autoZapAllowed: false,
+    })),
+  ];
+
+  if (args.includeWot && allDirectoryRecords.length) {
+    console.log('Collecting lightweight WoT signals for directory records...');
+    const pubkeys = [...new Set(allDirectoryRecords.map((record) => record.pubkey))];
+    const [followLists, reports, assertions] = await Promise.all([
+      queryPool(args.relays, { kinds: [3], '#p': pubkeys }, { timeoutMs: args.timeoutMs, max: 1500 }),
+      queryPool(args.relays, { kinds: [1984], '#p': pubkeys }, { timeoutMs: args.timeoutMs, max: 1000 }),
+      queryPool(args.relays, { kinds: [30382], '#d': pubkeys }, { timeoutMs: args.timeoutMs, max: 1500 }),
+    ]);
+    allDirectoryRecords = computeWotScores(allDirectoryRecords, [
+      ...followLists.events,
+      ...reports.events,
+      ...assertions.events,
+    ]);
+  }
+
+  allDirectoryRecords = allDirectoryRecords.map((record) => ({
+    ...record,
+    autoZapAllowed: record.identityStatus === 'verified' && record.zappable === true,
+  }));
+
+  const output = {
+    generatedAt: new Date().toISOString(),
+    strategy: {
+      identityProof: 'NIP-39 kind:10011 i tags, with legacy kind:0 i tags accepted',
+      proofVerification: args.verifyTweets
+        ? 'proof tweet must be authored by handle and contain exact npub'
+        : 'disabled by --no-tweet-verify',
+      zapPolicy: 'auto-zap requires verified identity and LNURL allowsNostr',
+      wotPolicy: 'WoT/NIP-85 is ranking and risk only, never identity proof',
+    },
+    relays: args.relays,
+    relayResults: {
+      kind10011: kind10011.results.map(summarizeRelayResult),
+      kind0: kind0.results.map(summarizeRelayResult),
+    },
+    stats: {
+      profileEvents: profileEvents.length,
+      verifiableCandidates: candidates.length,
+      proofTweetsAttempted: args.verifyTweets ? proofLimit : 0,
+      verified: verified.length,
+      rejected: rejected.length,
+      claimedOnly: claimed.length,
+      zappableVerified: verified.filter((record) => record.zappable).length,
+      autoZapAllowed: allDirectoryRecords.filter((record) => record.autoZapAllowed).length,
+    },
+    directory: allDirectoryRecords.sort(sortDirectoryRecord),
+    rejected,
+  };
+
+  await writeJson(args.out, output);
+  printSummary(output, args.out);
+  return output;
+}
+
+function summarizeRelayResult(result) {
+  return {
+    relay: result.relay,
+    events: result.events.length,
+    reason: result.reason,
+  };
+}
+
+function sortDirectoryRecord(a, b) {
+  return a.handle.localeCompare(b.handle) || a.directoryStatus.localeCompare(b.directoryStatus);
+}
+
+async function writeJson(file, data) {
+  const outPath = path.resolve(process.cwd(), file);
+  await mkdir(path.dirname(outPath), { recursive: true });
+  await writeFile(outPath, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
+}
+
+function printSummary(output, out) {
+  console.log('\nDirectory crawl complete.');
+  console.log(`  profile events:       ${output.stats.profileEvents}`);
+  console.log(`  proof candidates:     ${output.stats.verifiableCandidates}`);
+  console.log(`  proof tweets checked: ${output.stats.proofTweetsAttempted}`);
+  console.log(`  verified:             ${output.stats.verified}`);
+  console.log(`  claimed-only:         ${output.stats.claimedOnly}`);
+  console.log(`  zappable verified:    ${output.stats.zappableVerified}`);
+  console.log(`  auto-zap allowed:     ${output.stats.autoZapAllowed}`);
+  console.log(`  output:               ${out}`);
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+
+if (isMain) {
+  runCrawler(parseArgs(process.argv.slice(2))).catch((error) => {
+    console.error(error.stack || error.message || error);
+    process.exitCode = 1;
+  });
+}
+
+export {
+  computeWotScores,
+  extractDirectoryInputs,
+  extractTweetId,
+  lightningAddressToLnurlp,
+  normalizeTwitterHandle,
+  runCrawler,
+};

--- a/scripts/relay-directory-crawler.mjs
+++ b/scripts/relay-directory-crawler.mjs
@@ -2059,7 +2059,15 @@ function firestoreTimestampToMs(value) {
 
 async function assertFirestoreCredentialsAvailable() {
   if (process.env.GOOGLE_APPLICATION_CREDENTIALS) return;
-  if (process.env.CLOUD_RUN_JOB || process.env.K_SERVICE || process.env.FUNCTION_NAME) return;
+  if (
+    process.env.CLOUD_RUN_JOB
+    || process.env.K_SERVICE
+    || process.env.K_CONFIGURATION
+    || process.env.K_REVISION
+    || process.env.FUNCTION_NAME
+  ) {
+    return;
+  }
 
   const adcPath = getApplicationDefaultCredentialsPath();
 

--- a/scripts/relay-directory-crawler.mjs
+++ b/scripts/relay-directory-crawler.mjs
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: MIT
 
-import { mkdir, writeFile } from 'node:fs/promises';
+import { access, mkdir, writeFile } from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { FieldValue, Firestore } from '@google-cloud/firestore';
 import { nip19, validateEvent, verifyEvent } from 'nostr-tools';
 
 const DEFAULT_RELAYS = [
@@ -13,7 +15,19 @@ const DEFAULT_RELAYS = [
   'wss://relay.nostr.band',
 ];
 
-const DEFAULT_OUT = 'sob-proposal-review/relay-directory-output.json';
+const DEFAULT_OUT = 'relay-directory-output.json';
+const DEFAULT_FIRESTORE_ENTRIES_COLLECTION = 'nostrDirectoryEntries';
+const DEFAULT_FIRESTORE_HANDLES_COLLECTION = 'nostrDirectoryHandles';
+const DEFAULT_FIRESTORE_BACKFILL_RUNS_COLLECTION = 'relayBackfillRuns';
+const DEFAULT_FIRESTORE_PROJECTION_RUNS_COLLECTION = 'relayProjectionRuns';
+const DEFAULT_FIRESTORE_LIVE_RUNS_COLLECTION = 'relayLiveListenerRuns';
+const DEFAULT_FIRESTORE_EVENTS_COLLECTION = 'nostrIdentityEvents';
+const DEFAULT_FIRESTORE_QUEUE_COLLECTION = 'nostrProjectionQueue';
+const DEFAULT_FIRESTORE_STATE_COLLECTION = 'relayCrawlerState';
+const DEFAULT_FIRESTORE_GAPS_COLLECTION = 'relayCrawlerGaps';
+const BACKFILL_KINDS = [10011, 0];
+const LIVE_LISTENER_KINDS = BACKFILL_KINDS;
+const CREATE_IF_MISSING_CONCURRENCY = 20;
 const TWITTER_TAG = /^(?:twitter|x|com\.twitter):(.+)$/i;
 const X_PROFILE_LINK = /(?:https?:\/\/)?(?:www\.)?(?:x\.com|twitter\.com)\/(@?[A-Za-z0-9_]{1,15})\b/i;
 const TWEET_ID = /(\d{10,25})/;
@@ -33,29 +47,110 @@ const RESERVED_X_PATHS = new Set([
 
 function parseArgs(argv) {
   const args = {
+    mode: 'project',
     relays: DEFAULT_RELAYS,
     out: DEFAULT_OUT,
     timeoutMs: 12000,
-    kind10011Limit: 1000,
-    kind0Limit: 1500,
     maxProofs: 250,
     verifyTweets: true,
     checkZaps: true,
-    includeWot: true,
+    firestoreProject: process.env.FIRESTORE_PROJECT || process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT || null,
+    firestoreDatabase: process.env.FIRESTORE_DATABASE || '(default)',
+    firestoreEntriesCollection: process.env.FIRESTORE_ENTRIES_COLLECTION || DEFAULT_FIRESTORE_ENTRIES_COLLECTION,
+    firestoreHandlesCollection: process.env.FIRESTORE_HANDLES_COLLECTION || DEFAULT_FIRESTORE_HANDLES_COLLECTION,
+    firestoreBackfillRunsCollection: process.env.FIRESTORE_BACKFILL_RUNS_COLLECTION || DEFAULT_FIRESTORE_BACKFILL_RUNS_COLLECTION,
+    firestoreProjectionRunsCollection: process.env.FIRESTORE_PROJECTION_RUNS_COLLECTION || DEFAULT_FIRESTORE_PROJECTION_RUNS_COLLECTION,
+    firestoreLiveRunsCollection: process.env.FIRESTORE_LIVE_RUNS_COLLECTION || DEFAULT_FIRESTORE_LIVE_RUNS_COLLECTION,
+    firestoreEventsCollection: process.env.FIRESTORE_EVENTS_COLLECTION || DEFAULT_FIRESTORE_EVENTS_COLLECTION,
+    firestoreQueueCollection: process.env.FIRESTORE_QUEUE_COLLECTION || DEFAULT_FIRESTORE_QUEUE_COLLECTION,
+    firestoreStateCollection: process.env.FIRESTORE_STATE_COLLECTION || DEFAULT_FIRESTORE_STATE_COLLECTION,
+    firestoreGapsCollection: process.env.FIRESTORE_GAPS_COLLECTION || DEFAULT_FIRESTORE_GAPS_COLLECTION,
+    writeFirestore: process.env.WRITE_FIRESTORE === '1',
+    backfillPageLimit: Number(process.env.BACKFILL_PAGE_LIMIT || 500),
+    backfillMaxPageLimit: Number(process.env.BACKFILL_MAX_PAGE_LIMIT || 2000),
+    backfillMaxPages: Number(process.env.BACKFILL_MAX_PAGES || 25),
+    backfillUntil: process.env.BACKFILL_UNTIL ? Number(process.env.BACKFILL_UNTIL) : Math.floor(Date.now() / 1000),
+    backfillSince: process.env.BACKFILL_SINCE ? Number(process.env.BACKFILL_SINCE) : 0,
+    backfillResume: process.env.BACKFILL_RESUME !== '0',
+    backfillStatePrefix: process.env.BACKFILL_STATE_PREFIX || 'backfill',
+    projectionLimit: Number(process.env.PROJECTION_LIMIT || 1000),
+    projectionSource: process.env.PROJECTION_SOURCE || 'queue',
+    projectionWorkerId: process.env.PROJECTION_WORKER_ID || `projection:${os.hostname()}:${process.pid}`,
+    projectionLockMs: Number(process.env.PROJECTION_LOCK_MS || 10 * 60 * 1000),
+    projectionExternalRetryMs: Number(process.env.PROJECTION_EXTERNAL_RETRY_MS || 15 * 60 * 1000),
+    updateProcessingStatus: process.env.UPDATE_PROCESSING_STATUS !== '0',
+    liveDurationMs: Number(process.env.LIVE_DURATION_MS || 0),
+    liveFlushLimit: Number(process.env.LIVE_FLUSH_LIMIT || 25),
+    liveFlushIntervalMs: Number(process.env.LIVE_FLUSH_INTERVAL_MS || 5000),
+    liveHeartbeatIntervalMs: Number(process.env.LIVE_HEARTBEAT_INTERVAL_MS || 30000),
+    liveReconnectMinMs: Number(process.env.LIVE_RECONNECT_MIN_MS || 1000),
+    liveReconnectMaxMs: Number(process.env.LIVE_RECONNECT_MAX_MS || 30000),
+    liveSeenCacheLimit: Number(process.env.LIVE_SEEN_CACHE_LIMIT || 50000),
+    liveConnectTimeoutMs: Number(process.env.LIVE_CONNECT_TIMEOUT_MS || 15000),
   };
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     const next = () => argv[++i];
-    if (arg === '--relays') args.relays = next().split(',').map((s) => s.trim()).filter(Boolean);
+    if (arg === '--mode') args.mode = next();
+    else if (arg === '--backfill') {
+      args.mode = 'backfill';
+      args.writeFirestore = true;
+      args.out = null;
+    }
+    else if (arg === '--live-listen') {
+      args.mode = 'live';
+      args.writeFirestore = true;
+      args.out = null;
+    }
+    else if (arg === '--project-directory') {
+      args.mode = 'project';
+      args.writeFirestore = true;
+      args.out = null;
+    }
+    else if (arg === '--relays') args.relays = next().split(',').map((s) => s.trim()).filter(Boolean);
     else if (arg === '--out') args.out = next();
     else if (arg === '--timeout-ms') args.timeoutMs = Number(next());
-    else if (arg === '--kind10011-limit') args.kind10011Limit = Number(next());
-    else if (arg === '--kind0-limit') args.kind0Limit = Number(next());
     else if (arg === '--max-proofs') args.maxProofs = Number(next());
+    else if (arg === '--firestore') args.writeFirestore = true;
+    else if (arg === '--firestore-project') {
+      args.firestoreProject = next();
+      args.writeFirestore = true;
+    }
+    else if (arg === '--firestore-database') args.firestoreDatabase = next();
+    else if (arg === '--firestore-entries-collection') args.firestoreEntriesCollection = next();
+    else if (arg === '--firestore-handles-collection') args.firestoreHandlesCollection = next();
+    else if (arg === '--firestore-backfill-runs-collection') args.firestoreBackfillRunsCollection = next();
+    else if (arg === '--firestore-projection-runs-collection') args.firestoreProjectionRunsCollection = next();
+    else if (arg === '--firestore-live-runs-collection') args.firestoreLiveRunsCollection = next();
+    else if (arg === '--firestore-events-collection') args.firestoreEventsCollection = next();
+    else if (arg === '--firestore-queue-collection') args.firestoreQueueCollection = next();
+    else if (arg === '--firestore-state-collection') args.firestoreStateCollection = next();
+    else if (arg === '--firestore-gaps-collection') args.firestoreGapsCollection = next();
+    else if (arg === '--backfill-page-limit') args.backfillPageLimit = Number(next());
+    else if (arg === '--backfill-max-page-limit') args.backfillMaxPageLimit = Number(next());
+    else if (arg === '--backfill-max-pages') args.backfillMaxPages = Number(next());
+    else if (arg === '--backfill-until') args.backfillUntil = Number(next());
+    else if (arg === '--backfill-since') args.backfillSince = Number(next());
+    else if (arg === '--no-backfill-resume') args.backfillResume = false;
+    else if (arg === '--backfill-state-prefix') args.backfillStatePrefix = next();
+    else if (arg === '--projection-limit') args.projectionLimit = Number(next());
+    else if (arg === '--projection-source') args.projectionSource = next();
+    else if (arg === '--projection-worker-id') args.projectionWorkerId = next();
+    else if (arg === '--projection-lock-ms') args.projectionLockMs = Number(next());
+    else if (arg === '--projection-external-retry-ms') args.projectionExternalRetryMs = Number(next());
+    else if (arg === '--live-duration-ms') args.liveDurationMs = Number(next());
+    else if (arg === '--live-flush-limit') args.liveFlushLimit = Number(next());
+    else if (arg === '--live-flush-interval-ms') args.liveFlushIntervalMs = Number(next());
+    else if (arg === '--live-heartbeat-interval-ms') args.liveHeartbeatIntervalMs = Number(next());
+    else if (arg === '--live-reconnect-min-ms') args.liveReconnectMinMs = Number(next());
+    else if (arg === '--live-reconnect-max-ms') args.liveReconnectMaxMs = Number(next());
+    else if (arg === '--live-seen-cache-limit') args.liveSeenCacheLimit = Number(next());
+    else if (arg === '--live-connect-timeout-ms') args.liveConnectTimeoutMs = Number(next());
+    else if (arg === '--no-processing-status') args.updateProcessingStatus = false;
+    else if (arg === '--no-json') args.out = null;
     else if (arg === '--no-tweet-verify') args.verifyTweets = false;
     else if (arg === '--no-zap-check') args.checkZaps = false;
-    else if (arg === '--no-wot') args.includeWot = false;
     else if (arg === '--help' || arg === '-h') {
       printHelp();
       process.exit(0);
@@ -64,29 +159,147 @@ function parseArgs(argv) {
     }
   }
 
+  if (!['backfill', 'project', 'live'].includes(args.mode)) {
+    throw new Error('--mode must be backfill, project, or live.');
+  }
   if (!args.relays.length) throw new Error('At least one relay is required.');
   if (!Number.isFinite(args.timeoutMs) || args.timeoutMs <= 0) throw new Error('--timeout-ms must be positive.');
   if (!Number.isFinite(args.maxProofs) || args.maxProofs < 0) throw new Error('--max-proofs must be >= 0.');
+  if (!Number.isFinite(args.backfillPageLimit) || args.backfillPageLimit <= 0) {
+    throw new Error('--backfill-page-limit must be positive.');
+  }
+  if (!Number.isFinite(args.backfillMaxPageLimit) || args.backfillMaxPageLimit < args.backfillPageLimit) {
+    throw new Error('--backfill-max-page-limit must be >= --backfill-page-limit.');
+  }
+  if (!Number.isFinite(args.backfillMaxPages) || args.backfillMaxPages <= 0) {
+    throw new Error('--backfill-max-pages must be positive.');
+  }
+  if (!Number.isFinite(args.backfillUntil) || args.backfillUntil <= 0) {
+    throw new Error('--backfill-until must be a positive unix timestamp.');
+  }
+  if (!Number.isFinite(args.backfillSince) || args.backfillSince < 0) {
+    throw new Error('--backfill-since must be a unix timestamp >= 0.');
+  }
+  if (!args.backfillStatePrefix || /[\/#?]/.test(args.backfillStatePrefix)) {
+    throw new Error('--backfill-state-prefix must be non-empty and must not contain /, #, or ?.');
+  }
+  if (!Number.isFinite(args.projectionLimit) || args.projectionLimit <= 0) {
+    throw new Error('--projection-limit must be positive.');
+  }
+  if (!['queue', 'raw'].includes(args.projectionSource)) {
+    throw new Error('--projection-source must be queue or raw.');
+  }
+  if (!args.projectionWorkerId) {
+    throw new Error('--projection-worker-id must be non-empty.');
+  }
+  if (!Number.isFinite(args.projectionLockMs) || args.projectionLockMs <= 0) {
+    throw new Error('--projection-lock-ms must be positive.');
+  }
+  if (!Number.isFinite(args.projectionExternalRetryMs) || args.projectionExternalRetryMs <= 0) {
+    throw new Error('--projection-external-retry-ms must be positive.');
+  }
+  if (!Number.isFinite(args.liveDurationMs) || args.liveDurationMs < 0) {
+    throw new Error('--live-duration-ms must be >= 0. Use 0 to run until stopped.');
+  }
+  if (!Number.isFinite(args.liveFlushLimit) || args.liveFlushLimit <= 0) {
+    throw new Error('--live-flush-limit must be positive.');
+  }
+  if (!Number.isFinite(args.liveFlushIntervalMs) || args.liveFlushIntervalMs <= 0) {
+    throw new Error('--live-flush-interval-ms must be positive.');
+  }
+  if (!Number.isFinite(args.liveHeartbeatIntervalMs) || args.liveHeartbeatIntervalMs <= 0) {
+    throw new Error('--live-heartbeat-interval-ms must be positive.');
+  }
+  if (!Number.isFinite(args.liveReconnectMinMs) || args.liveReconnectMinMs <= 0) {
+    throw new Error('--live-reconnect-min-ms must be positive.');
+  }
+  if (!Number.isFinite(args.liveReconnectMaxMs) || args.liveReconnectMaxMs < args.liveReconnectMinMs) {
+    throw new Error('--live-reconnect-max-ms must be >= --live-reconnect-min-ms.');
+  }
+  if (!Number.isFinite(args.liveSeenCacheLimit) || args.liveSeenCacheLimit <= 0) {
+    throw new Error('--live-seen-cache-limit must be positive.');
+  }
+  if (!Number.isFinite(args.liveConnectTimeoutMs) || args.liveConnectTimeoutMs <= 0) {
+    throw new Error('--live-connect-timeout-ms must be positive.');
+  }
+  if ((args.writeFirestore || args.mode === 'backfill' || args.mode === 'project' || args.mode === 'live') && !args.firestoreProject) {
+    throw new Error('--firestore-project or GOOGLE_CLOUD_PROJECT is required for backfill/project/live modes.');
+  }
   return args;
 }
 
 function printHelp() {
   console.log(`Usage: npm run crawl:directory -- [options]
 
-Build a verified X/Twitter -> Nostr directory from relay data.
+Build a verified X/Twitter -> Nostr directory from stored relay data.
 
 Requires Node.js 22+ for the native WebSocket client used to query relays.
 
 Options:
+  --mode <backfill|project|live>
+                             Run historical backfill, Firestore projection, or live listener. Default: project
+  --backfill                 Shorthand for --mode backfill --firestore --no-json.
+  --live-listen              Shorthand for --mode live --firestore --no-json.
+  --project-directory        Shorthand for --mode project --firestore --no-json.
   --relays <csv>             Relays to query. Default: ${DEFAULT_RELAYS.join(',')}
   --out <file>               JSON output path. Default: ${DEFAULT_OUT}
   --timeout-ms <n>           Per-relay timeout. Default: 12000
-  --kind10011-limit <n>      Per-relay kind:10011 limit. Default: 1000
-  --kind0-limit <n>          Per-relay kind:0 limit. Default: 1500
   --max-proofs <n>           Max proof tweets to verify; 0 means all. Default: 250
+  --firestore                Enable Firestore writes.
+  --firestore-project <id>   GCP project for Firestore. Implies --firestore.
+  --firestore-database <id>  Firestore database id. Default: (default)
+  --firestore-entries-collection <name>
+                             Per-directory-record collection. Default: ${DEFAULT_FIRESTORE_ENTRIES_COLLECTION}
+  --firestore-handles-collection <name>
+                             Per-handle summary collection. Default: ${DEFAULT_FIRESTORE_HANDLES_COLLECTION}
+  --firestore-backfill-runs-collection <name>
+                             Backfill run summary collection. Default: ${DEFAULT_FIRESTORE_BACKFILL_RUNS_COLLECTION}
+  --firestore-projection-runs-collection <name>
+                             Projection run summary collection. Default: ${DEFAULT_FIRESTORE_PROJECTION_RUNS_COLLECTION}
+  --firestore-live-runs-collection <name>
+                             Live listener run summary collection. Default: ${DEFAULT_FIRESTORE_LIVE_RUNS_COLLECTION}
+  --firestore-events-collection <name>
+                             Raw event collection for backfill. Default: ${DEFAULT_FIRESTORE_EVENTS_COLLECTION}
+  --firestore-queue-collection <name>
+                             Projection queue collection. Default: ${DEFAULT_FIRESTORE_QUEUE_COLLECTION}
+  --firestore-state-collection <name>
+                             Checkpoint collection for backfill/listeners. Default: ${DEFAULT_FIRESTORE_STATE_COLLECTION}
+  --firestore-gaps-collection <name>
+                             Known backfill gap collection. Default: ${DEFAULT_FIRESTORE_GAPS_COLLECTION}
+  --backfill-page-limit <n>  Events requested per relay/kind page. Default: 500
+  --backfill-max-page-limit <n>
+                             Largest retry page size for stuck same-timestamp pages. Default: 2000
+  --backfill-max-pages <n>   Max pages per relay/kind in this process. Default: 25
+  --backfill-until <unix>    Start cursor for historical crawl. Default: now
+  --backfill-since <unix>    Stop after events older than this timestamp. Default: 0
+  --no-backfill-resume       Ignore stored Firestore cursor and start from --backfill-until.
+  --backfill-state-prefix <s>
+                             Prefix for backfill checkpoint ids. Use "overlap" for live recovery windows.
+  --projection-limit <n>     Max raw event docs read for directory projection. Default: 1000
+  --projection-source <queue|raw>
+                             Read projection work from queue or raw events. Default: queue
+  --projection-worker-id <s> Worker id written to claimed queue docs. Default: host/process id
+  --projection-lock-ms <n>   Queue claim lease duration. Default: 600000
+  --projection-external-retry-ms <n>
+                             Retry delay for temporary external proof failures. Default: 900000
+  --live-duration-ms <n>     Live listener runtime before clean shutdown; 0 means until stopped. Default: 0
+  --live-flush-limit <n>     Buffered valid events before Firestore flush. Default: 25
+  --live-flush-interval-ms <n>
+                             Max time between live event flushes. Default: 5000
+  --live-heartbeat-interval-ms <n>
+                             Live relay heartbeat interval. Default: 30000
+  --live-reconnect-min-ms <n>
+                             Initial relay reconnect delay. Default: 1000
+  --live-reconnect-max-ms <n>
+                             Max relay reconnect delay. Default: 30000
+  --live-seen-cache-limit <n>
+                             Max event ids remembered for live in-memory dedupe. Default: 50000
+  --live-connect-timeout-ms <n>
+                             Max time to wait for relay WebSocket open. Default: 15000
+  --no-processing-status     Do not write processing fields back to raw event docs.
+  --no-json                  Skip local JSON output.
   --no-tweet-verify          Extract candidates only; do not fetch X/Twitter.
   --no-zap-check             Skip LNURL/NIP-57 zappability checks.
-  --no-wot                   Skip Web-of-Trust/risk scoring.
 `);
 }
 
@@ -138,15 +351,6 @@ function queryRelay(url, filter, { timeoutMs, max }) {
     ws.addEventListener('error', () => finish('ws-error'));
     ws.addEventListener('close', () => finish('close'));
   });
-}
-
-async function queryPool(relays, filter, opts) {
-  const results = await Promise.all(relays.map((relay) => queryRelay(relay, filter, opts)));
-  const byId = new Map();
-  for (const result of results) {
-    for (const event of result.events) byId.set(event.id, event);
-  }
-  return { results, events: [...byId.values()] };
 }
 
 function latestReplaceable(events) {
@@ -250,6 +454,9 @@ function extractDirectoryInputs(events) {
         pubkey: event.pubkey,
         npub: hexToNpub(event.pubkey),
         source: `kind0.${field}`,
+        sourceKind: event.kind,
+        sourceEventId: event.id,
+        sourceCreatedAt: event.created_at,
         identityStatus: 'claimed',
       });
     }
@@ -260,23 +467,6 @@ function extractDirectoryInputs(events) {
     claimed: [...claimedByKey.values()].sort(sortClaim),
     metadataByPubkey,
   };
-}
-
-function mergeMetadata(metadataByPubkey, events) {
-  for (const event of events) {
-    if (event.kind !== 0) continue;
-    const metadata = safeJson(event.content);
-    metadataByPubkey.set(event.pubkey, {
-      pubkey: event.pubkey,
-      npub: hexToNpub(event.pubkey),
-      name: metadata.name || metadata.display_name || null,
-      nip05: metadata.nip05 || null,
-      lud16: metadata.lud16 || null,
-      lud06: metadata.lud06 || null,
-      website: metadata.website || null,
-      about: metadata.about || null,
-    });
-  }
 }
 
 function sortCandidate(a, b) {
@@ -300,15 +490,24 @@ function syndicationToken(tweetId) {
 
 async function fetchTweet(tweetId, handleHint, timeoutMs) {
   const bearerToken = process.env.X_BEARER_TOKEN || process.env.TWITTER_BEARER_TOKEN;
+  const failures = [];
   if (bearerToken) {
     const official = await fetchTweetViaXApi(tweetId, bearerToken, timeoutMs);
-    if (official) return official;
+    if (official.ok) return official;
+    failures.push(official);
+    if (official.retryable && official.rateLimited) return official;
   }
 
   const syndication = await fetchTweetViaSyndication(tweetId, timeoutMs);
-  if (syndication) return syndication;
+  if (syndication.ok) return syndication;
+  failures.push(syndication);
+  if (syndication.retryable && syndication.rateLimited) return syndication;
 
-  return fetchTweetViaOembed(tweetId, handleHint, timeoutMs);
+  const oembed = await fetchTweetViaOembed(tweetId, handleHint, timeoutMs);
+  if (oembed.ok) return oembed;
+  failures.push(oembed);
+
+  return mostImportantTweetFetchFailure(failures);
 }
 
 async function fetchTweetViaXApi(tweetId, bearerToken, timeoutMs) {
@@ -322,22 +521,28 @@ async function fetchTweetViaXApi(tweetId, bearerToken, timeoutMs) {
       headers: { Authorization: `Bearer ${bearerToken}` },
       signal: AbortSignal.timeout(timeoutMs),
     });
-    if (!response.ok) return null;
+    if (!response.ok) return tweetFetchHttpFailure('x-api', response);
     const json = await response.json();
     const user = json.includes?.users?.find((candidate) => candidate.id === json.data?.author_id);
-    if (!json.data?.text || !user?.username) return null;
+    if (!json.data?.text || !user?.username) {
+      return tweetFetchFailure('x-api', 'tweet_unavailable', { retryable: false });
+    }
     return {
-      text: json.data.text,
-      handle: user.username,
-      userId: user.id,
-      source: 'x-api',
+      ok: true,
+      tweet: {
+        text: json.data.text,
+        handle: user.username,
+        userId: user.id,
+        source: 'x-api',
+      },
     };
-  } catch {
-    return null;
+  } catch (error) {
+    return tweetFetchFailure('x-api', fetchErrorReason(error), { retryable: true });
   }
 }
 
 async function fetchTweetViaSyndication(tweetId, timeoutMs) {
+  const failures = [];
   for (const token of [syndicationToken(tweetId), 'a']) {
     try {
       const url = `https://cdn.syndication.twimg.com/tweet-result?id=${tweetId}&token=${token}&lang=en`;
@@ -345,18 +550,28 @@ async function fetchTweetViaSyndication(tweetId, timeoutMs) {
         headers: { 'User-Agent': 'Mozilla/5.0' },
         signal: AbortSignal.timeout(timeoutMs),
       });
-      if (!response.ok) continue;
+      if (!response.ok) {
+        const failure = tweetFetchHttpFailure('syndication', response);
+        failures.push(failure);
+        if (failure.retryable && failure.rateLimited) return failure;
+        continue;
+      }
       const json = await response.json();
       if (!json?.text || !json.user?.screen_name) continue;
       return {
-        text: json.text,
-        handle: json.user.screen_name,
-        userId: json.user.id_str || json.user.id || null,
-        source: 'syndication',
+        ok: true,
+        tweet: {
+          text: json.text,
+          handle: json.user.screen_name,
+          userId: json.user.id_str || json.user.id || null,
+          source: 'syndication',
+        },
       };
-    } catch {}
+    } catch (error) {
+      failures.push(tweetFetchFailure('syndication', fetchErrorReason(error), { retryable: true }));
+    }
   }
-  return null;
+  return mostImportantTweetFetchFailure(failures, tweetFetchFailure('syndication', 'tweet_unavailable', { retryable: false }));
 }
 
 async function fetchTweetViaOembed(tweetId, handleHint, timeoutMs) {
@@ -364,20 +579,64 @@ async function fetchTweetViaOembed(tweetId, handleHint, timeoutMs) {
     const tweetUrl = `https://twitter.com/${handleHint || 'i'}/status/${tweetId}`;
     const url = `https://publish.x.com/oembed?omit_script=1&url=${encodeURIComponent(tweetUrl)}`;
     const response = await fetch(url, { redirect: 'follow', signal: AbortSignal.timeout(timeoutMs) });
-    if (!response.ok) return null;
+    if (!response.ok) return tweetFetchHttpFailure('oembed', response);
     const json = await response.json();
     const handle = normalizeTwitterHandle(json.author_url);
     const text = stripHtml(json.html || '');
-    if (!handle || !text) return null;
+    if (!handle || !text) return tweetFetchFailure('oembed', 'tweet_unavailable', { retryable: false });
     return {
-      text,
-      handle,
-      userId: null,
-      source: 'oembed',
+      ok: true,
+      tweet: {
+        text,
+        handle,
+        userId: null,
+        source: 'oembed',
+      },
     };
-  } catch {
-    return null;
+  } catch (error) {
+    return tweetFetchFailure('oembed', fetchErrorReason(error), { retryable: true });
   }
+}
+
+function tweetFetchHttpFailure(source, response) {
+  const status = response.status;
+  const rateLimitResetAt = response.headers?.get?.('x-rate-limit-reset') || null;
+  const retryAfter = response.headers?.get?.('retry-after') || null;
+  const retryable = status === 429 || status === 408 || status >= 500;
+  return tweetFetchFailure(source, status === 429 ? 'rate_limited' : `http_${status}`, {
+    retryable,
+    rateLimited: status === 429,
+    status,
+    rateLimitResetAt,
+    retryAfter,
+  });
+}
+
+function tweetFetchFailure(source, reason, extra = {}) {
+  return {
+    ok: false,
+    source,
+    reason,
+    retryable: Boolean(extra.retryable),
+    rateLimited: Boolean(extra.rateLimited),
+    status: extra.status || null,
+    rateLimitResetAt: extra.rateLimitResetAt || null,
+    retryAfter: extra.retryAfter || null,
+  };
+}
+
+function mostImportantTweetFetchFailure(failures, fallback = null) {
+  const candidates = failures.filter(Boolean);
+  return candidates.find((failure) => failure.rateLimited)
+    || candidates.find((failure) => failure.retryable)
+    || candidates[0]
+    || fallback
+    || tweetFetchFailure('unknown', 'tweet_unavailable', { retryable: false });
+}
+
+function fetchErrorReason(error) {
+  if (error?.name === 'TimeoutError' || error?.name === 'AbortError') return 'timeout';
+  return 'network_error';
 }
 
 function stripHtml(html) {
@@ -393,9 +652,23 @@ function stripHtml(html) {
 }
 
 async function verifyCandidate(candidate, timeoutMs) {
-  const tweet = await fetchTweet(candidate.proofTweetId, candidate.handle, timeoutMs);
-  if (!tweet) return { ...candidate, identityStatus: 'rejected', rejectionReason: 'proof-tweet-unavailable' };
+  const result = await fetchTweet(candidate.proofTweetId, candidate.handle, timeoutMs);
+  if (!result.ok) {
+    if (result.retryable) {
+      return {
+        ...candidate,
+        identityStatus: 'retry_later',
+        retryReason: result.reason,
+        retrySource: result.source,
+        retryRateLimited: result.rateLimited,
+        rateLimitResetAt: result.rateLimitResetAt,
+        retryAfter: result.retryAfter,
+      };
+    }
+    return { ...candidate, identityStatus: 'rejected', rejectionReason: 'proof-tweet-unavailable' };
+  }
 
+  const tweet = result.tweet;
   const tweetHandle = normalizeTwitterHandle(tweet.handle);
   if (tweetHandle !== candidate.handle) {
     return {
@@ -553,14 +826,14 @@ function numericTag(tags, name) {
 }
 
 async function runCrawler(args) {
-  console.log(`Crawling ${args.relays.length} relays for kind:10011 and kind:0 identity data...`);
+  if (args.mode === 'backfill') return runBackfill(args);
+  if (args.mode === 'project') return runProjection(args);
+  if (args.mode === 'live') return runLiveListener(args);
+  throw new Error(`Unsupported mode: ${args.mode}`);
+}
 
-  const [kind10011, kind0] = await Promise.all([
-    queryPool(args.relays, { kinds: [10011] }, { timeoutMs: args.timeoutMs, max: args.kind10011Limit }),
-    queryPool(args.relays, { kinds: [0] }, { timeoutMs: args.timeoutMs, max: args.kind0Limit }),
-  ]);
-
-  const profileEvents = latestReplaceable([...kind10011.events, ...kind0.events]);
+async function buildDirectoryOutputFromEvents({ events, args, relayResults = null, source = 'events' }) {
+  const profileEvents = latestReplaceable(events);
   const { candidates, claimed, metadataByPubkey } = extractDirectoryInputs(profileEvents);
   const proofLimit = args.maxProofs === 0 ? candidates.length : Math.min(args.maxProofs, candidates.length);
 
@@ -568,10 +841,19 @@ async function runCrawler(args) {
   console.log(`Detected ${candidates.length} verifiable Twitter proof candidates and ${claimed.length} claimed-only leads.`);
 
   const verifiedOrRejected = [];
+  const retryLater = [];
+  let proofVerificationStoppedReason = null;
   if (args.verifyTweets) {
     console.log(`Verifying ${proofLimit}/${candidates.length} proof tweets...`);
     for (const candidate of candidates.slice(0, proofLimit)) {
-      verifiedOrRejected.push(await verifyCandidate(candidate, args.timeoutMs));
+      const result = await verifyCandidate(candidate, args.timeoutMs);
+      if (result.identityStatus === 'retry_later') {
+        retryLater.push(result);
+        proofVerificationStoppedReason = result.retryRateLimited ? 'x_rate_limited' : 'temporary_proof_fetch_failure';
+        if (result.retryRateLimited) break;
+      } else {
+        verifiedOrRejected.push(result);
+      }
     }
   } else {
     verifiedOrRejected.push(...candidates.map((candidate) => ({ ...candidate, identityStatus: 'candidate' })));
@@ -579,17 +861,6 @@ async function runCrawler(args) {
 
   let verified = verifiedOrRejected.filter((record) => record.identityStatus === 'verified');
   const rejected = verifiedOrRejected.filter((record) => record.identityStatus === 'rejected');
-
-  if (verified.length) {
-    console.log(`Fetching latest kind:0 metadata for ${verified.length} verified authors...`);
-    const verifiedPubkeys = [...new Set(verified.map((record) => record.pubkey))];
-    const verifiedMetadata = await queryPool(
-      args.relays,
-      { kinds: [0], authors: verifiedPubkeys },
-      { timeoutMs: args.timeoutMs, max: Math.max(verifiedPubkeys.length * 2, 50) }
-    );
-    mergeMetadata(metadataByPubkey, latestReplaceable(verifiedMetadata.events));
-  }
 
   verified = verified.map((record) => ({
     ...record,
@@ -619,21 +890,6 @@ async function runCrawler(args) {
     })),
   ];
 
-  if (args.includeWot && allDirectoryRecords.length) {
-    console.log('Collecting lightweight WoT signals for directory records...');
-    const pubkeys = [...new Set(allDirectoryRecords.map((record) => record.pubkey))];
-    const [followLists, reports, assertions] = await Promise.all([
-      queryPool(args.relays, { kinds: [3], '#p': pubkeys }, { timeoutMs: args.timeoutMs, max: 1500 }),
-      queryPool(args.relays, { kinds: [1984], '#p': pubkeys }, { timeoutMs: args.timeoutMs, max: 1000 }),
-      queryPool(args.relays, { kinds: [30382], '#d': pubkeys }, { timeoutMs: args.timeoutMs, max: 1500 }),
-    ]);
-    allDirectoryRecords = computeWotScores(allDirectoryRecords, [
-      ...followLists.events,
-      ...reports.events,
-      ...assertions.events,
-    ]);
-  }
-
   allDirectoryRecords = allDirectoryRecords.map((record) => ({
     ...record,
     autoZapAllowed: record.identityStatus === 'verified' && record.zappable === true,
@@ -641,23 +897,26 @@ async function runCrawler(args) {
 
   const output = {
     generatedAt: new Date().toISOString(),
+    source,
     strategy: {
       identityProof: 'NIP-39 kind:10011 i tags, with legacy kind:0 i tags accepted',
       proofVerification: args.verifyTweets
         ? 'proof tweet must be authored by handle and contain exact npub'
         : 'disabled by --no-tweet-verify',
+      proofVerificationStoppedReason,
       zapPolicy: 'auto-zap requires verified identity and LNURL allowsNostr',
       wotPolicy: 'WoT/NIP-85 is ranking and risk only, never identity proof',
     },
     relays: args.relays,
-    relayResults: {
-      kind10011: kind10011.results.map(summarizeRelayResult),
-      kind0: kind0.results.map(summarizeRelayResult),
-    },
+    relayResults,
     stats: {
       profileEvents: profileEvents.length,
       verifiableCandidates: candidates.length,
-      proofTweetsAttempted: args.verifyTweets ? proofLimit : 0,
+      proofTweetsPlanned: args.verifyTweets ? proofLimit : 0,
+      proofTweetsAttempted: verifiedOrRejected.length + retryLater.length,
+      proofTweetsChecked: verifiedOrRejected.length + retryLater.length,
+      proofRetriesScheduled: retryLater.length,
+      proofVerificationStopped: Boolean(proofVerificationStoppedReason),
       verified: verified.length,
       rejected: rejected.length,
       claimedOnly: claimed.length,
@@ -666,19 +925,1010 @@ async function runCrawler(args) {
     },
     directory: allDirectoryRecords.sort(sortDirectoryRecord),
     rejected,
+    retryLater,
   };
 
-  await writeJson(args.out, output);
-  printSummary(output, args.out);
   return output;
 }
 
-function summarizeRelayResult(result) {
-  return {
-    relay: result.relay,
-    events: result.events.length,
-    reason: result.reason,
+async function runBackfill(args, FirestoreCtor = Firestore) {
+  const runMetrics = createRunMetrics('backfill');
+  await assertFirestoreCredentialsAvailable();
+  const db = new FirestoreCtor({
+    projectId: args.firestoreProject,
+    databaseId: args.firestoreDatabase,
+  });
+  const startedAt = new Date().toISOString();
+  const totals = {
+    relayKindCursors: 0,
+    pages: 0,
+    relayEvents: 0,
+    validEvents: 0,
+    uniqueEventsWritten: 0,
+    completedCursors: 0,
+    gapsWritten: 0,
   };
+  const cursorSummaries = [];
+
+  console.log(
+    `Backfilling ${BACKFILL_KINDS.join(',')} from ${args.relays.length} relays into ${args.firestoreProject}/${args.firestoreDatabase}...`
+  );
+
+  for (const relay of args.relays) {
+    for (const kind of BACKFILL_KINDS) {
+      totals.relayKindCursors += 1;
+      const summary = await runBackfillCursor(db, relay, kind, args);
+      totals.pages += summary.pages;
+      totals.relayEvents += summary.relayEvents;
+      totals.validEvents += summary.validEvents;
+      totals.uniqueEventsWritten += summary.uniqueEventsWritten;
+      totals.gapsWritten += summary.gapsWritten;
+      if (summary.completed) totals.completedCursors += 1;
+      cursorSummaries.push(summary);
+    }
+  }
+
+  const output = {
+    mode: 'backfill',
+    run: finishRunMetrics(runMetrics, totals),
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    relays: args.relays,
+    kinds: BACKFILL_KINDS,
+    stats: totals,
+    cursors: cursorSummaries,
+      firestore: {
+      project: args.firestoreProject,
+      database: args.firestoreDatabase,
+      eventsCollection: args.firestoreEventsCollection,
+      queueCollection: args.firestoreQueueCollection,
+      stateCollection: args.firestoreStateCollection,
+      gapsCollection: args.firestoreGapsCollection,
+    },
+  };
+
+  await commitFirestoreWrites(db, [buildRunSummaryWrite(output.run, output, args.firestoreBackfillRunsCollection)]);
+  logRunSummary(output.run);
+
+  if (args.out) await writeJson(args.out, output);
+  printBackfillSummary(output, args);
+  return output;
+}
+
+async function runProjection(args, FirestoreCtor = Firestore) {
+  const runMetrics = createRunMetrics('projection');
+  await assertFirestoreCredentialsAvailable();
+  const db = new FirestoreCtor({
+    projectId: args.firestoreProject,
+    databaseId: args.firestoreDatabase,
+  });
+
+  console.log(
+    `Projecting up to ${args.projectionLimit} identity events from ${args.projectionSource}...`
+  );
+
+  const queueStatusCountsBefore = args.projectionSource === 'queue'
+    ? await countProjectionQueueStatuses(db, args)
+    : null;
+  const queueDocs = args.projectionSource === 'queue' ? await claimProjectionQueueDocs(db, args) : [];
+  const rawRead = args.projectionSource === 'queue'
+    ? await readRawIdentityEventDocsForQueue(db, queueDocs, args)
+    : { rawDocs: await readRawIdentityEventDocs(db, args), missingQueueDocs: [] };
+  const rawDocs = rawRead.rawDocs;
+  const eventDocs = rawDocs.map((doc) => ({
+    ...doc,
+    event: firestoreRawDocToNostrEvent(doc.data),
+  }));
+  const validRawDocs = eventDocs.filter((doc) => doc.event && isValidSignedEvent(doc.event));
+  const invalidRawDocs = eventDocs.filter((doc) => !doc.event || !isValidSignedEvent(doc.event));
+  const events = validRawDocs.map((doc) => doc.event);
+
+  const output = await buildDirectoryOutputFromEvents({
+    events,
+    args: { ...args, includeWot: false },
+    relayResults: null,
+    source: 'firestore-projection',
+  });
+  output.firestore = {
+    project: args.firestoreProject,
+    database: args.firestoreDatabase,
+    eventsCollection: args.firestoreEventsCollection,
+    queueCollection: args.firestoreQueueCollection,
+    entriesCollection: args.firestoreEntriesCollection,
+    handlesCollection: args.firestoreHandlesCollection,
+  };
+  output.stats.rawEventDocsRead = rawDocs.length;
+  output.stats.missingRawEventDocs = rawRead.missingQueueDocs.length;
+  output.stats.invalidRawEventDocs = invalidRawDocs.length;
+  output.stats.queueDocsRead = queueDocs.length;
+  output.stats.validRawEvents = events.length;
+  output.stats.queueStatusCountsBefore = queueStatusCountsBefore;
+  output.run = finishRunMetrics(runMetrics, {
+    queueDocsRead: queueDocs.length,
+    queueDocsClaimed: queueDocs.length,
+    rawEventDocsRead: rawDocs.length,
+    missingRawEventDocs: rawRead.missingQueueDocs.length,
+    invalidRawEventDocs: invalidRawDocs.length,
+    validRawEvents: events.length,
+    directoryRecords: output.directory.length,
+    rejected: output.rejected.length,
+    proofRetriesScheduled: output.stats.proofRetriesScheduled,
+    proofVerificationStopped: output.stats.proofVerificationStopped,
+    verified: output.stats.verified,
+    claimedOnly: output.stats.claimedOnly,
+    ...(queueStatusCountsBefore ? prefixObjectKeys(queueStatusCountsBefore, 'queueBefore') : {}),
+  });
+
+  const writes = [
+    ...buildFirestoreWrites(output, args),
+    ...(args.updateProcessingStatus ? buildProjectionProcessingWrites(validRawDocs, output, args) : []),
+    ...(args.updateProcessingStatus ? buildProjectionQueueWrites(validRawDocs, output, args) : []),
+    ...(args.updateProcessingStatus ? buildProjectionRawFailureWrites(invalidRawDocs, args) : []),
+    ...(args.updateProcessingStatus ? buildProjectionQueueFailureWrites(rawRead.missingQueueDocs, 'missing_raw_event', args) : []),
+    ...(args.updateProcessingStatus ? buildProjectionQueueFailureWrites(invalidRawDocs, 'invalid_raw_event', args) : []),
+    buildRunSummaryWrite(output.run, output, args.firestoreProjectionRunsCollection),
+  ];
+  await commitFirestoreWrites(db, writes);
+  logRunSummary(output.run);
+
+  if (args.out) await writeJson(args.out, output);
+  printSummary(output, args);
+  console.log(`  raw event docs read:  ${rawDocs.length}`);
+  console.log(`  queue docs read:      ${queueDocs.length}`);
+  console.log(`  valid raw events:     ${events.length}`);
+  console.log(`  firestore events:     ${args.firestoreEventsCollection}`);
+  return output;
+}
+
+async function runLiveListener(args, FirestoreCtor = Firestore) {
+  const runMetrics = createRunMetrics('live-listener');
+  await assertFirestoreCredentialsAvailable();
+  const db = new FirestoreCtor({
+    projectId: args.firestoreProject,
+    databaseId: args.firestoreDatabase,
+  });
+  const startedAt = new Date().toISOString();
+  const stopController = new AbortController();
+  const totals = {
+    relayCount: args.relays.length,
+    connectAttempts: 0,
+    reconnects: 0,
+    relayDisconnects: 0,
+    relayErrors: 0,
+    eventsReceived: 0,
+    validEventsBuffered: 0,
+    validEventsWritten: 0,
+    invalidEventsDropped: 0,
+    duplicateEvents: 0,
+    flushes: 0,
+    heartbeatWrites: 0,
+  };
+  const seenEventIds = new Set();
+  const seenEventIdQueue = [];
+  const buffer = [];
+  let stopReason = 'stopped';
+  let flushInFlight = Promise.resolve();
+
+  const stop = (reason) => {
+    if (stopController.signal.aborted) return;
+    stopReason = reason;
+    stopController.abort(reason);
+  };
+
+  const signalHandlers = [];
+  if (typeof process !== 'undefined') {
+    for (const signalName of ['SIGINT', 'SIGTERM']) {
+      const handler = () => stop(signalName);
+      process.once(signalName, handler);
+      signalHandlers.push([signalName, handler]);
+    }
+  }
+
+  let durationTimer = null;
+  if (args.liveDurationMs > 0) {
+    durationTimer = setTimeout(() => stop('duration_elapsed'), args.liveDurationMs);
+  }
+
+  const flushBuffer = async () => {
+    if (!buffer.length) return;
+    const writes = buffer.slice();
+    const rawEventWrites = writes.filter((write) => write.collection === args.firestoreEventsCollection && !write.operation).length;
+    await commitFirestoreWrites(db, writes);
+    buffer.splice(0, writes.length);
+    totals.validEventsWritten += rawEventWrites;
+    totals.flushes += 1;
+  };
+
+  const scheduleFlush = () => {
+    flushInFlight = flushInFlight.then(flushBuffer, flushBuffer);
+    return flushInFlight;
+  };
+
+  const flushInterval = setInterval(() => {
+    scheduleFlush();
+  }, args.liveFlushIntervalMs);
+
+  console.log(
+    `Listening to ${args.relays.length} relays for live kinds ${LIVE_LISTENER_KINDS.join(',')} into ${args.firestoreProject}/${args.firestoreDatabase}...`
+  );
+
+  const listeners = args.relays.map((relay) => listenRelayLive(relay, args, {
+    signal: stopController.signal,
+    onConnectAttempt: () => {
+      totals.connectAttempts += 1;
+    },
+    onReconnect: () => {
+      totals.reconnects += 1;
+    },
+    onDisconnect: () => {
+      totals.relayDisconnects += 1;
+    },
+    onError: () => {
+      totals.relayErrors += 1;
+    },
+    onEvent: (event) => {
+      totals.eventsReceived += 1;
+      if (!isValidSignedEvent(event)) {
+        totals.invalidEventsDropped += 1;
+        return;
+      }
+      if (seenEventIds.has(event.id)) {
+        totals.duplicateEvents += 1;
+        return;
+      }
+      rememberSeenEventId(event.id, seenEventIds, seenEventIdQueue, args.liveSeenCacheLimit);
+      buffer.push(...buildRawEventIngestionWrites(event, relay, 'live', args));
+      totals.validEventsBuffered += 1;
+      if (buffer.length >= args.liveFlushLimit) scheduleFlush();
+    },
+    onHeartbeat: async (status) => {
+      await commitFirestoreWrites(db, [buildLiveHeartbeatWrite(status, args)]);
+      totals.heartbeatWrites += 1;
+    },
+  }));
+
+  await Promise.all(listeners);
+  clearInterval(flushInterval);
+  if (durationTimer) clearTimeout(durationTimer);
+  await scheduleFlush();
+
+  for (const [signalName, handler] of signalHandlers) {
+    process.removeListener(signalName, handler);
+  }
+
+  const output = {
+    mode: 'live',
+    run: finishRunMetrics(runMetrics, totals),
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    stopReason,
+    relays: args.relays,
+    kinds: LIVE_LISTENER_KINDS,
+    stats: totals,
+    firestore: {
+      project: args.firestoreProject,
+      database: args.firestoreDatabase,
+      eventsCollection: args.firestoreEventsCollection,
+      queueCollection: args.firestoreQueueCollection,
+      stateCollection: args.firestoreStateCollection,
+    },
+  };
+
+  await commitFirestoreWrites(db, [buildRunSummaryWrite(output.run, output, args.firestoreLiveRunsCollection)]);
+  logRunSummary(output.run);
+  if (args.out) await writeJson(args.out, output);
+  printLiveSummary(output, args);
+  return output;
+}
+
+function listenRelayLive(relay, args, callbacks) {
+  const {
+    signal,
+    onConnectAttempt,
+    onReconnect,
+    onDisconnect,
+    onError,
+    onEvent,
+    onHeartbeat,
+  } = callbacks;
+
+  return new Promise((resolve) => {
+    let ws = null;
+    let reconnectTimer = null;
+    let heartbeatTimer = null;
+    let connectTimer = null;
+    let reconnectDelay = args.liveReconnectMinMs;
+    let attempts = 0;
+    let connected = false;
+    let lastEventAt = null;
+    let stopped = false;
+
+    const cleanup = () => {
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      if (heartbeatTimer) clearInterval(heartbeatTimer);
+      if (connectTimer) clearTimeout(connectTimer);
+      try {
+        ws?.close();
+      } catch {}
+      ws = null;
+    };
+
+    const heartbeat = async (status) => {
+      if (!onHeartbeat) return;
+      await onHeartbeat({
+        relay,
+        status,
+        mode: 'live',
+        connected,
+        lastEventAt,
+        attempts,
+      });
+    };
+
+    const finish = async () => {
+      if (stopped) return;
+      stopped = true;
+      cleanup();
+      await heartbeat('stopped').catch(() => {});
+      resolve();
+    };
+
+    const scheduleReconnect = () => {
+      if (signal.aborted || stopped) {
+        finish();
+        return;
+      }
+      const delay = reconnectDelay;
+      reconnectDelay = Math.min(reconnectDelay * 2, args.liveReconnectMaxMs);
+      onReconnect?.();
+      reconnectTimer = setTimeout(connect, delay);
+    };
+
+    const connect = () => {
+      if (signal.aborted || stopped) {
+        finish();
+        return;
+      }
+      attempts += 1;
+      onConnectAttempt?.();
+      const sub = `nc-live-${Math.random().toString(36).slice(2, 10)}`;
+
+      try {
+        ws = new WebSocket(relay);
+      } catch {
+        onError?.();
+        scheduleReconnect();
+        return;
+      }
+
+      connectTimer = setTimeout(() => {
+        onError?.();
+        try {
+          ws?.close();
+        } catch {}
+      }, args.liveConnectTimeoutMs);
+
+      ws.addEventListener('open', () => {
+        if (connectTimer) clearTimeout(connectTimer);
+        connected = true;
+        reconnectDelay = args.liveReconnectMinMs;
+        const since = Math.floor(Date.now() / 1000);
+        ws.send(JSON.stringify(['REQ', sub, { kinds: LIVE_LISTENER_KINDS, since }]));
+        heartbeat('connected').catch(() => {});
+        heartbeatTimer = setInterval(() => {
+          heartbeat(connected ? 'connected' : 'disconnected').catch(() => {});
+        }, args.liveHeartbeatIntervalMs);
+      });
+
+      ws.addEventListener('message', (ev) => {
+        let msg;
+        try {
+          msg = JSON.parse(ev.data);
+        } catch {
+          return;
+        }
+        if (msg[0] === 'EVENT' && msg[1] === sub && msg[2]?.id) {
+          lastEventAt = new Date().toISOString();
+          onEvent?.(msg[2], relay);
+        } else if (msg[0] === 'CLOSED' && msg[1] === sub) {
+          try {
+            ws.close();
+          } catch {}
+        }
+      });
+
+      ws.addEventListener('error', () => {
+        onError?.();
+      });
+
+      ws.addEventListener('close', () => {
+        if (connectTimer) clearTimeout(connectTimer);
+        connected = false;
+        if (heartbeatTimer) clearInterval(heartbeatTimer);
+        if (stopped || signal.aborted) return;
+        onDisconnect?.();
+        heartbeat('disconnected').finally(scheduleReconnect);
+      });
+    };
+
+    signal.addEventListener('abort', finish, { once: true });
+    connect();
+  });
+}
+
+async function readRawIdentityEventDocs(db, args) {
+  const querySnapshot = await db
+    .collection(args.firestoreEventsCollection)
+    .orderBy('createdAt', 'desc')
+    .limit(args.projectionLimit)
+    .get();
+  return querySnapshot.docs.map((doc) => ({ id: doc.id, data: doc.data() }));
+}
+
+async function readProjectionQueueDocs(db, args) {
+  const docs = [];
+  const perStatusLimit = Math.ceil(args.projectionLimit / 3);
+
+  for (const status of ['pending', 'retry_later', 'processing']) {
+    const querySnapshot = await db
+      .collection(args.firestoreQueueCollection)
+      .where('status', '==', status)
+      .limit(perStatusLimit)
+      .get();
+    docs.push(...querySnapshot.docs.map((doc) => ({ id: doc.id, data: doc.data() })));
+    if (docs.length >= args.projectionLimit) break;
+  }
+
+  return docs
+    .sort((a, b) => (firestoreTimestampToMs(a.data?.createdAt) || 0) - (firestoreTimestampToMs(b.data?.createdAt) || 0))
+    .slice(0, args.projectionLimit);
+}
+
+async function countProjectionQueueStatuses(db, args) {
+  const statuses = ['pending', 'retry_later', 'processing', 'done', 'ignored', 'failed'];
+  const counts = {};
+  await Promise.all(statuses.map(async (status) => {
+    try {
+      const snapshot = await db
+        .collection(args.firestoreQueueCollection)
+        .where('status', '==', status)
+        .count()
+        .get();
+      counts[status] = snapshot.data().count || 0;
+    } catch (error) {
+      counts[status] = null;
+      counts.countError = firestoreErrorSummary(error);
+    }
+  }));
+  return counts;
+}
+
+async function claimProjectionQueueDocs(db, args) {
+  const candidates = await readProjectionQueueDocs(db, args);
+  const claimed = [];
+
+  for (const candidate of candidates) {
+    if (claimed.length >= args.projectionLimit) break;
+    const claimedDoc = await claimProjectionQueueDoc(db, candidate, args);
+    if (claimedDoc) claimed.push(claimedDoc);
+  }
+
+  return claimed;
+}
+
+async function claimProjectionQueueDoc(db, candidate, args) {
+  const ref = db.collection(args.firestoreQueueCollection).doc(candidate.id);
+  const nowMs = Date.now();
+  const lockExpiresAt = new Date(nowMs + args.projectionLockMs);
+
+  return db.runTransaction(async (transaction) => {
+    const snapshot = await transaction.get(ref);
+    if (!snapshot.exists) return null;
+    const data = snapshot.data();
+    if (!queueDocIsClaimable(data, nowMs)) return null;
+
+    transaction.set(ref, buildProjectionQueueClaimData(args.projectionWorkerId, lockExpiresAt), { merge: true });
+    return {
+      id: snapshot.id,
+      data: {
+        ...data,
+        status: 'processing',
+        lockedBy: args.projectionWorkerId,
+        lockExpiresAt,
+      },
+    };
+  });
+}
+
+function buildProjectionQueueClaimData(workerId, lockExpiresAt) {
+  return stripUndefined({
+    status: 'processing',
+    lockedBy: workerId,
+    lockExpiresAt,
+    claimedAt: FieldValue.serverTimestamp(),
+    attempts: FieldValue.increment(1),
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+}
+
+function queueDocIsClaimable(data, nowMs = Date.now()) {
+  if (!data) return false;
+  const status = data.status;
+  if (!['pending', 'retry_later', 'processing'].includes(status)) return false;
+
+  const nextAttemptAtMs = firestoreTimestampToMs(data.nextAttemptAt);
+  if (status === 'retry_later' && nextAttemptAtMs && nextAttemptAtMs > nowMs) return false;
+
+  const lockExpiresAtMs = firestoreTimestampToMs(data.lockExpiresAt);
+  if (lockExpiresAtMs && lockExpiresAtMs > nowMs) return false;
+  if (status === 'processing' && !lockExpiresAtMs) return false;
+
+  return true;
+}
+
+async function readRawIdentityEventDocsForQueue(db, queueDocs, args) {
+  const reads = queueDocs.map(async ({ id, data }) => {
+    const eventId = data?.eventId || id;
+    const doc = await db.collection(args.firestoreEventsCollection).doc(firestoreSafeId(eventId)).get();
+    if (!doc.exists) return { missing: { id, data, eventId } };
+    return { id: doc.id, data: doc.data(), queueId: id };
+  });
+  const results = await Promise.all(reads);
+  return {
+    rawDocs: results.filter((result) => result && !result.missing),
+    missingQueueDocs: results.filter((result) => result?.missing).map((result) => result.missing),
+  };
+}
+
+function firestoreRawDocToNostrEvent(data) {
+  if (!data) return null;
+  if (data.eventJson) {
+    try {
+      return JSON.parse(data.eventJson);
+    } catch {
+      return null;
+    }
+  }
+  if (!data.event) return null;
+  return {
+    ...data.event,
+    tags: (data.event.tags || []).map((tag) => Array.isArray(tag) ? tag : tag.values || []),
+  };
+}
+
+function buildProjectionProcessingWrites(rawDocs, output, options = {}) {
+  const statusByEventId = buildProjectionStatusByEventId(output);
+  return rawDocs.map(({ id, data }) => {
+    const eventId = data?.id || id;
+    const status = projectionStatusForOutputRawEvent(output, eventId, statusByEventId);
+    return {
+      collection: options.firestoreEventsCollection || DEFAULT_FIRESTORE_EVENTS_COLLECTION,
+      id,
+      data: stripUndefined({
+        processing: {
+          status: status.processingStatus,
+          reason: status.reason,
+          processedAt: FieldValue.serverTimestamp(),
+          projectionRunAt: output.generatedAt,
+        },
+        identity: {
+          status: status.identityStatus,
+          reason: status.reason,
+        },
+        updatedAt: FieldValue.serverTimestamp(),
+      }),
+    };
+  });
+}
+
+function buildProjectionQueueWrites(rawDocs, output, options = {}) {
+  const statusByEventId = buildProjectionStatusByEventId(output);
+  return rawDocs.map(({ id, data }) => {
+    const eventId = data?.id || id;
+    const status = projectionStatusForOutputRawEvent(output, eventId, statusByEventId);
+    return {
+      collection: options.firestoreQueueCollection || DEFAULT_FIRESTORE_QUEUE_COLLECTION,
+      id: firestoreSafeId(eventId),
+      data: stripUndefined({
+        eventId,
+        status: queueStatusForProjection(status),
+        reason: status.reason,
+        processingStatus: status.processingStatus,
+        identityStatus: status.identityStatus,
+        nextAttemptAt: status.processingStatus === 'retry_later'
+          ? new Date(Date.now() + (options.projectionExternalRetryMs || 15 * 60 * 1000))
+          : null,
+        completedAt: FieldValue.serverTimestamp(),
+        lockedBy: null,
+        lockExpiresAt: null,
+        updatedAt: FieldValue.serverTimestamp(),
+      }),
+    };
+  });
+}
+
+function buildProjectionRawFailureWrites(rawDocs, options = {}) {
+  return rawDocs.map(({ id, data }) => {
+    const eventId = data?.id || id;
+    return {
+      collection: options.firestoreEventsCollection || DEFAULT_FIRESTORE_EVENTS_COLLECTION,
+      id,
+      data: stripUndefined({
+        processing: {
+          status: 'failed',
+          reason: 'invalid_raw_event',
+          processedAt: FieldValue.serverTimestamp(),
+        },
+        identity: {
+          status: 'unknown',
+          reason: 'invalid_raw_event',
+        },
+        updatedAt: FieldValue.serverTimestamp(),
+      }),
+      eventId,
+    };
+  });
+}
+
+function buildProjectionQueueFailureWrites(queueDocs, reason, options = {}) {
+  return queueDocs.map(({ id, data, eventId }) => ({
+    collection: options.firestoreQueueCollection || DEFAULT_FIRESTORE_QUEUE_COLLECTION,
+    id: firestoreSafeId(eventId || data?.eventId || data?.id || id),
+    data: stripUndefined({
+      eventId: eventId || data?.eventId || data?.id || id,
+      status: 'failed',
+      reason,
+      processingStatus: 'failed',
+      identityStatus: 'unknown',
+      completedAt: FieldValue.serverTimestamp(),
+      lockedBy: null,
+      lockExpiresAt: null,
+      updatedAt: FieldValue.serverTimestamp(),
+    }),
+  }));
+}
+
+function projectionStatusForOutputRawEvent(output, eventId, statusByEventId) {
+  if (output.strategy?.proofVerificationStoppedReason) {
+    return {
+      processingStatus: 'retry_later',
+      identityStatus: 'unknown',
+      reason: output.strategy.proofVerificationStoppedReason,
+    };
+  }
+  return statusByEventId.get(eventId) || projectionStatusForRawEvent(eventId, new Set(), new Set(), new Map());
+}
+
+function buildProjectionStatusByEventId(output) {
+  const usefulEventIds = new Set();
+  const verifiedEventIds = new Set();
+  const rejectedByEventId = new Map();
+  const retryByEventId = new Map();
+
+  for (const record of output.directory || []) {
+    if (record.sourceEventId) usefulEventIds.add(record.sourceEventId);
+    if (record.identityStatus === 'verified' && record.sourceEventId) verifiedEventIds.add(record.sourceEventId);
+  }
+  for (const record of output.rejected || []) {
+    if (!record.sourceEventId) continue;
+    usefulEventIds.add(record.sourceEventId);
+    rejectedByEventId.set(record.sourceEventId, record.rejectionReason || 'identity_rejected');
+  }
+  for (const record of output.retryLater || []) {
+    if (!record.sourceEventId) continue;
+    retryByEventId.set(record.sourceEventId, record.retryReason || 'temporary_proof_fetch_failure');
+  }
+
+  const eventIds = new Set([...usefulEventIds, ...rejectedByEventId.keys(), ...retryByEventId.keys()]);
+  const statuses = new Map();
+  for (const eventId of eventIds) {
+    statuses.set(eventId, projectionStatusForRawEvent(eventId, usefulEventIds, verifiedEventIds, rejectedByEventId, retryByEventId));
+  }
+  return statuses;
+}
+
+function queueStatusForProjection(status) {
+  if (status.processingStatus === 'retry_later') return 'retry_later';
+  return status.processingStatus === 'ignored' ? 'ignored' : 'done';
+}
+
+function projectionStatusForRawEvent(eventId, usefulEventIds, verifiedEventIds, rejectedByEventId, retryByEventId = new Map()) {
+  if (retryByEventId.has(eventId)) {
+    return { processingStatus: 'retry_later', identityStatus: 'unknown', reason: retryByEventId.get(eventId) };
+  }
+  if (verifiedEventIds.has(eventId)) {
+    return { processingStatus: 'processed', identityStatus: 'verified', reason: 'verified_identity_proof' };
+  }
+  if (rejectedByEventId.has(eventId)) {
+    return { processingStatus: 'processed', identityStatus: 'rejected', reason: rejectedByEventId.get(eventId) };
+  }
+  if (usefulEventIds.has(eventId)) {
+    return { processingStatus: 'processed', identityStatus: 'claimed', reason: 'claimed_identity_signal' };
+  }
+  return { processingStatus: 'ignored', identityStatus: 'none', reason: 'no_identity_signal' };
+}
+
+async function runBackfillCursor(db, relay, kind, args) {
+  const stateRef = db.collection(args.firestoreStateCollection).doc(backfillStateId(relay, kind, args.backfillStatePrefix));
+  const previousState = args.backfillResume ? await readBackfillState(stateRef) : null;
+  if (previousState?.status === 'complete') {
+    console.log(`  ${relay} kind:${kind} already complete; use --no-backfill-resume to recrawl.`);
+    return {
+      relay,
+      kind,
+      pages: 0,
+      relayEvents: 0,
+      validEvents: 0,
+      uniqueEventsWritten: 0,
+      gapsWritten: 0,
+      cursorUntil: previousState.cursorUntil,
+      oldestSeenAt: previousState.oldestSeenAt,
+      completed: true,
+      lastReason: previousState.lastReason || 'already-complete',
+    };
+  }
+  let until = previousState?.cursorUntil || args.backfillUntil;
+  let pageLimit = previousState?.pageLimit || args.backfillPageLimit;
+  let boundaryTimestamp = previousState?.boundaryTimestamp || null;
+  let boundarySeenIds = new Set(previousState?.boundarySeenIds || []);
+  let stuckCount = previousState?.stuckCount || 0;
+  let completed = false;
+  let lastReason = null;
+  let oldestSeenAt = previousState?.oldestSeenAt || null;
+  let pages = 0;
+  let relayEvents = 0;
+  let validEvents = 0;
+  let uniqueEventsWritten = 0;
+  let gapsWritten = 0;
+
+  console.log(`  ${relay} kind:${kind} starting until=${until}`);
+
+  while (pages < args.backfillMaxPages && until > args.backfillSince) {
+    const page = await queryRelay(
+      relay,
+      { kinds: [kind], until },
+      { timeoutMs: args.timeoutMs, max: pageLimit }
+    );
+    pages += 1;
+    lastReason = page.reason;
+    relayEvents += page.events.length;
+
+    const valid = dedupeEvents(page.events).filter(isValidSignedEvent);
+    validEvents += valid.length;
+    uniqueEventsWritten += valid.length;
+
+    const pageOldest = oldestCreatedAt(page.events);
+    if (!page.events.length || !pageOldest || pageOldest <= args.backfillSince) {
+      await commitFirestoreWrites(db, [
+        ...valid.flatMap((event) => buildRawEventIngestionWrites(event, relay, 'backfill', args)),
+        buildBackfillCheckpointWrite(
+          {
+            relay,
+            kind,
+            cursorUntil: pageOldest ? Math.max(pageOldest - 1, args.backfillSince) : until,
+            oldestSeenAt: pageOldest ? Math.min(oldestSeenAt || pageOldest, pageOldest) : oldestSeenAt,
+            pageEvents: page.events.length,
+            validPageEvents: valid.length,
+            lastReason,
+            completed: true,
+            pageLimit,
+            boundaryTimestamp,
+            boundarySeenIds: [...boundarySeenIds],
+            stuckCount,
+          },
+          args
+        ),
+      ]);
+      completed = true;
+      break;
+    }
+
+    const decision = decideBackfillCursor({
+      cursorUntil: until,
+      pageOldest,
+      pageEvents: page.events,
+      boundaryTimestamp,
+      boundarySeenIds,
+      stuckCount,
+      pageLimit,
+      defaultPageLimit: args.backfillPageLimit,
+      maxPageLimit: args.backfillMaxPageLimit,
+    });
+    until = decision.cursorUntil;
+    pageLimit = decision.pageLimit;
+    boundaryTimestamp = decision.boundaryTimestamp;
+    boundarySeenIds = new Set(decision.boundarySeenIds);
+    stuckCount = decision.stuckCount;
+    oldestSeenAt = Math.min(oldestSeenAt || pageOldest, pageOldest);
+
+    const writes = [
+      ...valid.flatMap((event) => buildRawEventIngestionWrites(event, relay, 'backfill', args)),
+      buildBackfillCheckpointWrite(
+        {
+          relay,
+          kind,
+          cursorUntil: until,
+          oldestSeenAt,
+          pageEvents: page.events.length,
+          validPageEvents: valid.length,
+          lastReason: decision.reason || lastReason,
+          completed: false,
+          pageLimit,
+          boundaryTimestamp,
+          boundarySeenIds: [...boundarySeenIds],
+          stuckCount,
+        },
+        args
+      ),
+    ];
+
+    if (decision.gap) {
+      writes.push(buildBackfillGapWrite({ ...decision.gap, relay, kind }, args));
+      gapsWritten += 1;
+    }
+
+    await commitFirestoreWrites(db, writes);
+  }
+
+  if (pages >= args.backfillMaxPages && until > args.backfillSince) {
+    console.log(`    paused after ${pages} page(s), resume cursor=${until}`);
+  } else {
+    completed = true;
+  }
+
+  await stateRef.set(
+    stripUndefined({
+      relay,
+      kind,
+      mode: 'backfill',
+      statePrefix: args.backfillStatePrefix,
+      cursorUntil: until,
+      oldestSeenAt,
+      pageLimit,
+      boundaryTimestamp,
+      boundarySeenIds: [...boundarySeenIds],
+      stuckCount,
+      completed,
+      status: completed ? 'complete' : 'paused',
+      lastReason,
+      updatedAt: FieldValue.serverTimestamp(),
+    }),
+    { merge: true }
+  );
+
+  console.log(
+    `    pages=${pages} relayEvents=${relayEvents} validEvents=${validEvents} status=${completed ? 'complete' : 'paused'}`
+  );
+
+  return {
+    relay,
+    kind,
+    pages,
+    relayEvents,
+    validEvents,
+    uniqueEventsWritten,
+    gapsWritten,
+    cursorUntil: until,
+    oldestSeenAt,
+    completed,
+    lastReason,
+  };
+}
+
+async function readBackfillState(stateRef) {
+  const docSnapshot = await stateRef.get();
+  if (!docSnapshot.exists) return null;
+  return docSnapshot.data() || null;
+}
+
+function dedupeEvents(events) {
+  const byId = new Map();
+  for (const event of events) {
+    if (event?.id) byId.set(event.id, event);
+  }
+  return [...byId.values()];
+}
+
+function oldestCreatedAt(events) {
+  let oldest = null;
+  for (const event of events) {
+    if (!Number.isFinite(event?.created_at)) continue;
+    oldest = oldest === null ? event.created_at : Math.min(oldest, event.created_at);
+  }
+  return oldest;
+}
+
+function decideBackfillCursor({
+  cursorUntil,
+  pageOldest,
+  pageEvents,
+  boundaryTimestamp,
+  boundarySeenIds,
+  stuckCount,
+  pageLimit,
+  defaultPageLimit,
+  maxPageLimit,
+}) {
+  if (pageOldest < cursorUntil) {
+    const nextBoundaryIds = eventIdsAtTimestamp(pageEvents, pageOldest);
+    return {
+      action: 'progress',
+      reason: 'older-events-found',
+      cursorUntil: pageOldest,
+      pageLimit: defaultPageLimit,
+      boundaryTimestamp: pageOldest,
+      boundarySeenIds: nextBoundaryIds,
+      stuckCount: 0,
+      gap: null,
+    };
+  }
+
+  const currentBoundaryIds = eventIdsAtTimestamp(pageEvents, cursorUntil);
+  const previousBoundaryIds = boundaryTimestamp === cursorUntil ? new Set(boundarySeenIds || []) : new Set();
+  const mergedBoundaryIds = new Set([...previousBoundaryIds, ...currentBoundaryIds]);
+  const newBoundaryIds = currentBoundaryIds.filter((id) => !previousBoundaryIds.has(id));
+
+  if (newBoundaryIds.length) {
+    return {
+      action: 'drain-boundary',
+      reason: 'new-boundary-events-found',
+      cursorUntil,
+      pageLimit,
+      boundaryTimestamp: cursorUntil,
+      boundarySeenIds: [...mergedBoundaryIds],
+      stuckCount: 0,
+      gap: null,
+    };
+  }
+
+  if (pageLimit < maxPageLimit) {
+    return {
+      action: 'increase-limit',
+      reason: 'same-boundary-no-new-events',
+      cursorUntil,
+      pageLimit: Math.min(pageLimit * 2, maxPageLimit),
+      boundaryTimestamp: cursorUntil,
+      boundarySeenIds: [...mergedBoundaryIds],
+      stuckCount: stuckCount + 1,
+      gap: null,
+    };
+  }
+
+  return {
+    action: 'skip-gap',
+    reason: 'stuck-same-timestamp',
+    cursorUntil: cursorUntil - 1,
+    pageLimit: defaultPageLimit,
+    boundaryTimestamp: null,
+    boundarySeenIds: [],
+    stuckCount: 0,
+    gap: {
+      relay: null,
+      kind: null,
+      timestamp: cursorUntil,
+      reason: 'stuck_same_timestamp',
+      pageLimit,
+      seenEventIds: [...mergedBoundaryIds],
+    },
+  };
+}
+
+function eventIdsAtTimestamp(events, timestamp) {
+  return dedupeEvents(events)
+    .filter((event) => event.created_at === timestamp)
+    .map((event) => event.id)
+    .sort();
+}
+
+function rememberSeenEventId(eventId, seenEventIds, seenEventIdQueue, limit) {
+  if (seenEventIds.has(eventId)) return false;
+  seenEventIds.add(eventId);
+  seenEventIdQueue.push(eventId);
+  while (seenEventIdQueue.length > limit) {
+    const expired = seenEventIdQueue.shift();
+    seenEventIds.delete(expired);
+  }
+  return true;
 }
 
 function sortDirectoryRecord(a, b) {
@@ -691,7 +1941,461 @@ async function writeJson(file, data) {
   await writeFile(outPath, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
 }
 
-function printSummary(output, out) {
+function buildFirestoreWrites(output, options = {}) {
+  const entriesCollection = options.firestoreEntriesCollection || DEFAULT_FIRESTORE_ENTRIES_COLLECTION;
+  const handlesCollection = options.firestoreHandlesCollection || DEFAULT_FIRESTORE_HANDLES_COLLECTION;
+  const runId = firestoreSafeId(output.generatedAt);
+  const writes = [];
+
+  for (const record of output.directory) {
+    writes.push({
+      collection: entriesCollection,
+      id: firestoreDirectoryRecordId(record),
+      data: stripUndefined({
+        ...record,
+        runId,
+        lastSeenAt: output.generatedAt,
+        updatedAt: FieldValue.serverTimestamp(),
+      }),
+    });
+  }
+
+  for (const summary of buildHandleSummaries(output.directory, output.generatedAt, runId)) {
+    writes.push({
+      collection: handlesCollection,
+      id: firestoreHandleId(summary.platform, summary.handle),
+      data: stripUndefined({
+        ...summary,
+        updatedAt: FieldValue.serverTimestamp(),
+      }),
+    });
+  }
+
+  return writes;
+}
+
+async function commitFirestoreWrites(db, writes) {
+  const normalWrites = [];
+  const createIfMissingWrites = [];
+  for (const write of writes) {
+    if (write.operation === 'createIfMissing') {
+      createIfMissingWrites.push(write);
+    } else {
+      normalWrites.push(write);
+    }
+  }
+
+  await commitCreateIfMissingWrites(db, createIfMissingWrites);
+
+  for (let i = 0; i < normalWrites.length; i += 450) {
+    const batch = db.batch();
+    for (const write of normalWrites.slice(i, i + 450)) {
+      batch.set(db.collection(write.collection).doc(write.id), write.data, { merge: true });
+    }
+    await batch.commit();
+  }
+}
+
+async function commitCreateIfMissingWrites(db, writes) {
+  for (let i = 0; i < writes.length; i += CREATE_IF_MISSING_CONCURRENCY) {
+    await Promise.all(
+      writes
+        .slice(i, i + CREATE_IF_MISSING_CONCURRENCY)
+        .map((write) => createFirestoreDocIfMissing(db, write))
+    );
+  }
+}
+
+async function createFirestoreDocIfMissing(db, write) {
+  try {
+    await db.collection(write.collection).doc(write.id).create(write.data);
+  } catch (error) {
+    if (isAlreadyExistsError(error)) return;
+    throw error;
+  }
+}
+
+function isAlreadyExistsError(error) {
+  return error?.code === 6 || /already exists/i.test(String(error?.message || ''));
+}
+
+function firestoreErrorSummary(error) {
+  return stripUndefined({
+    code: error?.code || null,
+    message: String(error?.message || 'unknown').slice(0, 200),
+  });
+}
+
+function firestoreTimestampToMs(value) {
+  if (!value) return null;
+  if (value instanceof Date) return value.getTime();
+  if (typeof value.toMillis === 'function') return value.toMillis();
+  if (typeof value.seconds === 'number') {
+    return value.seconds * 1000 + Math.floor((value.nanoseconds || 0) / 1000000);
+  }
+  if (typeof value === 'number') return value;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+async function assertFirestoreCredentialsAvailable() {
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS) return;
+  if (process.env.CLOUD_RUN_JOB || process.env.K_SERVICE || process.env.FUNCTION_NAME) return;
+
+  const adcPath = getApplicationDefaultCredentialsPath();
+
+  try {
+    await access(adcPath);
+  } catch {
+    throw new Error(
+      'Firestore write requires Application Default Credentials. Run `gcloud auth application-default login` locally, or run the crawler in Cloud Run with a Firestore-enabled service account.'
+    );
+  }
+}
+
+function getApplicationDefaultCredentialsPath() {
+  if (process.env.CLOUDSDK_CONFIG) {
+    return path.join(process.env.CLOUDSDK_CONFIG, 'application_default_credentials.json');
+  }
+  if (process.env.APPDATA) {
+    return path.join(process.env.APPDATA, 'gcloud', 'application_default_credentials.json');
+  }
+  return path.join(os.homedir(), '.config', 'gcloud', 'application_default_credentials.json');
+}
+
+function buildHandleSummaries(records, generatedAt, runId) {
+  const byHandle = new Map();
+
+  for (const record of records) {
+    const key = firestoreHandleId(record.platform, record.handle);
+    const current = byHandle.get(key) || {
+      platform: record.platform,
+      handle: record.handle,
+      runId,
+      lastSeenAt: generatedAt,
+      recordCount: 0,
+      verifiedCount: 0,
+      zappableVerifiedCount: 0,
+      autoZapAllowedCount: 0,
+      best: null,
+      records: [],
+    };
+
+    current.recordCount += 1;
+    if (record.identityStatus === 'verified') current.verifiedCount += 1;
+    if (record.identityStatus === 'verified' && record.zappable === true) current.zappableVerifiedCount += 1;
+    if (record.autoZapAllowed === true) current.autoZapAllowedCount += 1;
+    current.records.push({
+      pubkey: record.pubkey,
+      npub: record.npub,
+      directoryStatus: record.directoryStatus,
+      identityStatus: record.identityStatus,
+      autoZapAllowed: record.autoZapAllowed,
+      zappable: record.zappable,
+      wotScore: record.wot?.score ?? null,
+      entryId: firestoreDirectoryRecordId(record),
+    });
+
+    byHandle.set(key, current);
+  }
+
+  return [...byHandle.values()].map((summary) => ({
+    ...summary,
+    records: summary.records.sort(sortHandleSummaryRecord),
+    best: summary.records.sort(sortHandleSummaryRecord)[0] || null,
+  }));
+}
+
+function buildBackfillEventWrite(event, relay, options = {}) {
+  return {
+    collection: options.firestoreEventsCollection || DEFAULT_FIRESTORE_EVENTS_COLLECTION,
+    id: firestoreSafeId(event.id),
+    data: stripUndefined({
+      id: event.id,
+      kind: event.kind,
+      pubkey: event.pubkey,
+      createdAt: event.created_at,
+      sourceRelays: FieldValue.arrayUnion(relay),
+      event: normalizeEventForFirestore(event),
+      eventJson: JSON.stringify(event),
+      ingestion: {
+        mode: 'backfill',
+        lastRelay: relay,
+        lastSeenAt: FieldValue.serverTimestamp(),
+      },
+      updatedAt: FieldValue.serverTimestamp(),
+    }),
+  };
+}
+
+function buildLiveEventWrite(event, relay, options = {}) {
+  return {
+    collection: options.firestoreEventsCollection || DEFAULT_FIRESTORE_EVENTS_COLLECTION,
+    id: firestoreSafeId(event.id),
+    data: stripUndefined({
+      id: event.id,
+      kind: event.kind,
+      pubkey: event.pubkey,
+      createdAt: event.created_at,
+      sourceRelays: FieldValue.arrayUnion(relay),
+      event: normalizeEventForFirestore(event),
+      eventJson: JSON.stringify(event),
+      ingestion: {
+        mode: 'live',
+        lastRelay: relay,
+        lastSeenAt: FieldValue.serverTimestamp(),
+      },
+      updatedAt: FieldValue.serverTimestamp(),
+    }),
+  };
+}
+
+function buildRawEventIngestionWrites(event, relay, mode, options = {}) {
+  return [
+    mode === 'live' ? buildLiveEventWrite(event, relay, options) : buildBackfillEventWrite(event, relay, options),
+    buildProjectionQueueCreateWrite(event, mode, options),
+  ];
+}
+
+function buildProjectionQueueCreateWrite(event, mode, options = {}) {
+  return {
+    operation: 'createIfMissing',
+    collection: options.firestoreQueueCollection || DEFAULT_FIRESTORE_QUEUE_COLLECTION,
+    id: firestoreSafeId(event.id),
+    data: stripUndefined({
+      eventId: event.id,
+      kind: event.kind,
+      pubkey: event.pubkey,
+      eventCreatedAt: event.created_at,
+      sourceMode: mode,
+      status: 'pending',
+      reason: 'awaiting_projection',
+      attempts: 0,
+      nextAttemptAt: FieldValue.serverTimestamp(),
+      createdAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    }),
+  };
+}
+
+function buildLiveHeartbeatWrite({
+  relay,
+  status,
+  mode,
+  connected,
+  lastEventAt,
+  attempts,
+}, options = {}) {
+  return {
+    collection: options.firestoreStateCollection || DEFAULT_FIRESTORE_STATE_COLLECTION,
+    id: liveStateId(relay),
+    data: stripUndefined({
+      relay,
+      mode: mode || 'live',
+      status,
+      connected,
+      lastEventAt,
+      connectAttempts: attempts,
+      heartbeatAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    }),
+  };
+}
+
+function normalizeEventForFirestore(event) {
+  return {
+    id: event.id,
+    kind: event.kind,
+    pubkey: event.pubkey,
+    created_at: event.created_at,
+    content: event.content || '',
+    tags: (event.tags || []).map((tag) => ({ values: tag.map((value) => String(value)) })),
+    sig: event.sig,
+  };
+}
+
+function buildBackfillCheckpointWrite({
+  relay,
+  kind,
+  cursorUntil,
+  oldestSeenAt,
+  pageEvents,
+  validPageEvents,
+  lastReason,
+  completed,
+  pageLimit,
+  boundaryTimestamp,
+  boundarySeenIds,
+  stuckCount,
+}, options = {}) {
+  return {
+    collection: options.firestoreStateCollection || DEFAULT_FIRESTORE_STATE_COLLECTION,
+    id: backfillStateId(relay, kind, options.backfillStatePrefix || 'backfill'),
+    data: stripUndefined({
+      relay,
+      kind,
+      mode: 'backfill',
+      statePrefix: options.backfillStatePrefix || 'backfill',
+      cursorUntil,
+      oldestSeenAt,
+      pageLimit,
+      boundaryTimestamp,
+      boundarySeenIds,
+      stuckCount,
+      pagesProcessed: FieldValue.increment(1),
+      relayEventsSeen: FieldValue.increment(pageEvents),
+      validEventsSeen: FieldValue.increment(validPageEvents),
+      completed,
+      status: completed ? 'complete' : 'running',
+      lastReason,
+      updatedAt: FieldValue.serverTimestamp(),
+    }),
+  };
+}
+
+function buildBackfillGapWrite({
+  relay,
+  kind,
+  timestamp,
+  reason,
+  pageLimit,
+  seenEventIds,
+}, options = {}) {
+  return {
+    collection: options.firestoreGapsCollection || DEFAULT_FIRESTORE_GAPS_COLLECTION,
+    id: firestoreSafeId(`${relay}:kind:${kind}:timestamp:${timestamp}`),
+    data: stripUndefined({
+      relay,
+      kind,
+      timestamp,
+      reason,
+      pageLimit,
+      seenEventIds,
+      updatedAt: FieldValue.serverTimestamp(),
+    }),
+  };
+}
+
+function backfillStateId(relay, kind, prefix = 'backfill') {
+  return firestoreSafeId(`${prefix}:${relay}:kind:${kind}`);
+}
+
+function liveStateId(relay) {
+  return firestoreSafeId(`live:${relay}`);
+}
+
+function sortHandleSummaryRecord(a, b) {
+  const aStatus = statusRank(a);
+  const bStatus = statusRank(b);
+  return aStatus - bStatus || (b.wotScore || 0) - (a.wotScore || 0) || a.pubkey.localeCompare(b.pubkey);
+}
+
+function statusRank(record) {
+  if (record.autoZapAllowed) return 0;
+  if (record.directoryStatus === 'verified_not_zappable') return 1;
+  if (record.identityStatus === 'verified') return 2;
+  return 3;
+}
+
+function firestoreDirectoryRecordId(record) {
+  return firestoreSafeId(`${record.platform}:${record.handle}:${record.pubkey}`);
+}
+
+function firestoreHandleId(platform, handle) {
+  return firestoreSafeId(`${platform}:${handle}`);
+}
+
+function firestoreSafeId(value) {
+  return String(value).replace(/[/.#[\]]/g, '_');
+}
+
+function stripUndefined(value) {
+  if (Array.isArray(value)) return value.map(stripUndefined);
+  if (value instanceof Date) return value;
+  if (!value || typeof value !== 'object' || value instanceof FieldValue) return value;
+
+  const result = {};
+  for (const [key, child] of Object.entries(value)) {
+    if (child !== undefined) result[key] = stripUndefined(child);
+  }
+  return result;
+}
+
+function createRunMetrics(component, now = new Date()) {
+  return {
+    component,
+    runId: `${component}-${firestoreSafeId(now.toISOString())}`,
+    startedAt: now.toISOString(),
+    startedMs: now.getTime(),
+    timings: [],
+  };
+}
+
+function finishRunMetrics(runMetrics, counters = {}, now = new Date()) {
+  return stripUndefined({
+    component: runMetrics.component,
+    runId: runMetrics.runId,
+    startedAt: runMetrics.startedAt,
+    finishedAt: now.toISOString(),
+    durationMs: now.getTime() - runMetrics.startedMs,
+    memoryRssMb: memoryRssMb(),
+    avgProcessingMs: average(runMetrics.timings),
+    p95ProcessingMs: percentile(runMetrics.timings, 95),
+    counters,
+  });
+}
+
+function buildRunSummaryWrite(run, output, collection) {
+  return {
+    collection,
+    id: run.runId,
+    data: stripUndefined({
+      ...run,
+      mode: output.mode || output.source || run.component,
+      source: output.source || null,
+      stats: output.stats || null,
+      firestore: output.firestore || null,
+      relays: output.relays || null,
+      updatedAt: FieldValue.serverTimestamp(),
+    }),
+  };
+}
+
+function logRunSummary(run) {
+  console.log(JSON.stringify({
+    severity: 'INFO',
+    message: 'crawler_run_summary',
+    component: run.component,
+    runId: run.runId,
+    durationMs: run.durationMs,
+    memoryRssMb: run.memoryRssMb,
+    counters: run.counters,
+  }));
+}
+
+function memoryRssMb() {
+  return Math.round(process.memoryUsage().rss / 1024 / 1024);
+}
+
+function average(values) {
+  if (!values.length) return 0;
+  return Math.round(values.reduce((sum, value) => sum + value, 0) / values.length);
+}
+
+function percentile(values, percentileValue) {
+  if (!values.length) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.max(0, Math.ceil(sorted.length * (percentileValue / 100)) - 1);
+  return sorted[index];
+}
+
+function prefixObjectKeys(object, prefix) {
+  return Object.fromEntries(
+    Object.entries(object || {}).map(([key, value]) => [`${prefix}${key[0].toUpperCase()}${key.slice(1)}`, value])
+  );
+}
+
+function printSummary(output, args) {
   console.log('\nDirectory crawl complete.');
   console.log(`  profile events:       ${output.stats.profileEvents}`);
   console.log(`  proof candidates:     ${output.stats.verifiableCandidates}`);
@@ -700,7 +2404,44 @@ function printSummary(output, out) {
   console.log(`  claimed-only:         ${output.stats.claimedOnly}`);
   console.log(`  zappable verified:    ${output.stats.zappableVerified}`);
   console.log(`  auto-zap allowed:     ${output.stats.autoZapAllowed}`);
-  console.log(`  output:               ${out}`);
+  if (args.out) console.log(`  output:               ${args.out}`);
+  if (args.writeFirestore) {
+    console.log(`  firestore project:    ${args.firestoreProject}`);
+    console.log(`  firestore entries:    ${args.firestoreEntriesCollection}`);
+  }
+}
+
+function printBackfillSummary(output, args) {
+  console.log('\nBackfill complete.');
+  console.log(`  relay/kind cursors:   ${output.stats.relayKindCursors}`);
+  console.log(`  pages:                ${output.stats.pages}`);
+  console.log(`  relay events:         ${output.stats.relayEvents}`);
+  console.log(`  valid events:         ${output.stats.validEvents}`);
+  console.log(`  event docs written:   ${output.stats.uniqueEventsWritten}`);
+  console.log(`  gaps written:         ${output.stats.gapsWritten}`);
+  console.log(`  completed cursors:    ${output.stats.completedCursors}`);
+  console.log(`  firestore project:    ${args.firestoreProject}`);
+  console.log(`  firestore events:     ${args.firestoreEventsCollection}`);
+  console.log(`  firestore state:      ${args.firestoreStateCollection}`);
+  if (args.out) console.log(`  output:               ${args.out}`);
+}
+
+function printLiveSummary(output, args) {
+  console.log('\nLive listener stopped.');
+  console.log(`  stop reason:          ${output.stopReason}`);
+  console.log(`  relays:               ${output.stats.relayCount}`);
+  console.log(`  connect attempts:     ${output.stats.connectAttempts}`);
+  console.log(`  reconnects:           ${output.stats.reconnects}`);
+  console.log(`  relay disconnects:    ${output.stats.relayDisconnects}`);
+  console.log(`  relay errors:         ${output.stats.relayErrors}`);
+  console.log(`  events received:      ${output.stats.eventsReceived}`);
+  console.log(`  valid events written: ${output.stats.validEventsWritten}`);
+  console.log(`  invalid dropped:      ${output.stats.invalidEventsDropped}`);
+  console.log(`  duplicates:           ${output.stats.duplicateEvents}`);
+  console.log(`  firestore project:    ${args.firestoreProject}`);
+  console.log(`  firestore events:     ${args.firestoreEventsCollection}`);
+  console.log(`  firestore state:      ${args.firestoreStateCollection}`);
+  if (args.out) console.log(`  output:               ${args.out}`);
 }
 
 const isMain = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
@@ -713,10 +2454,34 @@ if (isMain) {
 }
 
 export {
+  buildBackfillCheckpointWrite,
+  buildBackfillEventWrite,
+  buildBackfillGapWrite,
+  buildLiveEventWrite,
+  buildLiveHeartbeatWrite,
+  buildProjectionQueueCreateWrite,
+  buildProjectionQueueClaimData,
+  buildProjectionQueueFailureWrites,
+  buildProjectionQueueWrites,
+  buildProjectionRawFailureWrites,
+  buildFirestoreWrites,
+  buildRunSummaryWrite,
+  buildProjectionProcessingWrites,
   computeWotScores,
+  createRunMetrics,
+  decideBackfillCursor,
   extractDirectoryInputs,
   extractTweetId,
+  firestoreRawDocToNostrEvent,
+  firestoreTimestampToMs,
   lightningAddressToLnurlp,
+  liveStateId,
   normalizeTwitterHandle,
+  projectionStatusForRawEvent,
+  queueDocIsClaimable,
+  queueStatusForProjection,
+  rememberSeenEventId,
+  finishRunMetrics,
+  percentile,
   runCrawler,
 };

--- a/scripts/relay-directory-crawler.mjs
+++ b/scripts/relay-directory-crawler.mjs
@@ -91,8 +91,14 @@ function parseArgs(argv) {
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
-    const next = () => argv[++i];
-    if (arg === '--mode') args.mode = next();
+    const next = (flagName) => {
+      const value = argv[++i];
+      if (value === undefined || value.startsWith('--')) {
+        throw new Error(`${flagName} requires a value.`);
+      }
+      return value;
+    };
+    if (arg === '--mode') args.mode = next('--mode');
     else if (arg === '--backfill') {
       args.mode = 'backfill';
       args.writeFirestore = true;
@@ -108,45 +114,45 @@ function parseArgs(argv) {
       args.writeFirestore = true;
       args.out = null;
     }
-    else if (arg === '--relays') args.relays = next().split(',').map((s) => s.trim()).filter(Boolean);
-    else if (arg === '--out') args.out = next();
-    else if (arg === '--timeout-ms') args.timeoutMs = Number(next());
-    else if (arg === '--max-proofs') args.maxProofs = Number(next());
+    else if (arg === '--relays') args.relays = next('--relays').split(',').map((s) => s.trim()).filter(Boolean);
+    else if (arg === '--out') args.out = next('--out');
+    else if (arg === '--timeout-ms') args.timeoutMs = Number(next('--timeout-ms'));
+    else if (arg === '--max-proofs') args.maxProofs = Number(next('--max-proofs'));
     else if (arg === '--firestore') args.writeFirestore = true;
     else if (arg === '--firestore-project') {
-      args.firestoreProject = next();
+      args.firestoreProject = next('--firestore-project');
       args.writeFirestore = true;
     }
-    else if (arg === '--firestore-database') args.firestoreDatabase = next();
-    else if (arg === '--firestore-entries-collection') args.firestoreEntriesCollection = next();
-    else if (arg === '--firestore-handles-collection') args.firestoreHandlesCollection = next();
-    else if (arg === '--firestore-backfill-runs-collection') args.firestoreBackfillRunsCollection = next();
-    else if (arg === '--firestore-projection-runs-collection') args.firestoreProjectionRunsCollection = next();
-    else if (arg === '--firestore-live-runs-collection') args.firestoreLiveRunsCollection = next();
-    else if (arg === '--firestore-events-collection') args.firestoreEventsCollection = next();
-    else if (arg === '--firestore-queue-collection') args.firestoreQueueCollection = next();
-    else if (arg === '--firestore-state-collection') args.firestoreStateCollection = next();
-    else if (arg === '--firestore-gaps-collection') args.firestoreGapsCollection = next();
-    else if (arg === '--backfill-page-limit') args.backfillPageLimit = Number(next());
-    else if (arg === '--backfill-max-page-limit') args.backfillMaxPageLimit = Number(next());
-    else if (arg === '--backfill-max-pages') args.backfillMaxPages = Number(next());
-    else if (arg === '--backfill-until') args.backfillUntil = Number(next());
-    else if (arg === '--backfill-since') args.backfillSince = Number(next());
+    else if (arg === '--firestore-database') args.firestoreDatabase = next('--firestore-database');
+    else if (arg === '--firestore-entries-collection') args.firestoreEntriesCollection = next('--firestore-entries-collection');
+    else if (arg === '--firestore-handles-collection') args.firestoreHandlesCollection = next('--firestore-handles-collection');
+    else if (arg === '--firestore-backfill-runs-collection') args.firestoreBackfillRunsCollection = next('--firestore-backfill-runs-collection');
+    else if (arg === '--firestore-projection-runs-collection') args.firestoreProjectionRunsCollection = next('--firestore-projection-runs-collection');
+    else if (arg === '--firestore-live-runs-collection') args.firestoreLiveRunsCollection = next('--firestore-live-runs-collection');
+    else if (arg === '--firestore-events-collection') args.firestoreEventsCollection = next('--firestore-events-collection');
+    else if (arg === '--firestore-queue-collection') args.firestoreQueueCollection = next('--firestore-queue-collection');
+    else if (arg === '--firestore-state-collection') args.firestoreStateCollection = next('--firestore-state-collection');
+    else if (arg === '--firestore-gaps-collection') args.firestoreGapsCollection = next('--firestore-gaps-collection');
+    else if (arg === '--backfill-page-limit') args.backfillPageLimit = Number(next('--backfill-page-limit'));
+    else if (arg === '--backfill-max-page-limit') args.backfillMaxPageLimit = Number(next('--backfill-max-page-limit'));
+    else if (arg === '--backfill-max-pages') args.backfillMaxPages = Number(next('--backfill-max-pages'));
+    else if (arg === '--backfill-until') args.backfillUntil = Number(next('--backfill-until'));
+    else if (arg === '--backfill-since') args.backfillSince = Number(next('--backfill-since'));
     else if (arg === '--no-backfill-resume') args.backfillResume = false;
-    else if (arg === '--backfill-state-prefix') args.backfillStatePrefix = next();
-    else if (arg === '--projection-limit') args.projectionLimit = Number(next());
-    else if (arg === '--projection-source') args.projectionSource = next();
-    else if (arg === '--projection-worker-id') args.projectionWorkerId = next();
-    else if (arg === '--projection-lock-ms') args.projectionLockMs = Number(next());
-    else if (arg === '--projection-external-retry-ms') args.projectionExternalRetryMs = Number(next());
-    else if (arg === '--live-duration-ms') args.liveDurationMs = Number(next());
-    else if (arg === '--live-flush-limit') args.liveFlushLimit = Number(next());
-    else if (arg === '--live-flush-interval-ms') args.liveFlushIntervalMs = Number(next());
-    else if (arg === '--live-heartbeat-interval-ms') args.liveHeartbeatIntervalMs = Number(next());
-    else if (arg === '--live-reconnect-min-ms') args.liveReconnectMinMs = Number(next());
-    else if (arg === '--live-reconnect-max-ms') args.liveReconnectMaxMs = Number(next());
-    else if (arg === '--live-seen-cache-limit') args.liveSeenCacheLimit = Number(next());
-    else if (arg === '--live-connect-timeout-ms') args.liveConnectTimeoutMs = Number(next());
+    else if (arg === '--backfill-state-prefix') args.backfillStatePrefix = next('--backfill-state-prefix');
+    else if (arg === '--projection-limit') args.projectionLimit = Number(next('--projection-limit'));
+    else if (arg === '--projection-source') args.projectionSource = next('--projection-source');
+    else if (arg === '--projection-worker-id') args.projectionWorkerId = next('--projection-worker-id');
+    else if (arg === '--projection-lock-ms') args.projectionLockMs = Number(next('--projection-lock-ms'));
+    else if (arg === '--projection-external-retry-ms') args.projectionExternalRetryMs = Number(next('--projection-external-retry-ms'));
+    else if (arg === '--live-duration-ms') args.liveDurationMs = Number(next('--live-duration-ms'));
+    else if (arg === '--live-flush-limit') args.liveFlushLimit = Number(next('--live-flush-limit'));
+    else if (arg === '--live-flush-interval-ms') args.liveFlushIntervalMs = Number(next('--live-flush-interval-ms'));
+    else if (arg === '--live-heartbeat-interval-ms') args.liveHeartbeatIntervalMs = Number(next('--live-heartbeat-interval-ms'));
+    else if (arg === '--live-reconnect-min-ms') args.liveReconnectMinMs = Number(next('--live-reconnect-min-ms'));
+    else if (arg === '--live-reconnect-max-ms') args.liveReconnectMaxMs = Number(next('--live-reconnect-max-ms'));
+    else if (arg === '--live-seen-cache-limit') args.liveSeenCacheLimit = Number(next('--live-seen-cache-limit'));
+    else if (arg === '--live-connect-timeout-ms') args.liveConnectTimeoutMs = Number(next('--live-connect-timeout-ms'));
     else if (arg === '--no-processing-status') args.updateProcessingStatus = false;
     else if (arg === '--no-json') args.out = null;
     else if (arg === '--no-tweet-verify') args.verifyTweets = false;
@@ -843,17 +849,30 @@ async function buildDirectoryOutputFromEvents({ events, args, relayResults = nul
   const verifiedOrRejected = [];
   const retryLater = [];
   let proofVerificationStoppedReason = null;
+  let proofTweetsAttempted = 0;
   if (args.verifyTweets) {
     console.log(`Verifying ${proofLimit}/${candidates.length} proof tweets...`);
     for (const candidate of candidates.slice(0, proofLimit)) {
+      proofTweetsAttempted += 1;
       const result = await verifyCandidate(candidate, args.timeoutMs);
       if (result.identityStatus === 'retry_later') {
         retryLater.push(result);
-        proofVerificationStoppedReason = result.retryRateLimited ? 'x_rate_limited' : 'temporary_proof_fetch_failure';
-        if (result.retryRateLimited) break;
+        if (result.retryRateLimited) {
+          proofVerificationStoppedReason = 'x_rate_limited';
+          break;
+        }
       } else {
         verifiedOrRejected.push(result);
       }
+    }
+    for (const candidate of candidates.slice(proofTweetsAttempted)) {
+      retryLater.push({
+        ...candidate,
+        identityStatus: 'retry_later',
+        retryReason: proofVerificationStoppedReason || 'max_proof_limit_reached',
+        retrySource: 'crawler',
+        retryRateLimited: proofVerificationStoppedReason === 'x_rate_limited',
+      });
     }
   } else {
     verifiedOrRejected.push(...candidates.map((candidate) => ({ ...candidate, identityStatus: 'candidate' })));
@@ -913,8 +932,8 @@ async function buildDirectoryOutputFromEvents({ events, args, relayResults = nul
       profileEvents: profileEvents.length,
       verifiableCandidates: candidates.length,
       proofTweetsPlanned: args.verifyTweets ? proofLimit : 0,
-      proofTweetsAttempted: verifiedOrRejected.length + retryLater.length,
-      proofTweetsChecked: verifiedOrRejected.length + retryLater.length,
+      proofTweetsAttempted,
+      proofTweetsChecked: proofTweetsAttempted,
       proofRetriesScheduled: retryLater.length,
       proofVerificationStopped: Boolean(proofVerificationStoppedReason),
       verified: verified.length,
@@ -2454,6 +2473,7 @@ if (isMain) {
 }
 
 export {
+  parseArgs,
   buildBackfillCheckpointWrite,
   buildBackfillEventWrite,
   buildBackfillGapWrite,

--- a/scripts/relay-directory-crawler.mjs
+++ b/scripts/relay-directory-crawler.mjs
@@ -75,6 +75,8 @@ function printHelp() {
 
 Build a verified X/Twitter -> Nostr directory from relay data.
 
+Requires Node.js 22+ for the native WebSocket client used to query relays.
+
 Options:
   --relays <csv>             Relays to query. Default: ${DEFAULT_RELAYS.join(',')}
   --out <file>               JSON output path. Default: ${DEFAULT_OUT}
@@ -287,7 +289,10 @@ function sortClaim(a, b) {
 
 function syndicationToken(tweetId) {
   try {
-    return ((Number(tweetId) / 1e15) * Math.PI).toString(36).replace(/(0+|\.)/g, '') || 'a';
+    const id = BigInt(tweetId);
+    const divisor = 1000000000000000n;
+    const scaled = Number(id / divisor) + Number(id % divisor) / Number(divisor);
+    return (scaled * Math.PI).toString(36).replace(/(0+|\.)/g, '') || 'a';
   } catch {
     return 'a';
   }

--- a/scripts/relay-directory-crawler.test.mjs
+++ b/scripts/relay-directory-crawler.test.mjs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+import {
+  computeWotScores,
+  extractDirectoryInputs,
+  extractTweetId,
+  lightningAddressToLnurlp,
+  normalizeTwitterHandle,
+} from './relay-directory-crawler.mjs';
+
+const PUBKEY = '7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e';
+const NPUB = 'npub10elfcs4fr0l0r8af98jlmgdh9c8tcxjvz9qkw038js35mp4dma8qzvjptg';
+
+describe('normalizeTwitterHandle', () => {
+  it('normalizes handles and X/Twitter profile URLs', () => {
+    expect(normalizeTwitterHandle('@Jack')).toBe('jack');
+    expect(normalizeTwitterHandle('https://x.com/Bebop2077_')).toBe('bebop2077_');
+    expect(normalizeTwitterHandle('https://twitter.com/alice/status/123')).toBe('alice');
+  });
+
+  it('rejects invalid handles', () => {
+    expect(normalizeTwitterHandle('this-has-dashes')).toBeNull();
+    expect(normalizeTwitterHandle('waytoolongtwitterhandle')).toBeNull();
+    expect(normalizeTwitterHandle('https://x.com/i/communities/1747149501561778581')).toBeNull();
+  });
+});
+
+describe('extractTweetId', () => {
+  it('extracts a numeric tweet id from URLs or raw ids', () => {
+    expect(extractTweetId('2064733905014440088')).toBe('2064733905014440088');
+    expect(extractTweetId('https://x.com/alice/status/2064733905014440088?s=20')).toBe(
+      '2064733905014440088'
+    );
+    expect(extractTweetId('AldenCo18783')).toBeNull();
+  });
+});
+
+describe('extractDirectoryInputs', () => {
+  it('extracts verifiable NIP-39 candidates and claimed-only leads', () => {
+    const { candidates, claimed, metadataByPubkey } = extractDirectoryInputs([
+      {
+        id: 'evt1',
+        kind: 10011,
+        pubkey: PUBKEY,
+        created_at: 1,
+        content: '',
+        tags: [['i', 'twitter:Alice', 'https://x.com/Alice/status/2064733905014440088']],
+      },
+      {
+        id: 'evt2',
+        kind: 0,
+        pubkey: PUBKEY,
+        created_at: 2,
+        content: JSON.stringify({
+          name: 'Alice',
+          lud16: 'alice@getalby.com',
+          about: 'X: https://x.com/alice',
+        }),
+        tags: [],
+      },
+    ]);
+
+    expect(candidates).toEqual([
+      expect.objectContaining({
+        handle: 'alice',
+        npub: NPUB,
+        proofTweetId: '2064733905014440088',
+        sourceKind: 10011,
+      }),
+    ]);
+    expect(claimed).toEqual([
+      expect.objectContaining({
+        handle: 'alice',
+        identityStatus: 'claimed',
+        source: 'kind0.about',
+      }),
+    ]);
+    expect(metadataByPubkey.get(PUBKEY).lud16).toBe('alice@getalby.com');
+  });
+});
+
+describe('lightningAddressToLnurlp', () => {
+  it('converts lud16 to a LNURL-pay metadata endpoint', () => {
+    expect(lightningAddressToLnurlp('alice@getalby.com')).toBe(
+      'https://getalby.com/.well-known/lnurlp/alice'
+    );
+  });
+});
+
+describe('computeWotScores', () => {
+  it('adds ranking signals without changing identity status or auto-zap policy', () => {
+    const claimed = {
+      handle: 'alice',
+      pubkey: PUBKEY,
+      identityStatus: 'claimed',
+      autoZapAllowed: false,
+    };
+
+    const scored = computeWotScores([claimed], [
+      {
+        id: 'follow',
+        kind: 3,
+        pubkey: '1111111111111111111111111111111111111111111111111111111111111111',
+        created_at: 1,
+        content: '',
+        tags: [['p', PUBKEY]],
+        sig: 'invalid-for-test',
+      },
+    ]);
+
+    expect(scored[0].identityStatus).toBe('claimed');
+    expect(scored[0].autoZapAllowed).toBe(false);
+    expect(scored[0].wot.note).toContain('not identity proof');
+  });
+});

--- a/scripts/relay-directory-crawler.test.mjs
+++ b/scripts/relay-directory-crawler.test.mjs
@@ -76,7 +76,9 @@ describe('extractDirectoryInputs', () => {
         source: 'kind0.about',
       }),
     ]);
-    expect(metadataByPubkey.get(PUBKEY).lud16).toBe('alice@getalby.com');
+    const metadata = metadataByPubkey.get(PUBKEY);
+    expect(metadata).toBeDefined();
+    expect(metadata?.lud16).toBe('alice@getalby.com');
   });
 });
 

--- a/scripts/relay-directory-crawler.test.mjs
+++ b/scripts/relay-directory-crawler.test.mjs
@@ -2,11 +2,35 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  buildBackfillCheckpointWrite,
+  buildBackfillEventWrite,
+  buildBackfillGapWrite,
+  buildFirestoreWrites,
+  buildLiveEventWrite,
+  buildLiveHeartbeatWrite,
+  buildProjectionQueueClaimData,
+  buildProjectionQueueFailureWrites,
+  buildProjectionProcessingWrites,
+  buildProjectionQueueCreateWrite,
+  buildProjectionQueueWrites,
+  buildProjectionRawFailureWrites,
+  buildRunSummaryWrite,
   computeWotScores,
+  createRunMetrics,
+  decideBackfillCursor,
   extractDirectoryInputs,
   extractTweetId,
+  finishRunMetrics,
+  firestoreRawDocToNostrEvent,
+  firestoreTimestampToMs,
   lightningAddressToLnurlp,
+  liveStateId,
   normalizeTwitterHandle,
+  percentile,
+  projectionStatusForRawEvent,
+  queueDocIsClaimable,
+  queueStatusForProjection,
+  rememberSeenEventId,
 } from './relay-directory-crawler.mjs';
 
 const PUBKEY = '7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e';
@@ -114,5 +138,786 @@ describe('computeWotScores', () => {
     expect(scored[0].identityStatus).toBe('claimed');
     expect(scored[0].autoZapAllowed).toBe(false);
     expect(scored[0].wot.note).toContain('not identity proof');
+  });
+});
+
+describe('buildFirestoreWrites', () => {
+  it('creates entry and handle documents for Firestore persistence', () => {
+    const writes = buildFirestoreWrites(
+      {
+        generatedAt: '2026-06-16T13:00:00.000Z',
+        strategy: { identityProof: 'test' },
+        relays: ['wss://relay.example'],
+        relayResults: { kind10011: [], kind0: [] },
+        stats: {
+          profileEvents: 1,
+          verifiableCandidates: 1,
+          proofTweetsAttempted: 1,
+          verified: 1,
+          rejected: 0,
+          claimedOnly: 0,
+          zappableVerified: 1,
+          autoZapAllowed: 1,
+        },
+        directory: [
+          {
+            platform: 'twitter',
+            handle: 'alice',
+            pubkey: PUBKEY,
+            npub: NPUB,
+            identityStatus: 'verified',
+            directoryStatus: 'verified_zappable',
+            zappable: true,
+            autoZapAllowed: true,
+            wot: { score: 42 },
+          },
+        ],
+        rejected: [],
+      },
+      {
+        firestoreEntriesCollection: 'entries',
+        firestoreHandlesCollection: 'handles',
+      }
+    );
+
+    expect(writes).toHaveLength(2);
+    expect(writes[0]).toMatchObject({
+      collection: 'entries',
+      id: `twitter:alice:${PUBKEY}`,
+      data: expect.objectContaining({
+        handle: 'alice',
+        runId: '2026-06-16T13:00:00_000Z',
+        autoZapAllowed: true,
+      }),
+    });
+    expect(writes[1]).toMatchObject({
+      collection: 'handles',
+      id: 'twitter:alice',
+      data: expect.objectContaining({
+        handle: 'alice',
+        best: expect.objectContaining({
+          entryId: `twitter:alice:${PUBKEY}`,
+          autoZapAllowed: true,
+        }),
+      }),
+    });
+  });
+});
+
+describe('backfill Firestore writes', () => {
+  it('stores raw relay events by event id', () => {
+    const write = buildBackfillEventWrite(
+      {
+        id: 'event/with.unsafe#chars',
+        kind: 10011,
+        pubkey: PUBKEY,
+        created_at: 1710000000,
+        content: '',
+        tags: [['i', 'twitter:alice', 'https://x.com/alice/status/2064733905014440088']],
+        sig: 'sig',
+      },
+      'wss://relay.example',
+      { firestoreEventsCollection: 'events' }
+    );
+
+    expect(write).toMatchObject({
+      collection: 'events',
+      id: 'event_with_unsafe_chars',
+      data: {
+        id: 'event/with.unsafe#chars',
+        kind: 10011,
+        pubkey: PUBKEY,
+        createdAt: 1710000000,
+        event: expect.objectContaining({
+          id: 'event/with.unsafe#chars',
+          tags: [{ values: ['i', 'twitter:alice', 'https://x.com/alice/status/2064733905014440088'] }],
+        }),
+        eventJson: expect.stringContaining('twitter:alice'),
+      },
+    });
+  });
+
+  it('creates a projection queue doc only when missing', () => {
+    const write = buildProjectionQueueCreateWrite(
+      {
+        id: 'queue-event',
+        kind: 0,
+        pubkey: PUBKEY,
+        created_at: 1710000000,
+      },
+      'backfill',
+      { firestoreQueueCollection: 'queue' }
+    );
+
+    expect(write).toMatchObject({
+      operation: 'createIfMissing',
+      collection: 'queue',
+      id: 'queue-event',
+      data: expect.objectContaining({
+        eventId: 'queue-event',
+        kind: 0,
+        pubkey: PUBKEY,
+        sourceMode: 'backfill',
+        status: 'pending',
+        reason: 'awaiting_projection',
+        attempts: 0,
+      }),
+    });
+  });
+
+  it('stores resumable relay-kind backfill checkpoints', () => {
+    const write = buildBackfillCheckpointWrite(
+      {
+        relay: 'wss://relay.example',
+        kind: 10011,
+        cursorUntil: 1709999999,
+        oldestSeenAt: 1710000000,
+        pageEvents: 10,
+        validPageEvents: 8,
+        lastReason: 'eose',
+        completed: false,
+      },
+      { firestoreStateCollection: 'state' }
+    );
+
+    expect(write).toMatchObject({
+      collection: 'state',
+      id: 'backfill:wss:__relay_example:kind:10011',
+      data: expect.objectContaining({
+        relay: 'wss://relay.example',
+        kind: 10011,
+        cursorUntil: 1709999999,
+        oldestSeenAt: 1710000000,
+        status: 'running',
+        lastReason: 'eose',
+      }),
+    });
+  });
+
+  it('stores overlap backfill checkpoints separately from historical checkpoints', () => {
+    const write = buildBackfillCheckpointWrite(
+      {
+        relay: 'wss://relay.example',
+        kind: 0,
+        cursorUntil: 500,
+        oldestSeenAt: 450,
+        pageEvents: 10,
+        validPageEvents: 9,
+        lastReason: 'eose',
+        completed: false,
+      },
+      {
+        firestoreStateCollection: 'state',
+        backfillStatePrefix: 'overlap',
+      }
+    );
+
+    expect(write).toMatchObject({
+      collection: 'state',
+      id: 'overlap:wss:__relay_example:kind:0',
+      data: expect.objectContaining({
+        mode: 'backfill',
+        statePrefix: 'overlap',
+        status: 'running',
+      }),
+    });
+  });
+
+  it('stores known backfill gaps before skipping stuck timestamps', () => {
+    const write = buildBackfillGapWrite(
+      {
+        relay: 'wss://relay.example',
+        kind: 10011,
+        timestamp: 498,
+        reason: 'stuck_same_timestamp',
+        pageLimit: 2000,
+        seenEventIds: ['a', 'b'],
+      },
+      { firestoreGapsCollection: 'gaps' }
+    );
+
+    expect(write).toMatchObject({
+      collection: 'gaps',
+      id: 'wss:__relay_example:kind:10011:timestamp:498',
+      data: expect.objectContaining({
+        relay: 'wss://relay.example',
+        kind: 10011,
+        timestamp: 498,
+        reason: 'stuck_same_timestamp',
+        seenEventIds: ['a', 'b'],
+      }),
+    });
+  });
+});
+
+describe('live listener Firestore writes', () => {
+  it('stores live events without overwriting projection processing state', () => {
+    const write = buildLiveEventWrite(
+      {
+        id: 'live-event',
+        kind: 10011,
+        pubkey: PUBKEY,
+        created_at: 1710000001,
+        content: '',
+        tags: [['i', 'twitter:alice', 'https://x.com/alice/status/2064733905014440088']],
+        sig: 'sig',
+      },
+      'wss://relay.example',
+      { firestoreEventsCollection: 'events' }
+    );
+
+    expect(write).toMatchObject({
+      collection: 'events',
+      id: 'live-event',
+      data: {
+        id: 'live-event',
+        kind: 10011,
+        pubkey: PUBKEY,
+        createdAt: 1710000001,
+        ingestion: expect.objectContaining({
+          mode: 'live',
+          lastRelay: 'wss://relay.example',
+        }),
+      },
+    });
+    expect(write.data.processing).toBeUndefined();
+    expect(write.data.ingestion.needsProjection).toBeUndefined();
+  });
+
+  it('keeps live event id dedupe bounded', () => {
+    const seen = new Set();
+    const queue = [];
+
+    expect(rememberSeenEventId('a', seen, queue, 2)).toBe(true);
+    expect(rememberSeenEventId('b', seen, queue, 2)).toBe(true);
+    expect(rememberSeenEventId('a', seen, queue, 2)).toBe(false);
+    expect(rememberSeenEventId('c', seen, queue, 2)).toBe(true);
+
+    expect([...seen]).toEqual(['b', 'c']);
+    expect(queue).toEqual(['b', 'c']);
+  });
+
+  it('stores live relay heartbeat state by relay id', () => {
+    const write = buildLiveHeartbeatWrite(
+      {
+        relay: 'wss://relay.example',
+        status: 'connected',
+        mode: 'live',
+        connected: true,
+        lastEventAt: '2026-06-19T10:00:00.000Z',
+        attempts: 2,
+      },
+      { firestoreStateCollection: 'state' }
+    );
+
+    expect(liveStateId('wss://relay.example')).toBe('live:wss:__relay_example');
+    expect(write).toMatchObject({
+      collection: 'state',
+      id: 'live:wss:__relay_example',
+      data: expect.objectContaining({
+        relay: 'wss://relay.example',
+        mode: 'live',
+        status: 'connected',
+        connected: true,
+        connectAttempts: 2,
+      }),
+    });
+  });
+});
+
+describe('decideBackfillCursor', () => {
+  const base = {
+    defaultPageLimit: 100,
+    maxPageLimit: 400,
+    stuckCount: 0,
+    pageLimit: 100,
+    boundaryTimestamp: null,
+    boundarySeenIds: [],
+  };
+
+  it('moves the cursor to the oldest timestamp when the page progresses backward', () => {
+    const decision = decideBackfillCursor({
+      ...base,
+      cursorUntil: 500,
+      pageOldest: 498,
+      pageEvents: [
+        { id: 'a', created_at: 500 },
+        { id: 'b', created_at: 498 },
+      ],
+    });
+
+    expect(decision).toMatchObject({
+      action: 'progress',
+      cursorUntil: 498,
+      boundaryTimestamp: 498,
+      boundarySeenIds: ['b'],
+      stuckCount: 0,
+    });
+  });
+
+  it('keeps the same cursor when same-timestamp boundary has new event ids', () => {
+    const decision = decideBackfillCursor({
+      ...base,
+      cursorUntil: 498,
+      pageOldest: 498,
+      boundaryTimestamp: 498,
+      boundarySeenIds: ['a', 'b'],
+      pageEvents: [
+        { id: 'a', created_at: 498 },
+        { id: 'b', created_at: 498 },
+        { id: 'c', created_at: 498 },
+      ],
+    });
+
+    expect(decision).toMatchObject({
+      action: 'drain-boundary',
+      cursorUntil: 498,
+      boundarySeenIds: ['a', 'b', 'c'],
+      stuckCount: 0,
+    });
+  });
+
+  it('increases page limit before skipping a same-timestamp page with no new ids', () => {
+    const decision = decideBackfillCursor({
+      ...base,
+      cursorUntil: 498,
+      pageOldest: 498,
+      boundaryTimestamp: 498,
+      boundarySeenIds: ['a', 'b'],
+      pageEvents: [
+        { id: 'a', created_at: 498 },
+        { id: 'b', created_at: 498 },
+      ],
+    });
+
+    expect(decision).toMatchObject({
+      action: 'increase-limit',
+      cursorUntil: 498,
+      pageLimit: 200,
+      stuckCount: 1,
+      gap: null,
+    });
+  });
+
+  it('records a gap and skips the timestamp after max page limit is exhausted', () => {
+    const decision = decideBackfillCursor({
+      ...base,
+      cursorUntil: 498,
+      pageOldest: 498,
+      pageLimit: 400,
+      boundaryTimestamp: 498,
+      boundarySeenIds: ['a', 'b'],
+      pageEvents: [
+        { id: 'a', created_at: 498 },
+        { id: 'b', created_at: 498 },
+      ],
+    });
+
+    expect(decision).toMatchObject({
+      action: 'skip-gap',
+      cursorUntil: 497,
+      pageLimit: 100,
+      boundaryTimestamp: null,
+      boundarySeenIds: [],
+      stuckCount: 0,
+      gap: {
+        timestamp: 498,
+        reason: 'stuck_same_timestamp',
+        pageLimit: 400,
+        seenEventIds: ['a', 'b'],
+      },
+    });
+  });
+});
+
+describe('projection helpers', () => {
+  it('rebuilds exact Nostr events from Firestore eventJson', () => {
+    const event = {
+      id: 'evt-json',
+      kind: 10011,
+      pubkey: PUBKEY,
+      created_at: 1710000000,
+      content: '',
+      tags: [['i', 'twitter:alice', 'https://x.com/alice/status/2064733905014440088']],
+      sig: 'sig',
+    };
+
+    expect(firestoreRawDocToNostrEvent({ eventJson: JSON.stringify(event) })).toEqual(event);
+  });
+
+  it('rebuilds Nostr events from Firestore-safe tag objects', () => {
+    expect(
+      firestoreRawDocToNostrEvent({
+        event: {
+          id: 'evt-safe',
+          kind: 10011,
+          pubkey: PUBKEY,
+          created_at: 1710000000,
+          content: '',
+          tags: [{ values: ['i', 'twitter:alice', 'proof'] }],
+          sig: 'sig',
+        },
+      })
+    ).toMatchObject({
+      id: 'evt-safe',
+      tags: [['i', 'twitter:alice', 'proof']],
+    });
+  });
+
+  it('classifies projection processing statuses', () => {
+    expect(
+      projectionStatusForRawEvent('verified-event', new Set(['verified-event']), new Set(['verified-event']), new Map())
+    ).toEqual({
+      processingStatus: 'processed',
+      identityStatus: 'verified',
+      reason: 'verified_identity_proof',
+    });
+    expect(
+      projectionStatusForRawEvent('claimed-event', new Set(['claimed-event']), new Set(), new Map())
+    ).toEqual({
+      processingStatus: 'processed',
+      identityStatus: 'claimed',
+      reason: 'claimed_identity_signal',
+    });
+    expect(
+      projectionStatusForRawEvent('ignored-event', new Set(), new Set(), new Map())
+    ).toEqual({
+      processingStatus: 'ignored',
+      identityStatus: 'none',
+      reason: 'no_identity_signal',
+    });
+    expect(
+      projectionStatusForRawEvent(
+        'rejected-event',
+        new Set(['rejected-event']),
+        new Set(),
+        new Map([['rejected-event', 'proof_author_mismatch']])
+      )
+    ).toEqual({
+      processingStatus: 'processed',
+      identityStatus: 'rejected',
+      reason: 'proof_author_mismatch',
+    });
+  });
+
+  it('maps projection results to terminal queue statuses', () => {
+    expect(queueStatusForProjection({ processingStatus: 'processed' })).toBe('done');
+    expect(queueStatusForProjection({ processingStatus: 'ignored' })).toBe('ignored');
+    expect(queueStatusForProjection({ processingStatus: 'retry_later' })).toBe('retry_later');
+  });
+
+  it('claims only due or expired queue docs', () => {
+    const now = Date.parse('2026-06-19T12:00:00.000Z');
+
+    expect(queueDocIsClaimable({ status: 'pending' }, now)).toBe(true);
+    expect(
+      queueDocIsClaimable(
+        {
+          status: 'retry_later',
+          nextAttemptAt: new Date('2026-06-19T12:00:01.000Z'),
+        },
+        now
+      )
+    ).toBe(false);
+    expect(
+      queueDocIsClaimable(
+        {
+          status: 'processing',
+          lockedBy: 'worker-a',
+          lockExpiresAt: new Date('2026-06-19T11:59:59.000Z'),
+        },
+        now
+      )
+    ).toBe(true);
+    expect(
+      queueDocIsClaimable(
+        {
+          status: 'processing',
+          lockedBy: 'worker-a',
+          lockExpiresAt: new Date('2026-06-19T12:00:01.000Z'),
+        },
+        now
+      )
+    ).toBe(false);
+    expect(queueDocIsClaimable({ status: 'done' }, now)).toBe(false);
+  });
+
+  it('builds queue claim writes with worker ownership and lock expiry', () => {
+    const lockExpiresAt = new Date('2026-06-19T12:10:00.000Z');
+    const data = buildProjectionQueueClaimData('worker-a', lockExpiresAt);
+
+    expect(data).toMatchObject({
+      status: 'processing',
+      lockedBy: 'worker-a',
+      lockExpiresAt,
+    });
+  });
+
+  it('normalizes Firestore-like timestamps for retry and lock comparisons', () => {
+    expect(firestoreTimestampToMs({ seconds: 10, nanoseconds: 500000000 })).toBe(10500);
+    expect(firestoreTimestampToMs(new Date('1970-01-01T00:00:11.000Z'))).toBe(11000);
+    expect(firestoreTimestampToMs('1970-01-01T00:00:12.000Z')).toBe(12000);
+  });
+
+  it('builds processing writes for raw event docs after projection', () => {
+    const writes = buildProjectionProcessingWrites(
+      [
+        { id: 'verified-doc', data: { id: 'verified-event' } },
+        { id: 'claimed-doc', data: { id: 'claimed-event' } },
+        { id: 'ignored-doc', data: { id: 'ignored-event' } },
+        { id: 'rejected-doc', data: { id: 'rejected-event' } },
+      ],
+      {
+        generatedAt: '2026-06-18T00:00:00.000Z',
+        directory: [
+          {
+            sourceEventId: 'verified-event',
+            identityStatus: 'verified',
+          },
+          {
+            sourceEventId: 'claimed-event',
+            identityStatus: 'claimed',
+          },
+        ],
+        rejected: [
+          {
+            sourceEventId: 'rejected-event',
+            rejectionReason: 'npub-not-in-proof-tweet',
+          },
+        ],
+      },
+      { firestoreEventsCollection: 'events' }
+    );
+
+    expect(writes).toHaveLength(4);
+    expect(writes[0]).toMatchObject({
+      collection: 'events',
+      id: 'verified-doc',
+      data: {
+        processing: expect.objectContaining({
+          status: 'processed',
+          reason: 'verified_identity_proof',
+        }),
+        identity: {
+          status: 'verified',
+          reason: 'verified_identity_proof',
+        },
+      },
+    });
+    expect(writes[2]).toMatchObject({
+      id: 'ignored-doc',
+      data: {
+        processing: expect.objectContaining({
+          status: 'ignored',
+          reason: 'no_identity_signal',
+        }),
+        identity: {
+          status: 'none',
+          reason: 'no_identity_signal',
+        },
+      },
+    });
+    expect(writes[3]).toMatchObject({
+      id: 'rejected-doc',
+      data: {
+        identity: {
+          status: 'rejected',
+          reason: 'npub-not-in-proof-tweet',
+        },
+      },
+    });
+  });
+
+  it('builds queue completion writes after projection', () => {
+    const writes = buildProjectionQueueWrites(
+      [
+        { id: 'verified-doc', data: { id: 'verified-event' } },
+        { id: 'ignored-doc', data: { id: 'ignored-event' } },
+      ],
+      {
+        directory: [
+          {
+            sourceEventId: 'verified-event',
+            identityStatus: 'verified',
+          },
+        ],
+        rejected: [],
+      },
+      { firestoreQueueCollection: 'queue' }
+    );
+
+    expect(writes).toHaveLength(2);
+    expect(writes[0]).toMatchObject({
+      collection: 'queue',
+      id: 'verified-event',
+      data: expect.objectContaining({
+        eventId: 'verified-event',
+        status: 'done',
+        reason: 'verified_identity_proof',
+        lockedBy: null,
+        lockExpiresAt: null,
+      }),
+    });
+    expect(writes[1]).toMatchObject({
+      collection: 'queue',
+      id: 'ignored-event',
+      data: expect.objectContaining({
+        eventId: 'ignored-event',
+        status: 'ignored',
+        reason: 'no_identity_signal',
+      }),
+    });
+  });
+
+  it('keeps claimed queue docs retryable when external proof verification stops', () => {
+    const writes = buildProjectionQueueWrites(
+      [
+        { id: 'event-a', data: { id: 'event-a' } },
+        { id: 'event-b', data: { id: 'event-b' } },
+      ],
+      {
+        strategy: {
+          proofVerificationStoppedReason: 'x_rate_limited',
+        },
+        directory: [],
+        rejected: [],
+        retryLater: [],
+      },
+      {
+        firestoreQueueCollection: 'queue',
+        projectionExternalRetryMs: 60000,
+      }
+    );
+
+    expect(writes).toHaveLength(2);
+    for (const write of writes) {
+      expect(write).toMatchObject({
+        collection: 'queue',
+        data: expect.objectContaining({
+          status: 'retry_later',
+          reason: 'x_rate_limited',
+          processingStatus: 'retry_later',
+          identityStatus: 'unknown',
+          lockedBy: null,
+          lockExpiresAt: null,
+        }),
+      });
+      expect(write.data.nextAttemptAt).toBeInstanceOf(Date);
+    }
+  });
+
+  it('marks missing raw queue docs as failed', () => {
+    const writes = buildProjectionQueueFailureWrites(
+      [
+        {
+          id: 'queue-doc',
+          eventId: 'missing-event',
+          data: { eventId: 'missing-event' },
+        },
+      ],
+      'missing_raw_event',
+      { firestoreQueueCollection: 'queue' }
+    );
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toMatchObject({
+      collection: 'queue',
+      id: 'missing-event',
+      data: expect.objectContaining({
+        eventId: 'missing-event',
+        status: 'failed',
+        reason: 'missing_raw_event',
+        processingStatus: 'failed',
+        identityStatus: 'unknown',
+      }),
+    });
+  });
+
+  it('marks corrupt raw docs as failed', () => {
+    const writes = buildProjectionRawFailureWrites(
+      [{ id: 'raw-doc', data: { id: 'bad-event' } }],
+      { firestoreEventsCollection: 'events' }
+    );
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toMatchObject({
+      collection: 'events',
+      id: 'raw-doc',
+      data: {
+        processing: expect.objectContaining({
+          status: 'failed',
+          reason: 'invalid_raw_event',
+        }),
+        identity: {
+          status: 'unknown',
+          reason: 'invalid_raw_event',
+        },
+      },
+    });
+  });
+});
+
+describe('run metrics helpers', () => {
+  it('creates stable run ids and finishes with counters', () => {
+    const run = createRunMetrics('projection', new Date('2026-06-19T10:00:00.000Z'));
+    run.timings.push(10, 20, 100);
+
+    const finished = finishRunMetrics(
+      run,
+      { eventsRead: 3, verified: 1 },
+      new Date('2026-06-19T10:00:02.000Z')
+    );
+
+    expect(finished).toMatchObject({
+      component: 'projection',
+      runId: 'projection-2026-06-19T10:00:00_000Z',
+      startedAt: '2026-06-19T10:00:00.000Z',
+      finishedAt: '2026-06-19T10:00:02.000Z',
+      durationMs: 2000,
+      avgProcessingMs: 43,
+      p95ProcessingMs: 100,
+      counters: {
+        eventsRead: 3,
+        verified: 1,
+      },
+    });
+    expect(finished.memoryRssMb).toBeGreaterThan(0);
+  });
+
+  it('calculates percentile from sorted position', () => {
+    expect(percentile([100, 10, 20, 30], 50)).toBe(20);
+    expect(percentile([100, 10, 20, 30], 95)).toBe(100);
+    expect(percentile([], 95)).toBe(0);
+  });
+
+  it('builds one Firestore summary write per run', () => {
+    const write = buildRunSummaryWrite(
+      {
+        component: 'backfill',
+        runId: 'backfill-run',
+        durationMs: 123,
+        counters: { eventsWritten: 10 },
+      },
+      {
+        mode: 'backfill',
+        relays: ['wss://relay.example'],
+        stats: { validEvents: 10 },
+        firestore: { project: 'gr-prod' },
+      },
+      'backfillRuns'
+    );
+
+    expect(write).toMatchObject({
+      collection: 'backfillRuns',
+      id: 'backfill-run',
+      data: expect.objectContaining({
+        component: 'backfill',
+        mode: 'backfill',
+        durationMs: 123,
+        counters: { eventsWritten: 10 },
+        stats: { validEvents: 10 },
+        relays: ['wss://relay.example'],
+      }),
+    });
   });
 });

--- a/scripts/relay-directory-crawler.test.mjs
+++ b/scripts/relay-directory-crawler.test.mjs
@@ -26,6 +26,7 @@ import {
   lightningAddressToLnurlp,
   liveStateId,
   normalizeTwitterHandle,
+  parseArgs,
   percentile,
   projectionStatusForRawEvent,
   queueDocIsClaimable,
@@ -47,6 +48,18 @@ describe('normalizeTwitterHandle', () => {
     expect(normalizeTwitterHandle('this-has-dashes')).toBeNull();
     expect(normalizeTwitterHandle('waytoolongtwitterhandle')).toBeNull();
     expect(normalizeTwitterHandle('https://x.com/i/communities/1747149501561778581')).toBeNull();
+  });
+});
+
+describe('parseArgs', () => {
+  it('rejects missing values for value-taking flags', () => {
+    expect(() => parseArgs(['--relays'])).toThrow('--relays requires a value.');
+  });
+
+  it('rejects another option where a value is required', () => {
+    expect(() => parseArgs(['--firestore-project', 'gr-prod', '--relays', '--out'])).toThrow(
+      '--relays requires a value.'
+    );
   });
 });
 
@@ -115,7 +128,7 @@ describe('lightningAddressToLnurlp', () => {
 });
 
 describe('computeWotScores', () => {
-  it('adds ranking signals without changing identity status or auto-zap policy', () => {
+  it('preserves identity status and auto-zap policy when ranking inputs are not valid signed events', () => {
     const claimed = {
       handle: 'alice',
       pubkey: PUBKEY,
@@ -137,6 +150,7 @@ describe('computeWotScores', () => {
 
     expect(scored[0].identityStatus).toBe('claimed');
     expect(scored[0].autoZapAllowed).toBe(false);
+    expect(scored[0].wot.followerGraphMentions).toBe(0);
     expect(scored[0].wot.note).toContain('not identity proof');
   });
 });
@@ -804,6 +818,89 @@ describe('projection helpers', () => {
       });
       expect(write.data.nextAttemptAt).toBeInstanceOf(Date);
     }
+  });
+
+  it('keeps non-rate-limited transient proof failures scoped to their source event', () => {
+    const writes = buildProjectionQueueWrites(
+      [
+        { id: 'retry-doc', data: { id: 'retry-event' } },
+        { id: 'ignored-doc', data: { id: 'ignored-event' } },
+      ],
+      {
+        strategy: {},
+        directory: [],
+        rejected: [],
+        retryLater: [
+          {
+            sourceEventId: 'retry-event',
+            retryReason: 'timeout',
+          },
+        ],
+      },
+      {
+        firestoreQueueCollection: 'queue',
+        projectionExternalRetryMs: 60000,
+      }
+    );
+
+    expect(writes).toHaveLength(2);
+    expect(writes[0]).toMatchObject({
+      collection: 'queue',
+      id: 'retry-event',
+      data: expect.objectContaining({
+        status: 'retry_later',
+        reason: 'timeout',
+        processingStatus: 'retry_later',
+        identityStatus: 'unknown',
+      }),
+    });
+    expect(writes[0].data.nextAttemptAt).toBeInstanceOf(Date);
+    expect(writes[1]).toMatchObject({
+      collection: 'queue',
+      id: 'ignored-event',
+      data: expect.objectContaining({
+        status: 'ignored',
+        reason: 'no_identity_signal',
+        processingStatus: 'ignored',
+        identityStatus: 'none',
+      }),
+    });
+  });
+
+  it('keeps proof-limit overflow candidates retryable instead of ignored', () => {
+    const writes = buildProjectionQueueWrites(
+      [
+        { id: 'overflow-doc', data: { id: 'overflow-event' } },
+      ],
+      {
+        strategy: {},
+        directory: [],
+        rejected: [],
+        retryLater: [
+          {
+            sourceEventId: 'overflow-event',
+            retryReason: 'max_proof_limit_reached',
+          },
+        ],
+      },
+      {
+        firestoreQueueCollection: 'queue',
+        projectionExternalRetryMs: 60000,
+      }
+    );
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toMatchObject({
+      collection: 'queue',
+      id: 'overflow-event',
+      data: expect.objectContaining({
+        status: 'retry_later',
+        reason: 'max_proof_limit_reached',
+        processingStatus: 'retry_later',
+        identityStatus: 'unknown',
+      }),
+    });
+    expect(writes[0].data.nextAttemptAt).toBeInstanceOf(Date);
   });
 
   it('marks missing raw queue docs as failed', () => {


### PR DESCRIPTION
## Summary

Adds a Firestore-backed relay directory ingestion and projection pipeline for Nostr identity events.

The system is split into three runtimes:

- historical backfill: crawls past `kind:10011` and `kind:0` events from relays
- live listener: keeps WebSocket subscriptions open for new events
- projection worker: converts stored raw events into lookup-ready directory docs

## Architecture

Raw signed relay events are stored in:

- `nostrIdentityEvents/{eventId}`

Projection work is tracked separately in:

- `nostrProjectionQueue/{eventId}`

The projection queue is created only if missing, so live/backfill re-ingestion does not reset already processed work.

Directory output is written to:

- `nostrDirectoryEntries`
- `nostrDirectoryHandles`

Crawler state and run summaries are written to:

- `relayCrawlerState`
- `relayCrawlerGaps`
- `relayBackfillRuns`
- `relayProjectionRuns`
- `relayLiveListenerRuns`

## Reliability

- Adds backfill pagination with checkpointing and stuck same-timestamp gap recording.
- Adds overlap backfill support through `--backfill-state-prefix overlap`.
- Adds live listener reconnects, heartbeat writes, bounded in-memory dedupe, and buffered Firestore writes.
- Adds transactional queue claiming with `lockedBy` and `lockExpiresAt`.
- Adds `retry_later` handling with `nextAttemptAt`.
- Prevents X/Twitter temporary failures and HTTP 429s from permanently rejecting valid proofs.
- Stops proof verification for the current run after rate limiting.
- Marks missing/corrupt raw events as failed instead of leaving queue docs stuck forever.

## Deployment

Adds Docker, Cloud Build, and deploy scripts for:

- projection Cloud Run Job
- historical backfill Cloud Run Job
- live listener Cloud Run worker pool

## Validation

- `node --check scripts/relay-directory-crawler.mjs`
- `npm test -- scripts/relay-directory-crawler.test.mjs`

Projection smoke was attempted against `CodexSmoke` Firestore collections. It found and fixed a Firestore index requirement. Final smoke retry was blocked by ADC token refresh failure inside the Codex process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added new npm commands to run a directory crawler in backfill, project, and continuous live-listen modes, with optional proof and zapability verification.
  * Introduced Docker + Cloud Build/Cloud Run automation, including deployment scripts for scheduled backfills and live listener worker pools.

* **Tests**
  * Added Vitest coverage for crawler helpers, Firestore write generation, queue/projection behavior, and run metrics.

* **Documentation**
  * Added an upgrade/tackling rollout and monitoring plan for the crawler pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->