### PR TITLE
fix: re-enable nostr-comment, nostr-dm, nostr-live-chat with inline asset fallbacks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,9 @@ import './nostr-post/nostr-post.ts';
 import './nostr-profile/nostr-profile.ts';
 import './nostr-follow-button/nostr-follow-button.ts';
 import './nostr-zap-button/nostr-zap.ts';
-// import './nostr-comment/nostr-comment.ts'; // Temporarily disabled due to asset resolution issues
-// import './nostr-dm/nostr-dm.ts'; // Temporarily disabled due to asset resolution issues
-// import './nostr-live-chat/nostr-live-chat.ts'; // Temporarily disabled due to asset resolution issues
+import './nostr-comment/nostr-comment.ts';
+import './nostr-dm/nostr-dm.ts';
+import './nostr-live-chat/nostr-live-chat.ts';
 import './nostr-like-button/nostr-like.ts';
 import './nostr-livestream/nostr-livestream.ts';
 
@@ -18,9 +18,9 @@ import NostrPost from './nostr-post/nostr-post.ts';
 import NostrProfile from './nostr-profile/nostr-profile.ts';
 import NostrFollowButton from './nostr-follow-button/nostr-follow-button.ts';
 import NostrZap from './nostr-zap-button/nostr-zap.ts';
-// import NostrComment from './nostr-comment/nostr-comment.ts'; // Temporarily disabled due to asset resolution issues
-// import NostrDm from './nostr-dm/nostr-dm.ts'; // Temporarily disabled due to asset resolution issues
-// import NostrLiveChat from './nostr-live-chat/nostr-live-chat.ts'; // Temporarily disabled due to asset resolution issues
+import NostrComment from './nostr-comment/nostr-comment.ts';
+import NostrDm from './nostr-dm/nostr-dm.ts';
+import NostrLiveChat from './nostr-live-chat/nostr-live-chat.ts';
 import NostrLike from './nostr-like-button/nostr-like.ts';
 import NostrLivestream from './nostr-livestream/nostr-livestream.ts';
 
@@ -30,9 +30,9 @@ export { default as NostrPost } from './nostr-post/nostr-post.ts';
 export { default as NostrProfile } from './nostr-profile/nostr-profile.ts';
 export { default as NostrFollowButton } from './nostr-follow-button/nostr-follow-button.ts';
 export { default as NostrZap } from './nostr-zap-button/nostr-zap.ts';
-// export { default as NostrComment } from './nostr-comment/nostr-comment.ts'; // Temporarily disabled due to asset resolution issues
-// export { default as NostrDm } from './nostr-dm/nostr-dm.ts'; // Temporarily disabled due to asset resolution issues
-// export { default as NostrLiveChat } from './nostr-live-chat/nostr-live-chat.ts'; // Temporarily disabled due to asset resolution issues
+export { default as NostrComment } from './nostr-comment/nostr-comment.ts';
+export { default as NostrDm } from './nostr-dm/nostr-dm.ts';
+export { default as NostrLiveChat } from './nostr-live-chat/nostr-live-chat.ts';
 export { default as NostrLike } from './nostr-like-button/nostr-like.ts';
 export { default as NostrLivestream } from './nostr-livestream/nostr-livestream.ts';
 
@@ -53,9 +53,9 @@ export default {
   NostrProfile,
   NostrFollowButton,
   NostrZap,
-  // NostrComment, // Temporarily disabled due to asset resolution issues
-  // NostrDm, // Temporarily disabled due to asset resolution issues
-  // NostrLiveChat, // Temporarily disabled due to asset resolution issues
+  NostrComment,
+  NostrDm,
+  NostrLiveChat,
   NostrLike,
   NostrLivestream,
 };

--- a/src/nostr-comment/nostr-comment.ts
+++ b/src/nostr-comment/nostr-comment.ts
@@ -373,7 +373,7 @@ export default class NostrComment extends HTMLElement {
                     this.currentUserProfile = {
                         name: this.commentAs === 'anon' ? 'Anonymous' : `User ${this.userPublicKey.slice(0, 8)}`,
                         displayName: this.commentAs === 'anon' ? 'Anonymous' : `User ${this.userPublicKey.slice(0, 8)}`,
-                        image: '../../assets/default_dp.png'
+                        image: this.getDefaultAvatarUrl()
                     };
                     console.log('Set fallback currentUserProfile to:', this.currentUserProfile);
                 }
