### PR TITLE
Split relay directory live monitoring

### DIFF
--- a/backend/deploy-relay-directory-backfill.sh
+++ b/backend/deploy-relay-directory-backfill.sh
@@ -51,8 +51,14 @@ gcloud services enable \
   cloudscheduler.googleapis.com
 
 if ! gcloud iam service-accounts describe "${SERVICE_ACCOUNT}" >/dev/null 2>&1; then
-  gcloud iam service-accounts create relay-directory-crawler \
-    --display-name="Relay Directory Crawler"
+  SERVICE_ACCOUNT_ID="${SERVICE_ACCOUNT%%@*}"
+  SERVICE_ACCOUNT_DOMAIN="${SERVICE_ACCOUNT#*@}"
+  if [ "${SERVICE_ACCOUNT_DOMAIN}" != "${PROJECT_ID}.iam.gserviceaccount.com" ]; then
+    echo "SERVICE_ACCOUNT ${SERVICE_ACCOUNT} does not exist and is not in ${PROJECT_ID}." >&2
+    exit 1
+  fi
+  gcloud iam service-accounts create "${SERVICE_ACCOUNT_ID}" \
+    --display-name="Relay Directory Crawler (${SERVICE_ACCOUNT_ID})"
 fi
 
 if [ "${CREATE_SCHEDULER}" = "true" ]; then

--- a/backend/deploy-relay-directory-live-listener.sh
+++ b/backend/deploy-relay-directory-live-listener.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-gr-prod}"
+REGION="${REGION:-us-central1}"
+WORKER_POOL_NAME="${WORKER_POOL_NAME:-relay-directory-live-listener}"
+IMAGE_JOB_NAME="${IMAGE_JOB_NAME:-relay-directory-crawler}"
+IMAGE="gcr.io/${PROJECT_ID}/${IMAGE_JOB_NAME}:latest"
+SERVICE_ACCOUNT="${SERVICE_ACCOUNT:-relay-directory-crawler@${PROJECT_ID}.iam.gserviceaccount.com}"
+INSTANCE_COUNT="${INSTANCE_COUNT:-1}"
+LIVE_FLUSH_LIMIT="${LIVE_FLUSH_LIMIT:-25}"
+LIVE_FLUSH_INTERVAL_MS="${LIVE_FLUSH_INTERVAL_MS:-5000}"
+LIVE_HEARTBEAT_INTERVAL_MS="${LIVE_HEARTBEAT_INTERVAL_MS:-30000}"
+
+gcloud config set project "${PROJECT_ID}"
+gcloud services enable run.googleapis.com firestore.googleapis.com cloudbuild.googleapis.com
+
+if ! gcloud iam service-accounts describe "${SERVICE_ACCOUNT}" >/dev/null 2>&1; then
+  gcloud iam service-accounts create relay-directory-crawler \
+    --display-name="Relay Directory Crawler"
+fi
+
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+  --member="serviceAccount:${SERVICE_ACCOUNT}" \
+  --role="roles/datastore.user" \
+  --condition=None >/dev/null
+
+gcloud builds submit \
+  --config backend/cloudbuild.yaml \
+  --substitutions "_IMAGE=${IMAGE}" backend
+
+gcloud run worker-pools deploy "${WORKER_POOL_NAME}" \
+  --image "${IMAGE}" \
+  --region "${REGION}" \
+  --service-account "${SERVICE_ACCOUNT}" \
+  --instances "${INSTANCE_COUNT}" \
+  --set-env-vars "GOOGLE_CLOUD_PROJECT=${PROJECT_ID},FIRESTORE_PROJECT=${PROJECT_ID},LIVE_FLUSH_LIMIT=${LIVE_FLUSH_LIMIT},LIVE_FLUSH_INTERVAL_MS=${LIVE_FLUSH_INTERVAL_MS},LIVE_HEARTBEAT_INTERVAL_MS=${LIVE_HEARTBEAT_INTERVAL_MS}" \
+  --args "relay-directory/live-monitor.js,--firestore-project,${PROJECT_ID},--no-json"

--- a/backend/deploy-relay-directory-live-listener.sh
+++ b/backend/deploy-relay-directory-live-listener.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${PROJECT_ID:-}" ]; then
+  echo "PROJECT_ID is required." >&2
+  echo "Example: PROJECT_ID=gr-prod ./deploy-relay-directory-live-listener.sh" >&2
+  exit 1
+fi
+
+REGION="${REGION:-us-central1}"
+WORKER_POOL_NAME="${WORKER_POOL_NAME:-relay-directory-live-listener}"
+IMAGE_JOB_NAME="${IMAGE_JOB_NAME:-relay-directory-crawler}"
+IMAGE="gcr.io/${PROJECT_ID}/${IMAGE_JOB_NAME}:latest"
+SERVICE_ACCOUNT="${SERVICE_ACCOUNT:-relay-directory-crawler@${PROJECT_ID}.iam.gserviceaccount.com}"
+INSTANCE_COUNT="${INSTANCE_COUNT:-1}"
+LIVE_FLUSH_LIMIT="${LIVE_FLUSH_LIMIT:-25}"
+LIVE_FLUSH_INTERVAL_MS="${LIVE_FLUSH_INTERVAL_MS:-5000}"
+LIVE_HEARTBEAT_INTERVAL_MS="${LIVE_HEARTBEAT_INTERVAL_MS:-30000}"
+
+gcloud config set project "${PROJECT_ID}"
+gcloud services enable run.googleapis.com firestore.googleapis.com cloudbuild.googleapis.com
+
+if ! gcloud iam service-accounts describe "${SERVICE_ACCOUNT}" >/dev/null 2>&1; then
+  SERVICE_ACCOUNT_ID="${SERVICE_ACCOUNT%%@*}"
+  SERVICE_ACCOUNT_DOMAIN="${SERVICE_ACCOUNT#*@}"
+  if [ "${SERVICE_ACCOUNT_DOMAIN}" != "${PROJECT_ID}.iam.gserviceaccount.com" ]; then
+    echo "SERVICE_ACCOUNT ${SERVICE_ACCOUNT} does not exist and is not in ${PROJECT_ID}." >&2
+    exit 1
+  fi
+  gcloud iam service-accounts create "${SERVICE_ACCOUNT_ID}" \
+    --display-name="Relay Directory Crawler (${SERVICE_ACCOUNT_ID})"
+fi
+
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+  --member="serviceAccount:${SERVICE_ACCOUNT}" \
+  --role="roles/datastore.user" \
+  --condition=None >/dev/null
+
+gcloud builds submit \
+  --config backend/cloudbuild.yaml \
+  --substitutions "_IMAGE=${IMAGE}" backend
+
+gcloud run worker-pools deploy "${WORKER_POOL_NAME}" \
+  --image "${IMAGE}" \
+  --region "${REGION}" \
+  --service-account "${SERVICE_ACCOUNT}" \
+  --instances "${INSTANCE_COUNT}" \
+  --set-env-vars "GOOGLE_CLOUD_PROJECT=${PROJECT_ID},FIRESTORE_PROJECT=${PROJECT_ID},LIVE_FLUSH_LIMIT=${LIVE_FLUSH_LIMIT},LIVE_FLUSH_INTERVAL_MS=${LIVE_FLUSH_INTERVAL_MS},LIVE_HEARTBEAT_INTERVAL_MS=${LIVE_HEARTBEAT_INTERVAL_MS}" \
+  --args "relay-directory/live-monitor.js,--firestore-project,${PROJECT_ID},--no-json"

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "backfill": "node --env-file-if-exists=.env relay-directory/backfill.js",
+    "live": "node --env-file-if-exists=.env relay-directory/live-monitor.js",
     "test": "vitest run"
   },
   "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "backfill": "node --env-file-if-exists=.env relay-directory/backfill.js",
     "project": "node --env-file-if-exists=.env relay-directory/projection.js",