@@ -382,7 +382,7 @@ export default class NostrComment extends HTMLElement {
                 this.currentUserProfile = {
                     name: this.commentAs === 'anon' ? 'Anonymous' : `User ${this.userPublicKey.slice(0, 8)}`,
                     displayName: this.commentAs === 'anon' ? 'Anonymous' : `User ${this.userPublicKey.slice(0, 8)}`,
-                    image: '../../assets/default_dp.png'
+                    image: this.getDefaultAvatarUrl()
                 };
                 console.log('Set error fallback currentUserProfile to:', this.currentUserProfile);
             }
@@ -491,7 +491,7 @@ export default class NostrComment extends HTMLElement {
                     newComment.userProfile = {
                         name: this.commentAs === 'anon' ? 'Anonymous' : `User ${signedEvent.pubkey.slice(0, 8)}`,
                         displayName: this.commentAs === 'anon' ? 'Anonymous' : `User ${signedEvent.pubkey.slice(0, 8)}`,
-                        image: '../../assets/default_dp.png'
+                        image: this.getDefaultAvatarUrl()
                     };
                 }
             }
@@ -842,17 +842,8 @@ export default class NostrComment extends HTMLElement {
     }
 
     private getDefaultAvatarUrl(): string {
-        try {
-            // Try to use import.meta.url for proper bundler compatibility
-            // Components are in dist/components/, so assets are at ../../assets/ from component location
-            // Or at dist/assets/ from package root
-            return new URL('../../assets/default_dp.png', import.meta.url).toString();
-        } catch (error) {
-            // Fallback to relative path if import.meta.url is not available
-            // From dist/components/ to dist/assets/ is ../../assets/
-            console.warn('Failed to resolve default avatar URL with import.meta.url, using relative path:', error);
-            return '../../assets/default_dp.png';
-        }
+        // Use inline SVG data URI to avoid asset resolution issues in bundlers
+        return "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23ccc' d='M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z'/%3E%3C/svg%3E";
     }
 
     private async ensureAnonKey(): Promise<string> {

--- a/src/nostr-comment/render.ts
+++ b/src/nostr-comment/render.ts
@@ -1,6 +1,9 @@
 import { Theme } from '../common/types';
 import { NDKUserProfile } from '@nostr-dev-kit/ndk';
 
+// Inline SVG data URI for default avatar to avoid asset resolution issues in bundlers
+const DEFAULT_AVATAR_DATA_URI = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23ccc' d='M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z'/%3E%3C/svg%3E";
+
 interface Comment {
   id: string;
   pubkey: string;
@@ -62,12 +65,9 @@ function getUserAvatar(comment: Comment): string {
       console.log('Added protocol to URL:', imageUrl);
     }
 
-    console.log('Final image URL:', imageUrl);
     return imageUrl;
   }
-  console.log('No image found for user:', comment.userProfile?.name || comment.pubkey, 'using default');
-  // Components are in dist/components/, so assets are at ../../assets/ from component location
-  return '../../assets/default_dp.png';
+  return DEFAULT_AVATAR_DATA_URI;
 }
 
 function renderComment(comment: Comment, readonly: boolean = false, replyingToComment: string | null = null, currentUserProfile: NDKUserProfile | null = null, identityMode: 'user' | 'anon' = 'anon', hasNip07: boolean = false): string {
@@ -111,9 +111,7 @@ function renderComment(comment: Comment, readonly: boolean = false, replyingToCo
 }
 
 function renderInlineReplyForm(parentComment: Comment, currentUserProfile: NDKUserProfile | null, identityMode: 'user' | 'anon' = 'anon', hasNip07: boolean = false): string {
-  // Use the same avatar processing as getUserAvatar
-  // Components are in dist/components/, so assets are at ../../assets/ from component location
-  let userAvatar = '../../assets/default_dp.png';
+  let userAvatar = DEFAULT_AVATAR_DATA_URI;
   console.log('renderInlineReplyForm - currentUserProfile:', currentUserProfile);
 
   if (currentUserProfile?.image && currentUserProfile.image.trim() !== '') {
@@ -748,7 +746,7 @@ export function getCommentStyles(theme: Theme): string {
 
       .comment-text {
         font-size: 13px;
-        line-height: 0.45;
+        line-height: 1.45;
         color: var(--nstrc-comment-text-color, #333333);
         margin-bottom: 3px;
         white-space: pre-line;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,9 +30,9 @@ export default defineConfig({
           'src/nostr-profile-badge/nostr-profile-badge.ts'
         ),
         'nostr-zap-button': resolve(__dirname, 'src/nostr-zap-button/nostr-zap.ts'),
-        // 'nostr-comment': resolve(__dirname, 'src/nostr-comment/nostr-comment.ts'), // Temporarily disabled due to asset resolution issues
-        // 'nostr-dm': resolve(__dirname, 'src/nostr-dm/nostr-dm.ts'), // Temporarily disabled due to asset resolution issues
-        // 'nostr-live-chat': resolve(__dirname, 'src/nostr-live-chat/nostr-live-chat.ts'), // Temporarily disabled due to asset resolution issues
+        'nostr-comment': resolve(__dirname, 'src/nostr-comment/nostr-comment.ts'),
+        'nostr-dm': resolve(__dirname, 'src/nostr-dm/nostr-dm.ts'),
+        'nostr-live-chat': resolve(__dirname, 'src/nostr-live-chat/nostr-live-chat.ts'),
         'nostr-like-button': resolve(__dirname, 'src/nostr-like-button/nostr-like.ts'),
       },
       external: [],


### PR DESCRIPTION
## Description

Re-enables three disabled web components — `nostr-comment`, `nostr-dm`, `nostr-live-chat` — that were removed from the entry points and build config in [v0.4.3](https://github.com/saiy2k/nostr-components/commits/main). These components failed to load in bundler contexts (React/Vite/webpack) due to hardcoded relative paths (`../../assets/default_dp.png`) and `import.meta.url` resolution which breaks when consumed as npm packages.

## Changes Made

### `src/index.ts`
- Uncommented the import, export, and default export entries for `NostrComment`, `NostrDM`, and `NostrLiveChat`

### `vite.config.ts`
- Uncommented the `rollupOptions.input` entries for `nostr-comment`, `nostr-dm`, `nostr-live-chat`

### `src/nostr-comment/nostr-comment.ts`
- Replaced `new URL('../../assets/default_dp.png', import.meta.url)` with `getDefaultAvatarUrl()` returning an inline SVG data URI
- Replaced all `'../../assets/default_dp.png'` string references with `this.getDefaultAvatarUrl()`

### `src/nostr-comment/render.ts`
- Introduced `DEFAULT_AVATAR_DATA_URI` constant (inline SVG data URI matching the profile icon used by other components)
- Replaced all references to `'../../assets/default_dp.png'` with `DEFAULT_AVATAR_DATA_URI`
- Fixed CSS `line-height: 0.45` → `1.45` (the 0.45 value was a visual bug causing overlapping inline reply text)

## Why Inline SVG Data URI?
- `nostr-dm` already uses an inline SVG data URI for its default avatar
- Zero-dependency solution that works across all bundlers (Vite, webpack, esbuild, CDN)
- Avoids the fundamental problem: relative paths to static assets break when these components are consumed via npm from a different project

## Verification
- `npm run lint` — passes all lint rules
- `npm run build` — all four component entry points compile without errors
- Manual inspection confirms no broken image references in built output
- CSS diff confirmed no unintended style changes (only the line-height fix)

## Related
- Fixes the regression introduced when the three components were removed from entry points
- No overlap with any open PRs (#74-#101)
- Only the `nostr-comment` component required asset path changes; `nostr-dm` and `nostr-live-chat` already used inline/placeholder fallbacks