+    "live": "node --env-file-if-exists=.env relay-directory/live-monitor.js",
     "test": "vitest run"
   },
   "dependencies": {

--- a/backend/relay-directory-crawler.js
+++ b/backend/relay-directory-crawler.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+
+import {
+  loadBackfillConfig,
+  runBackfill,
+} from "./relay-directory/backfill.js";
+import {
+  parseLiveArgs,
+  runLiveMonitor,
+} from "./relay-directory/live-monitor.js";
+import { isMainModule } from "./relay-directory/runtime.js";
+
+if (isMainModule(import.meta.url)) {
+  const argv = process.argv.slice(2);
+  const isLive = argv.includes("--live-listen");
+  const normalized = argv.filter((flag) => flag !== "--live-listen");
+  const parseArgs = isLive ? parseLiveArgs : () => loadBackfillConfig();
+  const runner = isLive ? runLiveMonitor : runBackfill;
+
+  runner(parseArgs(normalized)).catch((error) => {
+    console.error(error.stack || error.message || error);
+    process.exitCode = 1;
+  });
+}
+
+export * from "./relay-directory/backfill.js";
+export * from "./relay-directory/ingestion.js";
+export * from "./relay-directory/live-monitor.js";
+export * from "./relay-directory/runtime.js";

--- a/backend/relay-directory-crawler.js
+++ b/backend/relay-directory-crawler.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+
+import { loadBackfillConfig, runBackfill } from "./relay-directory/backfill.js";
+import {
+  parseLiveArgs,
+  runLiveMonitor,
+} from "./relay-directory/live-monitor.js";
+import { isMainModule } from "./relay-directory/runtime.js";
+
+if (isMainModule(import.meta.url)) {
+  const argv = process.argv.slice(2);
+  const isLive = argv.includes("--live-listen");
+  const normalized = argv.filter((flag) => flag !== "--live-listen");
+  const parseArgs = isLive ? parseLiveArgs : () => loadBackfillConfig();
+  const runner = isLive ? runLiveMonitor : runBackfill;
+
+  Promise.resolve()
+    .then(() => runner(parseArgs(normalized)))
+    .catch((error) => {
+      console.error(error.stack || error.message || error);
+      process.exitCode = 1;
+    });
+}
+
+export * from "./relay-directory/backfill.js";
+export * from "./relay-directory/ingestion.js";
+export * from "./relay-directory/live-monitor.js";
+export * from "./relay-directory/runtime.js";

--- a/backend/relay-directory/ingestion.js
+++ b/backend/relay-directory/ingestion.js
@@ -20,7 +20,7 @@ export function createNdkRelayClient(url) {
     connect: (timeoutMs) => ndk.connect(timeoutMs),
     subscribe(filter, { max, onEvent, onEose, onClosed }) {
       const subscription = ndk.subscribe(
-        { ...filter, limit: max },
+        Number.isFinite(max) ? { ...filter, limit: max } : filter,
         {
           closeOnEose: false,
           dontSaveToCache: true,
@@ -30,10 +30,30 @@ export function createNdkRelayClient(url) {
         false,
       );
       subscription.on("event", (event) => onEvent(event.rawEvent()));
-      subscription.on("eose", onEose);
-      subscription.on("closed", (_relay, reason) => onClosed(reason));
+      subscription.on("eose", () => onEose?.());
+      subscription.on("closed", (_relay, reason) => onClosed?.(reason));
       subscription.start();
       return () => subscription.stop();
+    },
+    onStatus({ onConnecting, onConnect, onDisconnect }) {
+      const matchesRelay = (relay) => relay?.url === url;
+      const handleConnecting = (relay) => {
+        if (matchesRelay(relay)) onConnecting?.();
+      };
+      const handleConnect = (relay) => {
+        if (matchesRelay(relay)) onConnect?.();
+      };
+      const handleDisconnect = (relay) => {
+        if (matchesRelay(relay)) onDisconnect?.();
+      };
+      ndk.pool.on("relay:connecting", handleConnecting);
+      ndk.pool.on("relay:connect", handleConnect);
+      ndk.pool.on("relay:disconnect", handleDisconnect);
+      return () => {
+        ndk.pool.off("relay:connecting", handleConnecting);
+        ndk.pool.off("relay:connect", handleConnect);
+        ndk.pool.off("relay:disconnect", handleDisconnect);
+      };
     },
     close() {
       for (const relay of [...ndk.pool.relays.values()]) {
@@ -105,6 +125,78 @@ export function isValidSignedEvent(event) {
   }
 }
 
+export function buildBackfillEventWrite(event, relay, options = {}) {
+  return buildIngestedEventWrite(event, relay, "backfill", options);
+}
+
+export function buildLiveEventWrite(event, relay, options = {}) {
+  return buildIngestedEventWrite(event, relay, "live", options);
+}
+
+export function buildIngestedEventWrite(event, relay, mode, options = {}) {
+  return {
+    collection: options.firestoreEventsCollection || DEFAULT_COLLECTIONS.events,
+    id: firestoreSafeId(event.id),
+    data: stripUndefined({
+      id: event.id,
+      kind: event.kind,
+      pubkey: event.pubkey,
+      createdAt: event.created_at,
+      sourceRelays: FieldValue.arrayUnion(relay),
+      event: normalizeEventForFirestore(event),
+      eventJson: JSON.stringify(event),
+      ingestion: {
+        mode,
+        lastRelay: relay,
+        lastSeenAt: FieldValue.serverTimestamp(),
+      },
+      updatedAt: FieldValue.serverTimestamp(),
+    }),
+  };
+}
+
+export function buildRawEventIngestionWrites(event, relay, mode, options = {}) {
+  return [
+    buildIngestedEventWrite(event, relay, mode, options),
+    buildProjectionQueueCreateWrite(event, mode, options),
+  ];
+}
+
+export function buildProjectionQueueCreateWrite(event, mode, options = {}) {
+  return {
+    operation: "createIfMissing",
+    collection: options.firestoreQueueCollection || DEFAULT_COLLECTIONS.queue,
+    id: firestoreSafeId(event.id),
+    data: stripUndefined({
+      eventId: event.id,
+      kind: event.kind,
+      pubkey: event.pubkey,
+      eventCreatedAt: event.created_at,
+      sourceMode: mode,
+      status: "pending",
+      reason: "awaiting_projection",
+      attempts: 0,
+      nextAttemptAt: FieldValue.serverTimestamp(),
+      createdAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    }),
+  };
+}
+
+function normalizeEventForFirestore(event) {
+  return {
+    id: event.id,
+    kind: event.kind,
+    pubkey: event.pubkey,
+    created_at: event.created_at,
+    content: event.content || "",
+    tags: (event.tags || []).map((tag) => ({
+      values: tag.map((value) => String(value)),
+    })),
+    sig: event.sig,
+  };
+}
+
 export function buildBackfillCheckpointWrite(
   {
     relay,
@@ -166,6 +258,30 @@ export function buildBackfillGapWrite(
       updatedAt: FieldValue.serverTimestamp(),
     }),
   };
+}
+
+export function buildLiveHeartbeatWrite(
+  { relay, status, mode, connected, lastEventAt, attempts },
+  options = {},
+) {
+  return {
+    collection: options.firestoreStateCollection || DEFAULT_COLLECTIONS.state,
+    id: liveStateId(relay),
+    data: stripUndefined({
+      relay,
+      mode: mode || "live",
+      status,
+      connected,
+      lastEventAt,
+      connectAttempts: attempts,
+      heartbeatAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    }),
+  };
+}
+
+export function liveStateId(relay) {
+  return firestoreSafeId(`live:${relay}`);
 }
 
 /**

--- a/backend/relay-directory/ingestion.js
+++ b/backend/relay-directory/ingestion.js
@@ -37,6 +37,26 @@ export function createNdkRelayClient(url) {
       void subscription.start();
       return () => subscription.stop();
     },
+    onStatus({ onConnecting, onConnect, onDisconnect }) {
+      const matchesRelay = (relay) => relay?.url === url;
+      const handleConnecting = (relay) => {
+        if (matchesRelay(relay)) onConnecting?.();
+      };
+      const handleConnect = (relay) => {
+        if (matchesRelay(relay)) onConnect?.();
+      };
+      const handleDisconnect = (relay) => {
+        if (matchesRelay(relay)) onDisconnect?.();
+      };
+      ndk.pool.on("relay:connecting", handleConnecting);
+      ndk.pool.on("relay:connect", handleConnect);
+      ndk.pool.on("relay:disconnect", handleDisconnect);
+      return () => {
+        ndk.pool.off("relay:connecting", handleConnecting);
+        ndk.pool.off("relay:connect", handleConnect);
+        ndk.pool.off("relay:disconnect", handleDisconnect);
+      };
+    },
     close() {
       for (const relay of [...ndk.pool.relays.values()]) {
         try {
@@ -107,6 +127,78 @@ export function isValidSignedEvent(event) {
   }
 }
 
+export function buildBackfillEventWrite(event, relay, options = {}) {
+  return buildIngestedEventWrite(event, relay, "backfill", options);
+}
+
+export function buildLiveEventWrite(event, relay, options = {}) {
+  return buildIngestedEventWrite(event, relay, "live", options);
+}
+
+export function buildIngestedEventWrite(event, relay, mode, options = {}) {
+  return {
+    collection: options.firestoreEventsCollection || DEFAULT_COLLECTIONS.events,
+    id: firestoreSafeId(event.id),
+    data: stripUndefined({
+      id: event.id,
+      kind: event.kind,
+      pubkey: event.pubkey,
+      createdAt: event.created_at,
+      sourceRelays: FieldValue.arrayUnion(relay),
+      event: normalizeEventForFirestore(event),
+      eventJson: JSON.stringify(event),
+      ingestion: {
+        mode,
+        lastRelay: relay,
+        lastSeenAt: FieldValue.serverTimestamp(),
+      },
+      updatedAt: FieldValue.serverTimestamp(),
+    }),
+  };
+}
+
+export function buildRawEventIngestionWrites(event, relay, mode, options = {}) {
+  return [
+    buildIngestedEventWrite(event, relay, mode, options),
+    buildProjectionQueueCreateWrite(event, mode, options),
+  ];
+}
+
+export function buildProjectionQueueCreateWrite(event, mode, options = {}) {
+  return {
+    operation: "createIfMissing",
+    collection: options.firestoreQueueCollection || DEFAULT_COLLECTIONS.queue,
+    id: firestoreSafeId(event.id),
+    data: stripUndefined({
+      eventId: event.id,
+      kind: event.kind,
+      pubkey: event.pubkey,
+      eventCreatedAt: event.created_at,
+      sourceMode: mode,
+      status: "pending",
+      reason: "awaiting_projection",
+      attempts: 0,
+      nextAttemptAt: FieldValue.serverTimestamp(),
+      createdAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    }),
+  };
+}
+
+function normalizeEventForFirestore(event) {
+  return {
+    id: event.id,
+    kind: event.kind,
+    pubkey: event.pubkey,
+    created_at: event.created_at,
+    content: event.content || "",
+    tags: (event.tags || []).map((tag) => ({
+      values: tag.map((value) => String(value)),
+    })),
+    sig: event.sig,
+  };
+}
+
 export function buildBackfillCheckpointWrite(
   {
     relay,
@@ -170,13 +262,44 @@ export function buildBackfillGapWrite(
   };
 }
 
+export function buildLiveHeartbeatWrite(
+  { relay, status, mode, connected, lastEventAt, attempts },
+  options = {},
+) {
+  return {
+    collection: options.firestoreStateCollection || DEFAULT_COLLECTIONS.state,
+    id: liveStateId(relay),
+    data: stripUndefined({
+      relay,
+      mode: mode || "live",
+      status,
+      connected,
+      lastEventAt,
+      connectAttempts: attempts,
+      heartbeatAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    }),
+  };
+}
+
+export function liveStateId(relay) {
+  return firestoreSafeId(`live:${relay}`);
+}
+
 /**
  * Dead-letter a failed handle write. payloadJson is stringified so nested
  * arrays / other Firestore-illegal shapes cannot break the failure doc itself.
  * Document IDs are deterministic so cursor retries upsert the same failure doc.
  */
 export function buildHandleWriteFailureWrite(
-  { write, error, relay, kind, cursorUntil, failedAt = new Date().toISOString() },
+  {
+    write,
+    error,
+    relay,
+    kind,
+    cursorUntil,
+    failedAt = new Date().toISOString(),
+  },
   options = {},
 ) {
   const claims = Array.isArray(write?.data?.claims) ? write.data.claims : [];

--- a/backend/relay-directory/live-monitor.js
+++ b/backend/relay-directory/live-monitor.js
@@ -1,0 +1,431 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+
+import {
+  buildLiveHeartbeatWrite,
+  buildRawEventIngestionWrites,
+  createNdkRelayClient,
+  isValidSignedEvent,
+} from "./ingestion.js";
+import {
+  IDENTITY_KINDS,
+  buildRunSummaryWrite,
+  commitFirestoreWrites,
+  createFirestore,
+  createRunMetrics,
+  finishRunMetrics,
+  firestoreConfigFromEnv,
+  loadRelaysFromFile,
+  logRunSummary,
+  runCli,
+  takeOptionValue,
+  writeJson,
+} from "./runtime.js";
+
+export function parseLiveArgs(argv) {
+  const args = {
+    ...firestoreConfigFromEnv(),
+    relays: loadRelaysFromFile(),
+    out: null,
+    liveDurationMs: Number(process.env.LIVE_DURATION_MS || 0),
+    liveFlushLimit: Number(process.env.LIVE_FLUSH_LIMIT || 25),
+    liveFlushIntervalMs: Number(process.env.LIVE_FLUSH_INTERVAL_MS || 5000),
+    liveHeartbeatIntervalMs: Number(
+      process.env.LIVE_HEARTBEAT_INTERVAL_MS || 30000,
+    ),
+    liveSeenCacheLimit: Number(process.env.LIVE_SEEN_CACHE_LIMIT || 50000),
+    liveConnectTimeoutMs: Number(process.env.LIVE_CONNECT_TIMEOUT_MS || 15000),
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const take = () => {
+      const result = takeOptionValue(argv, index, flag);
+      index = result.nextIndex;
+      return result.value;
+    };
+
+    if (flag === "--live-listen") continue;
+    if (flag === "--relays") {
+      args.relays = take()
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean);
+    } else if (flag === "--out") args.out = take();
+    else if (flag === "--no-json") args.out = null;
+    else if (flag === "--firestore-project") args.firestoreProject = take();
+    else if (flag === "--firestore-database") args.firestoreDatabase = take();
+    else if (flag === "--firestore-live-runs-collection") {
+      args.firestoreLiveRunsCollection = take();
+    } else if (flag === "--firestore-events-collection") {
+      args.firestoreEventsCollection = take();
+    } else if (flag === "--firestore-queue-collection") {
+      args.firestoreQueueCollection = take();
+    } else if (flag === "--firestore-state-collection") {
+      args.firestoreStateCollection = take();
+    } else if (flag === "--live-duration-ms") {
+      args.liveDurationMs = Number(take());
+    } else if (flag === "--live-flush-limit") {
+      args.liveFlushLimit = Number(take());
+    } else if (flag === "--live-flush-interval-ms") {
+      args.liveFlushIntervalMs = Number(take());
+    } else if (flag === "--live-heartbeat-interval-ms") {
+      args.liveHeartbeatIntervalMs = Number(take());
+    } else if (flag === "--live-seen-cache-limit") {
+      args.liveSeenCacheLimit = Number(take());
+    } else if (flag === "--live-connect-timeout-ms") {
+      args.liveConnectTimeoutMs = Number(take());
+    } else if (flag === "--help" || flag === "-h") {
+      printLiveHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown live-monitor argument: ${flag}`);
+    }
+  }
+
+  validateLiveArgs(args);
+  return args;
+}
+
+function validateLiveArgs(args) {
+  if (!args.firestoreProject) {
+    throw new Error("--firestore-project or GOOGLE_CLOUD_PROJECT is required.");
+  }
+  if (!args.relays.length) throw new Error("At least one relay is required.");
+  if (!Number.isFinite(args.liveDurationMs) || args.liveDurationMs < 0) {
+    throw new Error(
+      "--live-duration-ms must be >= 0. Use 0 to run until stopped.",
+    );
+  }
+  if (!Number.isFinite(args.liveFlushLimit) || args.liveFlushLimit <= 0) {
+    throw new Error("--live-flush-limit must be positive.");
+  }
+  if (
+    !Number.isFinite(args.liveFlushIntervalMs) ||
+    args.liveFlushIntervalMs <= 0
+  ) {
+    throw new Error("--live-flush-interval-ms must be positive.");
+  }
+  if (
+    !Number.isFinite(args.liveHeartbeatIntervalMs) ||
+    args.liveHeartbeatIntervalMs <= 0
+  ) {
+    throw new Error("--live-heartbeat-interval-ms must be positive.");
+  }
+  if (
+    !Number.isFinite(args.liveSeenCacheLimit) ||
+    args.liveSeenCacheLimit <= 0
+  ) {
+    throw new Error("--live-seen-cache-limit must be positive.");
+  }
+  if (
+    !Number.isFinite(args.liveConnectTimeoutMs) ||
+    args.liveConnectTimeoutMs <= 0
+  ) {
+    throw new Error("--live-connect-timeout-ms must be positive.");
+  }
+}
+
+function printLiveHelp() {
+  console.log(`Usage: npm run crawl:directory:live -- [options]
+
+Continuously ingest signed Nostr kind:10011 and kind:0 events into Firestore.
+
+Options:
+  --relays <csv>                       Relays to monitor.
+  --firestore-project <id>             GCP project.
+  --live-duration-ms <n>               0 runs until stopped. Default: 0
+  --live-flush-limit <n>               Buffered events before flush. Default: 25
+  --live-flush-interval-ms <n>         Max time between flushes. Default: 5000
+  --live-heartbeat-interval-ms <n>     Relay heartbeat interval. Default: 30000
+  --live-seen-cache-limit <n>          In-memory dedupe size. Default: 50000
+  --live-connect-timeout-ms <n>        NDK connection timeout. Default: 15000
+  --out <file>                         Optional JSON run summary.
+`);
+}
+
+export async function runLiveMonitor(args, FirestoreCtor) {
+  const runMetrics = createRunMetrics("live-monitor");
+  const db = await createFirestore(args, FirestoreCtor);
+  const startedAt = new Date().toISOString();
+  const stopController = new AbortController();
+  const totals = {
+    relayCount: args.relays.length,
+    connectAttempts: 0,
+    reconnects: 0,
+    relayDisconnects: 0,
+    relayErrors: 0,
+    eventsReceived: 0,
+    validEventsBuffered: 0,
+    validEventsWritten: 0,
+    invalidEventsDropped: 0,
+    duplicateEvents: 0,
+    flushes: 0,
+    heartbeatWrites: 0,
+  };
+  const seenEventIds = new Set();
+  const seenEventIdQueue = [];
+  const buffer = [];
+  let stopReason = "stopped";
+  let flushInFlight = Promise.resolve();
+
+  const stop = (reason) => {
+    if (stopController.signal.aborted) return;
+    stopReason = reason;
+    stopController.abort(reason);
+  };
+
+  const signalHandlers = [];
+  for (const signalName of ["SIGINT", "SIGTERM"]) {
+    const handler = () => stop(signalName);
+    process.once(signalName, handler);
+    signalHandlers.push([signalName, handler]);
+  }
+
+  const durationTimer =
+    args.liveDurationMs > 0
+      ? setTimeout(() => stop("duration_elapsed"), args.liveDurationMs)
+      : null;
+
+  const flushBuffer = async () => {
+    if (!buffer.length) return;
+    const writes = buffer.slice();
+    const rawEventWrites = writes.filter(
+      (write) =>
+        write.collection === args.firestoreEventsCollection && !write.operation,
+    ).length;
+    await commitFirestoreWrites(db, writes);
+    buffer.splice(0, writes.length);
+    totals.validEventsWritten += rawEventWrites;
+    totals.flushes += 1;
+  };
+
+  const scheduleFlush = () => {
+    flushInFlight = flushInFlight.then(flushBuffer, flushBuffer);
+    return flushInFlight;
+  };
+
+  const flushInterval = setInterval(scheduleFlush, args.liveFlushIntervalMs);
+
+  console.log(
+    `Monitoring ${args.relays.length} relays for kinds ${IDENTITY_KINDS.join(",")} into ${args.firestoreProject}/${args.firestoreDatabase}...`,
+  );
+
+  const listeners = args.relays.map((relay) =>
+    listenRelayLive(relay, args, {
+      signal: stopController.signal,
+      onConnectAttempt: () => {
+        totals.connectAttempts += 1;
+      },
+      onReconnect: () => {
+        totals.reconnects += 1;
+      },
+      onDisconnect: () => {
+        totals.relayDisconnects += 1;
+      },
+      onError: () => {
+        totals.relayErrors += 1;
+      },
+      onEvent: (event) => {
+        totals.eventsReceived += 1;
+        if (!isValidSignedEvent(event)) {
+          totals.invalidEventsDropped += 1;
+          return;
+        }
+        if (seenEventIds.has(event.id)) {
+          totals.duplicateEvents += 1;
+          return;
+        }
+        rememberSeenEventId(
+          event.id,
+          seenEventIds,
+          seenEventIdQueue,
+          args.liveSeenCacheLimit,
+        );
+        buffer.push(
+          ...buildRawEventIngestionWrites(event, relay, "live", args),
+        );
+        totals.validEventsBuffered += 1;
+        if (buffer.length >= args.liveFlushLimit) scheduleFlush();
+      },
+      onHeartbeat: async (status) => {
+        await commitFirestoreWrites(db, [
+          buildLiveHeartbeatWrite(status, args),
+        ]);
+        totals.heartbeatWrites += 1;
+      },
+    }),
+  );
+
+  await Promise.all(listeners);
+  clearInterval(flushInterval);
+  if (durationTimer) clearTimeout(durationTimer);
+  await scheduleFlush();
+
+  for (const [signalName, handler] of signalHandlers) {
+    process.removeListener(signalName, handler);
+  }
+
+  const output = {
+    mode: "live",
+    run: finishRunMetrics(runMetrics, totals),
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    stopReason,
+    relays: args.relays,
+    kinds: IDENTITY_KINDS,
+    stats: totals,
+    firestore: {
+      project: args.firestoreProject,
+      database: args.firestoreDatabase,
+      eventsCollection: args.firestoreEventsCollection,
+      queueCollection: args.firestoreQueueCollection,
+      stateCollection: args.firestoreStateCollection,
+    },
+  };
+
+  await commitFirestoreWrites(db, [
+    buildRunSummaryWrite(output.run, output, args.firestoreLiveRunsCollection),
+  ]);
+  logRunSummary(output.run);
+  if (args.out) await writeJson(args.out, output);
+  printLiveSummary(output, args);
+  return output;
+}
+
+export function listenRelayLive(
+  relay,
+  args,
+  callbacks,
+  clientFactory = createNdkRelayClient,
+) {
+  const {
+    signal,
+    onConnectAttempt,
+    onReconnect,
+    onDisconnect,
+    onError,
+    onEvent,
+    onHeartbeat,
+  } = callbacks;
+
+  return new Promise((resolve) => {
+    const client = clientFactory(relay);
+    let stopSubscription = null;
+    let stopStatusListeners = null;
+    let heartbeatTimer = null;
+    let attempts = 0;
+    let connected = false;
+    let lastEventAt = null;
+    let stopped = false;
+
+    const cleanup = () => {
+      if (heartbeatTimer) clearInterval(heartbeatTimer);
+      stopSubscription?.();
+      stopStatusListeners?.();
+      client.close?.();
+    };
+
+    const heartbeat = async (status) => {
+      if (!onHeartbeat) return;
+      await onHeartbeat({
+        relay,
+        status,
+        mode: "live",
+        connected,
+        lastEventAt,
+        attempts,
+      });
+    };
+
+    const finish = async () => {
+      if (stopped) return;
+      stopped = true;
+      cleanup();
+      await heartbeat("stopped").catch(() => {});
+      resolve();
+    };
+
+    stopStatusListeners = client.onStatus?.({
+      onConnecting: () => {
+        attempts += 1;
+        onConnectAttempt?.();
+        if (attempts > 1) onReconnect?.();
+      },
+      onConnect: () => {
+        if (stopped || signal.aborted) return;
+        connected = true;
+        heartbeat("connected").catch(() => {});
+      },
+      onDisconnect: () => {
+        if (stopped || signal.aborted) return;
+        connected = false;
+        onDisconnect?.();
+        heartbeat("disconnected").catch(() => {});
+      },
+    });
+
+    signal.addEventListener("abort", finish, { once: true });
+    heartbeatTimer = setInterval(() => {
+      heartbeat(connected ? "connected" : "disconnected").catch(() => {});
+    }, args.liveHeartbeatIntervalMs);
+
+    Promise.resolve(client.connect(args.liveConnectTimeoutMs))
+      .then(() => {
+        if (stopped || signal.aborted) return;
+        stopSubscription = client.subscribe(
+          { kinds: IDENTITY_KINDS, since: Math.floor(Date.now() / 1000) },
+          {
+            onEvent: (event) => {
+              if (!event?.id) return;
+              lastEventAt = new Date().toISOString();
+              onEvent?.(event, relay);
+            },
+            onClosed: () => onError?.(),
+          },
+        );
+      })
+      .catch(() => {
+        if (!stopped) {
+          onError?.();
+          finish();
+        }
+      });
+  });
+}
+
+export function rememberSeenEventId(
+  eventId,
+  seenEventIds,
+  seenEventIdQueue,
+  limit,
+) {
+  if (seenEventIds.has(eventId)) return false;
+  seenEventIds.add(eventId);
+  seenEventIdQueue.push(eventId);
+  while (seenEventIdQueue.length > limit) {
+    const expired = seenEventIdQueue.shift();
+    seenEventIds.delete(expired);
+  }
+  return true;
+}
+
+function printLiveSummary(output, args) {
+  console.log("\nLive monitor stopped.");
+  console.log(`  stop reason:          ${output.stopReason}`);
+  console.log(`  relays:               ${output.stats.relayCount}`);
+  console.log(`  connect attempts:     ${output.stats.connectAttempts}`);
+  console.log(`  reconnects:           ${output.stats.reconnects}`);
+  console.log(`  relay disconnects:    ${output.stats.relayDisconnects}`);
+  console.log(`  relay errors:         ${output.stats.relayErrors}`);
+  console.log(`  events received:      ${output.stats.eventsReceived}`);
+  console.log(`  valid events written: ${output.stats.validEventsWritten}`);
+  console.log(`  invalid dropped:      ${output.stats.invalidEventsDropped}`);
+  console.log(`  duplicates:           ${output.stats.duplicateEvents}`);
+  console.log(`  firestore project:    ${args.firestoreProject}`);
+  console.log(`  firestore events:     ${args.firestoreEventsCollection}`);
+  console.log(`  firestore state:      ${args.firestoreStateCollection}`);
+  if (args.out) console.log(`  output:               ${args.out}`);
+}
+
+runCli(import.meta.url, parseLiveArgs, runLiveMonitor);

--- a/backend/relay-directory/live-monitor.js
+++ b/backend/relay-directory/live-monitor.js
@@ -1,0 +1,439 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+
+import {
+  buildLiveHeartbeatWrite,
+  buildRawEventIngestionWrites,
+  createNdkRelayClient,
+  isValidSignedEvent,
+} from "./ingestion.js";
+import {
+  IDENTITY_KINDS,
+  buildRunSummaryWrite,
+  commitFirestoreWrites,
+  createFirestore,
+  createRunMetrics,
+  finishRunMetrics,
+  firestoreConfigFromEnv,
+  loadRelaysFromFile,
+  logRunSummary,
+  runCli,
+  takeOptionValue,
+  writeJson,
+} from "./runtime.js";
+
+export function parseLiveArgs(argv) {
+  const args = {
+    ...firestoreConfigFromEnv(),
+    relays: loadRelaysFromFile(),
+    out: null,
+    liveDurationMs: Number(process.env.LIVE_DURATION_MS || 0),
+    liveFlushLimit: Number(process.env.LIVE_FLUSH_LIMIT || 25),
+    liveFlushIntervalMs: Number(process.env.LIVE_FLUSH_INTERVAL_MS || 5000),
+    liveHeartbeatIntervalMs: Number(
+      process.env.LIVE_HEARTBEAT_INTERVAL_MS || 30000,
+    ),
+    liveSeenCacheLimit: Number(process.env.LIVE_SEEN_CACHE_LIMIT || 50000),
+    liveConnectTimeoutMs: Number(process.env.LIVE_CONNECT_TIMEOUT_MS || 15000),
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const take = () => {
+      const result = takeOptionValue(argv, index, flag);
+      index = result.nextIndex;
+      return result.value;
+    };
+
+    if (flag === "--live-listen") continue;
+    if (flag === "--relays") {
+      args.relays = take()
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean);
+    } else if (flag === "--out") args.out = take();
+    else if (flag === "--no-json") args.out = null;
+    else if (flag === "--firestore-project") args.firestoreProject = take();
+    else if (flag === "--firestore-database") args.firestoreDatabase = take();
+    else if (flag === "--firestore-live-runs-collection") {
+      args.firestoreLiveRunsCollection = take();
+    } else if (flag === "--firestore-events-collection") {
+      args.firestoreEventsCollection = take();
+    } else if (flag === "--firestore-queue-collection") {
+      args.firestoreQueueCollection = take();
+    } else if (flag === "--firestore-state-collection") {
+      args.firestoreStateCollection = take();
+    } else if (flag === "--live-duration-ms") {
+      args.liveDurationMs = Number(take());
+    } else if (flag === "--live-flush-limit") {
+      args.liveFlushLimit = Number(take());
+    } else if (flag === "--live-flush-interval-ms") {
+      args.liveFlushIntervalMs = Number(take());
+    } else if (flag === "--live-heartbeat-interval-ms") {
+      args.liveHeartbeatIntervalMs = Number(take());
+    } else if (flag === "--live-seen-cache-limit") {
+      args.liveSeenCacheLimit = Number(take());
+    } else if (flag === "--live-connect-timeout-ms") {
+      args.liveConnectTimeoutMs = Number(take());
+    } else if (flag === "--help" || flag === "-h") {
+      printLiveHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown live-monitor argument: ${flag}`);
+    }
+  }
+
+  validateLiveArgs(args);
+  return args;
+}
+
+function validateLiveArgs(args) {
+  if (!args.firestoreProject) {
+    throw new Error("--firestore-project or GOOGLE_CLOUD_PROJECT is required.");
+  }
+  if (!args.relays.length) throw new Error("At least one relay is required.");
+  if (!Number.isFinite(args.liveDurationMs) || args.liveDurationMs < 0) {
+    throw new Error(
+      "--live-duration-ms must be >= 0. Use 0 to run until stopped.",
+    );
+  }
+  if (!Number.isFinite(args.liveFlushLimit) || args.liveFlushLimit <= 0) {
+    throw new Error("--live-flush-limit must be positive.");
+  }
+  if (
+    !Number.isFinite(args.liveFlushIntervalMs) ||
+    args.liveFlushIntervalMs <= 0
+  ) {
+    throw new Error("--live-flush-interval-ms must be positive.");
+  }
+  if (
+    !Number.isFinite(args.liveHeartbeatIntervalMs) ||
+    args.liveHeartbeatIntervalMs <= 0
+  ) {
+    throw new Error("--live-heartbeat-interval-ms must be positive.");
+  }
+  if (
+    !Number.isFinite(args.liveSeenCacheLimit) ||
+    args.liveSeenCacheLimit <= 0
+  ) {
+    throw new Error("--live-seen-cache-limit must be positive.");
+  }
+  if (
+    !Number.isFinite(args.liveConnectTimeoutMs) ||
+    args.liveConnectTimeoutMs <= 0
+  ) {
+    throw new Error("--live-connect-timeout-ms must be positive.");
+  }
+}
+
+function printLiveHelp() {
+  console.log(`Usage: npm run crawl:directory:live -- [options]
+
+Continuously ingest signed Nostr kind:10011 and kind:0 events into Firestore.
+
+Options:
+  --relays <csv>                       Relays to monitor.
+  --firestore-project <id>             GCP project.
+  --live-duration-ms <n>               0 runs until stopped. Default: 0
+  --live-flush-limit <n>               Buffered events before flush. Default: 25
+  --live-flush-interval-ms <n>         Max time between flushes. Default: 5000
+  --live-heartbeat-interval-ms <n>     Relay heartbeat interval. Default: 30000
+  --live-seen-cache-limit <n>          In-memory dedupe size. Default: 50000
+  --live-connect-timeout-ms <n>        NDK connection timeout. Default: 15000
+  --out <file>                         Optional JSON run summary.
+`);
+}
+
+export async function runLiveMonitor(args, FirestoreCtor) {
+  const runMetrics = createRunMetrics("live-monitor");
+  const db = await createFirestore(args, FirestoreCtor);
+  const startedAt = new Date().toISOString();
+  const stopController = new AbortController();
+  const totals = {
+    relayCount: args.relays.length,
+    connectAttempts: 0,
+    reconnects: 0,
+    relayDisconnects: 0,
+    relayErrors: 0,
+    eventsReceived: 0,
+    validEventsBuffered: 0,
+    validEventsWritten: 0,
+    invalidEventsDropped: 0,
+    duplicateEvents: 0,
+    flushes: 0,
+    heartbeatWrites: 0,
+  };
+  const seenEventIds = new Set();
+  const seenEventIdQueue = [];
+  const buffer = [];
+  let stopReason = "stopped";
+  let flushInFlight = Promise.resolve();
+
+  const stop = (reason) => {
+    if (stopController.signal.aborted) return;
+    stopReason = reason;
+    stopController.abort(reason);
+  };
+
+  const signalHandlers = [];
+  for (const signalName of ["SIGINT", "SIGTERM"]) {
+    const handler = () => stop(signalName);
+    process.once(signalName, handler);
+    signalHandlers.push([signalName, handler]);
+  }
+
+  const durationTimer =
+    args.liveDurationMs > 0
+      ? setTimeout(() => stop("duration_elapsed"), args.liveDurationMs)
+      : null;
+
+  const flushBuffer = async () => {
+    if (!buffer.length) return;
+    const writes = buffer.slice();
+    const rawEventWrites = writes.filter(
+      (write) =>
+        write.collection === args.firestoreEventsCollection && !write.operation,
+    ).length;
+    await commitFirestoreWrites(db, writes);
+    buffer.splice(0, writes.length);
+    totals.validEventsWritten += rawEventWrites;
+    totals.flushes += 1;
+  };
+
+  const scheduleFlush = ({ propagate = false } = {}) => {
+    const nextFlush = flushInFlight.then(flushBuffer, flushBuffer);
+    flushInFlight = nextFlush.catch((error) => {
+      console.error(
+        "Live monitor flush failed; buffered writes will be retried.",
+        error,
+      );
+    });
+    return propagate ? nextFlush : flushInFlight;
+  };
+
+  const flushInterval = setInterval(() => {
+    void scheduleFlush();
+  }, args.liveFlushIntervalMs);
+
+  console.log(
+    `Monitoring ${args.relays.length} relays for kinds ${IDENTITY_KINDS.join(",")} into ${args.firestoreProject}/${args.firestoreDatabase}...`,
+  );
+
+  const listeners = args.relays.map((relay) =>
+    listenRelayLive(relay, args, {
+      signal: stopController.signal,
+      onConnectAttempt: () => {
+        totals.connectAttempts += 1;
+      },
+      onReconnect: () => {
+        totals.reconnects += 1;
+      },
+      onDisconnect: () => {
+        totals.relayDisconnects += 1;
+      },
+      onError: () => {
+        totals.relayErrors += 1;
+      },
+      onEvent: (event) => {
+        totals.eventsReceived += 1;
+        if (!isValidSignedEvent(event)) {
+          totals.invalidEventsDropped += 1;
+          return;
+        }
+        if (seenEventIds.has(event.id)) {
+          totals.duplicateEvents += 1;
+          return;
+        }
+        rememberSeenEventId(
+          event.id,
+          seenEventIds,
+          seenEventIdQueue,
+          args.liveSeenCacheLimit,
+        );
+        buffer.push(
+          ...buildRawEventIngestionWrites(event, relay, "live", args),
+        );
+        totals.validEventsBuffered += 1;
+        if (buffer.length >= args.liveFlushLimit) void scheduleFlush();
+      },
+      onHeartbeat: async (status) => {
+        await commitFirestoreWrites(db, [
+          buildLiveHeartbeatWrite(status, args),
+        ]);
+        totals.heartbeatWrites += 1;
+      },
+    }),
+  );
+
+  await Promise.all(listeners);
+  clearInterval(flushInterval);
+  if (durationTimer) clearTimeout(durationTimer);
+  await scheduleFlush({ propagate: true });
+
+  for (const [signalName, handler] of signalHandlers) {
+    process.removeListener(signalName, handler);
+  }
+
+  const output = {
+    mode: "live",
+    run: finishRunMetrics(runMetrics, totals),
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    stopReason,
+    relays: args.relays,
+    kinds: IDENTITY_KINDS,
+    stats: totals,
+    firestore: {
+      project: args.firestoreProject,
+      database: args.firestoreDatabase,
+      eventsCollection: args.firestoreEventsCollection,
+      queueCollection: args.firestoreQueueCollection,
+      stateCollection: args.firestoreStateCollection,
+    },
+  };
+
+  await commitFirestoreWrites(db, [
+    buildRunSummaryWrite(output.run, output, args.firestoreLiveRunsCollection),
+  ]);
+  logRunSummary(output.run);
+  if (args.out) await writeJson(args.out, output);
+  printLiveSummary(output, args);
+  return output;
+}
+
+export function listenRelayLive(
+  relay,
+  args,
+  callbacks,
+  clientFactory = createNdkRelayClient,
+) {
+  const {
+    signal,
+    onConnectAttempt,
+    onReconnect,
+    onDisconnect,
+    onError,
+    onEvent,
+    onHeartbeat,
+  } = callbacks;
+
+  return new Promise((resolve) => {
+    const client = clientFactory(relay);
+    let stopSubscription = null;
+    let stopStatusListeners = null;
+    let heartbeatTimer = null;
+    let attempts = 0;
+    let connected = false;
+    let lastEventAt = null;
+    let stopped = false;
+
+    const cleanup = () => {
+      if (heartbeatTimer) clearInterval(heartbeatTimer);
+      stopSubscription?.();
+      stopStatusListeners?.();
+      client.close?.();
+    };
+
+    const heartbeat = async (status) => {
+      if (!onHeartbeat) return;
+      await onHeartbeat({
+        relay,
+        status,
+        mode: "live",
+        connected,
+        lastEventAt,
+        attempts,
+      });
+    };
+
+    const finish = async () => {
+      if (stopped) return;
+      stopped = true;
+      cleanup();
+      await heartbeat("stopped").catch(() => {});
+      resolve();
+    };
+
+    stopStatusListeners = client.onStatus?.({
+      onConnecting: () => {
+        attempts += 1;
+        onConnectAttempt?.();
+        if (attempts > 1) onReconnect?.();
+      },
+      onConnect: () => {
+        if (stopped || signal.aborted) return;
+        connected = true;
+        heartbeat("connected").catch(() => {});
+      },
+      onDisconnect: () => {
+        if (stopped || signal.aborted) return;
+        connected = false;
+        onDisconnect?.();
+        heartbeat("disconnected").catch(() => {});
+      },
+    });
+
+    signal.addEventListener("abort", finish, { once: true });
+    heartbeatTimer = setInterval(() => {
+      heartbeat(connected ? "connected" : "disconnected").catch(() => {});
+    }, args.liveHeartbeatIntervalMs);
+
+    Promise.resolve(client.connect(args.liveConnectTimeoutMs))
+      .then(() => {
+        if (stopped || signal.aborted) return;
+        stopSubscription = client.subscribe(
+          { kinds: IDENTITY_KINDS, since: Math.floor(Date.now() / 1000) },
+          {
+            onEvent: (event) => {
+              if (!event?.id) return;
+              lastEventAt = new Date().toISOString();
+              onEvent?.(event, relay);
+            },
+            onClosed: () => onError?.(),
+          },
+        );
+      })
+      .catch(() => {
+        if (!stopped) {
+          onError?.();
+          finish();
+        }
+      });
+  });
+}
+
+export function rememberSeenEventId(
+  eventId,
+  seenEventIds,
+  seenEventIdQueue,
+  limit,
+) {
+  if (seenEventIds.has(eventId)) return false;
+  seenEventIds.add(eventId);
+  seenEventIdQueue.push(eventId);
+  while (seenEventIdQueue.length > limit) {
+    const expired = seenEventIdQueue.shift();
+    seenEventIds.delete(expired);
+  }
+  return true;
+}
+
+function printLiveSummary(output, args) {
+  console.log("\nLive monitor stopped.");
+  console.log(`  stop reason:          ${output.stopReason}`);
+  console.log(`  relays:               ${output.stats.relayCount}`);
+  console.log(`  connect attempts:     ${output.stats.connectAttempts}`);
+  console.log(`  reconnects:           ${output.stats.reconnects}`);
+  console.log(`  relay disconnects:    ${output.stats.relayDisconnects}`);
+  console.log(`  relay errors:         ${output.stats.relayErrors}`);
+  console.log(`  events received:      ${output.stats.eventsReceived}`);
+  console.log(`  valid events written: ${output.stats.validEventsWritten}`);
+  console.log(`  invalid dropped:      ${output.stats.invalidEventsDropped}`);
+  console.log(`  duplicates:           ${output.stats.duplicateEvents}`);
+  console.log(`  firestore project:    ${args.firestoreProject}`);
+  console.log(`  firestore events:     ${args.firestoreEventsCollection}`);
+  console.log(`  firestore state:      ${args.firestoreStateCollection}`);
+  if (args.out) console.log(`  output:               ${args.out}`);
+}
+
+runCli(import.meta.url, parseLiveArgs, runLiveMonitor);

--- a/backend/relay-directory/live-monitor.test.js
+++ b/backend/relay-directory/live-monitor.test.js
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from "vitest";
+import {
+  buildLiveEventWrite,
+  buildLiveHeartbeatWrite,
+  liveStateId,
+} from "./ingestion.js";
+import {
+  listenRelayLive,
+  parseLiveArgs,
+  rememberSeenEventId,
+} from "./live-monitor.js";
+
+const PUBKEY =
+  "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e";
+
+describe("parseLiveArgs", () => {
+  it("validates the NDK connection timeout", () => {
+    expect(() =>
+      parseLiveArgs([
+        "--firestore-project",
+        "gr-prod",
+        "--live-connect-timeout-ms",
+        "0",
+      ]),
+    ).toThrow("--live-connect-timeout-ms must be positive.");
+  });
+});
+
+describe("NDK live subscription adapter", () => {
+  it("streams events and lets NDK own relay lifecycle handling", async () => {
+    const controller = new AbortController();
+    const events = [];
+    const statuses = [];
+    let statusHandlers;
+    let stopped = false;
+
+    const listening = listenRelayLive(
+      "wss://relay.example",
+      {
+        liveConnectTimeoutMs: 1000,
+        liveHeartbeatIntervalMs: 60000,
+      },
+      {
+        signal: controller.signal,
+        onConnectAttempt: () => statuses.push("connecting"),
+        onReconnect: () => statuses.push("reconnecting"),
+        onDisconnect: () => statuses.push("disconnected"),
+        onError: () => statuses.push("error"),
+        onEvent: (event) => {
+          events.push(event);
+          controller.abort();
+        },
+        onHeartbeat: async () => {},
+      },
+      () => ({
+        onStatus(handlers) {
+          statusHandlers = handlers;
+          return () => {};
+        },
+        async connect() {
+          statusHandlers.onConnecting();
+          statusHandlers.onConnect();
+        },
+        subscribe(_filter, handlers) {
+          queueMicrotask(() => handlers.onEvent({ id: "live-event" }));
+          return () => {
+            stopped = true;
+          };
+        },
+        close: () => {},
+      }),
+    );
+
+    await listening;
+    expect(events).toEqual([{ id: "live-event" }]);
+    expect(statuses).toEqual(["connecting"]);
+    expect(stopped).toBe(true);
+  });
+});
+
+describe("live monitor Firestore writes", () => {
+  it("stores live events without overwriting projection state", () => {
+    const write = buildLiveEventWrite(
+      {
+        id: "live-event",
+        kind: 10011,
+        pubkey: PUBKEY,
+        created_at: 1710000001,
+        content: "",
+        tags: [["i", "twitter:alice", "proof"]],
+        sig: "sig",
+      },
+      "wss://relay.example",
+      { firestoreEventsCollection: "events" },
+    );
+
+    expect(write).toMatchObject({
+      collection: "events",
+      id: "live-event",
+      data: {
+        ingestion: expect.objectContaining({
+          mode: "live",
+          lastRelay: "wss://relay.example",
+        }),
+      },
+    });
+    expect(write.data.processing).toBeUndefined();
+  });
+
+  it("keeps event id dedupe bounded", () => {
+    const seen = new Set();
+    const queue = [];
+
+    expect(rememberSeenEventId("a", seen, queue, 2)).toBe(true);
+    expect(rememberSeenEventId("b", seen, queue, 2)).toBe(true);
+    expect(rememberSeenEventId("a", seen, queue, 2)).toBe(false);
+    expect(rememberSeenEventId("c", seen, queue, 2)).toBe(true);
+    expect([...seen]).toEqual(["b", "c"]);
+    expect(queue).toEqual(["b", "c"]);
+  });
+
+  it("stores heartbeat state by relay id", () => {
+    const write = buildLiveHeartbeatWrite(
+      {
+        relay: "wss://relay.example",
+        status: "connected",
+        mode: "live",
+        connected: true,
+        lastEventAt: "2026-06-19T10:00:00.000Z",
+        attempts: 2,
+      },
+      { firestoreStateCollection: "state" },
+    );
+
+    expect(liveStateId("wss://relay.example")).toBe("live:wss:__relay_example");
+    expect(write).toMatchObject({
+      collection: "state",
+      id: "live:wss:__relay_example",
+      data: expect.objectContaining({
+        status: "connected",
+        connected: true,
+        connectAttempts: 2,
+      }),
+    });
+  });
+});

--- a/backend/relay-directory/runtime.js
+++ b/backend/relay-directory/runtime.js
@@ -99,10 +99,15 @@ export function loadRelaysFromFile(filePath = DEFAULT_RELAYS_FILE) {
 
 export const DEFAULT_COLLECTIONS = {
   handles: "nostrDirectoryHandles",
+  liveRuns: "relayLiveListenerRuns",
+  events: "nostrIdentityEvents",
+  queue: "nostrProjectionQueue",
   state: "relayCrawlerState",
   gaps: "relayCrawlerGaps",
   handleWriteFailures: "nostrDirectoryHandleWriteFailures",
 };
+
+const CREATE_IF_MISSING_CONCURRENCY = 20;
 
 export function firestoreConfigFromEnv(env = process.env) {
   return {
@@ -114,6 +119,12 @@ export function firestoreConfigFromEnv(env = process.env) {
     firestoreDatabase: env.FIRESTORE_DATABASE || "(default)",
     firestoreHandlesCollection:
       env.FIRESTORE_HANDLES_COLLECTION || DEFAULT_COLLECTIONS.handles,
+    firestoreLiveRunsCollection:
+      env.FIRESTORE_LIVE_RUNS_COLLECTION || DEFAULT_COLLECTIONS.liveRuns,
+    firestoreEventsCollection:
+      env.FIRESTORE_EVENTS_COLLECTION || DEFAULT_COLLECTIONS.events,
+    firestoreQueueCollection:
+      env.FIRESTORE_QUEUE_COLLECTION || DEFAULT_COLLECTIONS.queue,
     firestoreStateCollection:
       env.FIRESTORE_STATE_COLLECTION || DEFAULT_COLLECTIONS.state,
     firestoreGapsCollection:
@@ -122,6 +133,14 @@ export function firestoreConfigFromEnv(env = process.env) {
       env.FIRESTORE_HANDLE_WRITE_FAILURES_COLLECTION ||
       DEFAULT_COLLECTIONS.handleWriteFailures,
   };
+}
+
+export function takeOptionValue(argv, index, flagName) {
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`${flagName} requires a value.`);
+  }
+  return { value, nextIndex: index + 1 };
 }
 
 export async function createFirestore(args, FirestoreCtor = Firestore) {
@@ -154,14 +173,51 @@ export async function terminateFirestore(db, { timeoutMs = 5000 } = {}) {
 }
 
 export async function commitFirestoreWrites(db, writes) {
-  for (let i = 0; i < writes.length; i += 450) {
+  const normalWrites = [];
+  const createIfMissingWrites = [];
+
+  for (const write of writes) {
+    if (write.operation === "createIfMissing") {
+      createIfMissingWrites.push(write);
+    } else {
+      normalWrites.push(write);
+    }
+  }
+
+  for (
+    let i = 0;
+    i < createIfMissingWrites.length;
+    i += CREATE_IF_MISSING_CONCURRENCY
+  ) {
+    await Promise.all(
+      createIfMissingWrites
+        .slice(i, i + CREATE_IF_MISSING_CONCURRENCY)
+        .map((write) => createFirestoreDocIfMissing(db, write)),
+    );
+  }
+
+  for (let i = 0; i < normalWrites.length; i += 450) {
     const batch = db.batch();
-    for (const write of writes.slice(i, i + 450)) {
+    for (const write of normalWrites.slice(i, i + 450)) {
       batch.set(db.collection(write.collection).doc(write.id), write.data, {
         merge: true,
       });
     }
     await batch.commit();
+  }
+}
+
+async function createFirestoreDocIfMissing(db, write) {
+  try {
+    await db.collection(write.collection).doc(write.id).create(write.data);
+  } catch (error) {
+    if (
+      error?.code === 6 ||
+      /already exists/i.test(String(error?.message || ""))
+    ) {
+      return;
+    }
+    throw error;
   }
 }
 
@@ -276,6 +332,22 @@ export function finishRunMetrics(runMetrics, counters = {}, now = new Date()) {
   });
 }
 
+export function buildRunSummaryWrite(run, output, collection) {
+  return {
+    collection,
+    id: run.runId,
+    data: stripUndefined({
+      ...run,
+      mode: output.mode || output.source || run.module,
+      source: output.source || null,
+      stats: output.stats || null,
+      firestore: output.firestore || null,
+      relays: output.relays || null,
+      updatedAt: FieldValue.serverTimestamp(),
+    }),
+  };
+}
+
 export function logRunSummary(run) {
   console.log(
     JSON.stringify({
@@ -327,4 +399,12 @@ export function runMain(moduleUrl, main) {
       // NDK/Firestore can leave open handles; Cloud Run batch jobs must exit.
       process.exit(process.exitCode ?? 0);
     });
+}
+
+export function runCli(moduleUrl, parseArgs, runner) {
+  if (!isMainModule(moduleUrl)) return;
+  runner(parseArgs(process.argv.slice(2))).catch((error) => {
+    console.error(error.stack || error.message || error);
+    process.exitCode = 1;
+  });
 }

--- a/backend/relay-directory/runtime.js
+++ b/backend/relay-directory/runtime.js
@@ -31,7 +31,11 @@ export function parseRelaysJson(data) {
     let entry;
     if (typeof item === "string") {
       entry = { rank: index + 1, url: item.trim() };
-    } else if (item && typeof item === "object" && typeof item.url === "string") {
+    } else if (
+      item &&
+      typeof item === "object" &&
+      typeof item.url === "string"
+    ) {
       const rank = Number.isFinite(item.rank) ? item.rank : index + 1;
       entry = { rank, url: item.url.trim() };
     } else {
@@ -101,12 +105,16 @@ export const DEFAULT_COLLECTIONS = {
   entries: "nostrDirectoryEntries",
   handles: "nostrDirectoryHandles",
   projectionRuns: "relayProjectionRuns",
+  liveRuns: "relayLiveListenerRuns",
+  events: "nostrIdentityEvents",
+  queue: "nostrProjectionQueue",
   state: "relayCrawlerState",
   gaps: "relayCrawlerGaps",
   handleWriteFailures: "nostrDirectoryHandleWriteFailures",
 };
 
 const BATCH_WRITE_LIMIT = 450;
+const CREATE_IF_MISSING_CONCURRENCY = 20;
 
 export function firestoreConfigFromEnv(env = process.env) {
   return {
@@ -123,6 +131,12 @@ export function firestoreConfigFromEnv(env = process.env) {
     firestoreProjectionRunsCollection:
       env.FIRESTORE_PROJECTION_RUNS_COLLECTION ||
       DEFAULT_COLLECTIONS.projectionRuns,
+    firestoreLiveRunsCollection:
+      env.FIRESTORE_LIVE_RUNS_COLLECTION || DEFAULT_COLLECTIONS.liveRuns,
+    firestoreEventsCollection:
+      env.FIRESTORE_EVENTS_COLLECTION || DEFAULT_COLLECTIONS.events,
+    firestoreQueueCollection:
+      env.FIRESTORE_QUEUE_COLLECTION || DEFAULT_COLLECTIONS.queue,
     firestoreStateCollection:
       env.FIRESTORE_STATE_COLLECTION || DEFAULT_COLLECTIONS.state,
     firestoreGapsCollection:
@@ -131,6 +145,14 @@ export function firestoreConfigFromEnv(env = process.env) {
       env.FIRESTORE_HANDLE_WRITE_FAILURES_COLLECTION ||
       DEFAULT_COLLECTIONS.handleWriteFailures,
   };
+}
+
+export function takeOptionValue(argv, index, flagName) {
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`${flagName} requires a value.`);
+  }
+  return { value, nextIndex: index + 1 };
 }
 
 export async function createFirestore(args, FirestoreCtor = Firestore) {
@@ -163,14 +185,54 @@ export async function terminateFirestore(db, { timeoutMs = 5000 } = {}) {
 }
 
 export async function commitFirestoreWrites(db, writes) {
-  for (let i = 0; i < writes.length; i += BATCH_WRITE_LIMIT) {
+  const normalWrites = [];
+  const createIfMissingWrites = [];
+
+  for (const write of writes) {
+    if (write.operation === "createIfMissing") {
+      createIfMissingWrites.push(write);
+    } else {
+      normalWrites.push(write);
+    }
+  }
+
+  // Commit source/state documents before making create-only queue documents
+  // visible. Consumers can never observe a queue item whose source event has
+  // not been durably written yet.
+  for (let i = 0; i < normalWrites.length; i += BATCH_WRITE_LIMIT) {
     const batch = db.batch();
-    for (const write of writes.slice(i, i + BATCH_WRITE_LIMIT)) {
+    for (const write of normalWrites.slice(i, i + BATCH_WRITE_LIMIT)) {
       batch.set(db.collection(write.collection).doc(write.id), write.data, {
         merge: true,
       });
     }
     await batch.commit();
+  }
+
+  for (
+    let i = 0;
+    i < createIfMissingWrites.length;
+    i += CREATE_IF_MISSING_CONCURRENCY
+  ) {
+    await Promise.all(
+      createIfMissingWrites
+        .slice(i, i + CREATE_IF_MISSING_CONCURRENCY)
+        .map((write) => createFirestoreDocIfMissing(db, write)),
+    );
+  }
+}
+
+async function createFirestoreDocIfMissing(db, write) {
+  try {
+    await db.collection(write.collection).doc(write.id).create(write.data);
+  } catch (error) {
+    if (
+      error?.code === 6 ||
+      /already exists/i.test(String(error?.message || ""))
+    ) {
+      return;
+    }
+    throw error;
   }
 }
 
@@ -372,4 +434,12 @@ export function runMain(moduleUrl, main) {
       // NDK/Firestore can leave open handles; Cloud Run batch jobs must exit.
       process.exit(process.exitCode ?? 0);
     });
+}
+
+export function runCli(moduleUrl, parseArgs, runner) {
+  if (!isMainModule(moduleUrl)) return;
+  runner(parseArgs(process.argv.slice(2))).catch((error) => {
+    console.error(error.stack || error.message || error);
+    process.exitCode = 1;
+  });
 }

--- a/backend/relay-directory/runtime.test.js
+++ b/backend/relay-directory/runtime.test.js
@@ -2,7 +2,11 @@
 
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { firestoreTimestampToMs, runMain } from "./runtime.js";
+import {
+  commitFirestoreWrites,
+  firestoreTimestampToMs,
+  runMain,
+} from "./runtime.js";
 
 const ORIGINAL_ARGV = [...process.argv];
 
@@ -42,4 +46,54 @@ describe("firestoreTimestampToMs", () => {
       expect(firestoreTimestampToMs(value)).toBeNull();
     },
   );
+});
+
+describe("commitFirestoreWrites", () => {
+  it("commits normal documents before exposing create-only queue documents", async () => {
+    const calls = [];
+    const db = {
+      batch() {
+        return {
+          set(ref) {
+            calls.push(`set:${ref.path}`);
+          },
+          async commit() {
+            calls.push("commit");
+          },
+        };
+      },
+      collection(collection) {
+        return {
+          doc(id) {
+            return {
+              path: `${collection}/${id}`,
+              async create() {
+                calls.push(`create:${collection}/${id}`);
+              },
+            };
+          },
+        };
+      },
+    };
+
+    await commitFirestoreWrites(db, [
+      {
+        operation: "createIfMissing",
+        collection: "queue",
+        id: "event-1",
+        data: { status: "pending" },
+      },
+      {
+        collection: "events",
+        id: "event-1",
+        data: { id: "event-1" },
+      },
+    ]);
+
+    expect(calls).toEqual([
+      "set:events/event-1",
+      "commit",
+      "create:queue/event-1",
+    ]);
+  });
 });


### PR DESCRIPTION
## Stack

2 of 3. Depends on #99 (backfill).

Until PR 1 merges, GitHub shows the earlier commit cumulatively. The live-monitoring slice is commit `5a79343`.

## What changed

- adds a dedicated `scripts/relay-directory/live-monitor.mjs` worker entry
- moves reconnect, heartbeat, bounded dedupe, buffering, and flush behavior out of the crawler dispatcher
- extends the shared ingestion module with live event and heartbeat writes
- adds a focused worker-pool deployment script and live-monitoring tests

## Why

Live monitoring has different lifecycle and failure behavior from batch backfill. Its entry interface now owns process signals, reconnect backoff, relay health, and clean shutdown.

## Validation

- `npm test` — 120 tests passed on the completed stack
- backfill + live focused tests — 18 passed after this slice
- Node syntax, Prettier, and `bash -n` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added live relay monitoring for signed events across multiple relays.
  - Added buffering, deduplication, periodic Firestore ingestion, heartbeat tracking, and run summaries.
  - Added a unified crawler command supporting both live monitoring and backfill workflows.
  - Added configurable live-monitor settings for relays, collections, flush intervals, heartbeats, and shutdown duration.

- **Deployment**
  - Added deployment support for running the live listener as a Cloud Run worker pool.
  - Service-account setup now derives and validates account details from configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->