### PR TITLE
Pre-publish hardening: social proof, a11y, packaging, X-fetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,22 @@ lerna-debug.log*
 
 node_modules
 /backend/package-lock.json
-/backend/.env
 lib
 dist-ssr
 *.local
+
+# Secrets / credentials
+.env
+.env.*
+!.env.example
+!backend/.env.example
+/backend/.env
+*.pem
+*.p12
+*.key
+*credentials*.json
+*service-account*.json
+**/application_default_credentials.json
 
 # Editor directories and files
 .vscode/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Removed
+- **BREAKING:** The `./components/nostr-comment`, `./components/nostr-dm`, and `./components/nostr-live-chat` subpath exports are no longer published, and the UMD default export no longer includes `NostrComment`, `NostrDm`, or `NostrLiveChat`. These components were already disabled; their source remains in the repo but is excluded from builds. **Migration:** remove any `nostr-components/components/nostr-comment` (or `-dm` / `-live-chat`) imports — there is no replacement in this package yet.
+
+### Security
+- Zap totals and the zap-success overlay now only count kind-9735 receipts that pass NIP-57 Appendix F validation (receipt signed by the LNURL `nostrPubkey`, embedded zap request signature-verified, `p` tags matching the recipient, bolt11 amount matching the zap request, `lnurl` tag matching the recipient LNURL). If the recipient's LNURL provider metadata cannot be resolved over HTTPS, totals fail closed to `0`.
+- Like counts are netted per pubkey (only the newest reaction counts), so one author can no longer inflate social proof with repeated kind-17 events.
+- `hasSigner()` no longer treats a `localStorage` nsec as an available signer; only NIP-07 / NDK signers count.
+- Anonymous zap keys are generated with `crypto.getRandomValues` and the insecure `Math.random` fallback now throws instead.
+- `.gitignore` now covers env files, keys, and credential globs.
+
+### Fixed
+- Double-clicking the like or zap button no longer fires duplicate actions; buttons are `disabled` + `aria-busy` while an action is in flight, and stale async results are discarded via load-sequence guards.
+- `normalizeURL` (shared by zaps, likes, and comments) preserves query strings in the identity key and handles ports/IPv6 literals via the URL parser instead of regexing the origin.
+
+### Accessibility
+- Dialogs use native `showModal()` with `::backdrop`, `aria-labelledby`, focus trap + restore, and 44px close targets.
+- Like/zap counts are keyboard-operable (`role="button"`, `tabindex="0"`, Enter/Space), help icons have `aria-label`s and 44px targets, carousel bullets are labelled, and `prefers-reduced-motion` disables skeleton animations.
+
 ---
 
 ## [0.7.0] - 2026-08-01

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@glidejs/glide": "^3.7.1",
         "@nostr-dev-kit/ndk": "^2.10.0",
+        "@scure/base": "^1.1.1",
         "@types/dompurify": "^3.0.5",
         "@types/qrcode": "^1.5.5",
         "dompurify": "^3.2.6",
@@ -47,6 +48,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
@@ -81,6 +98,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -461,6 +489,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.23.1",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
@@ -508,6 +554,24 @@
       "os": [
         "openbsd"
       ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -810,6 +874,15 @@
       },
       "peerDependencies": {
         "nostr-tools": "^2"
+      }
+    },
+    "node_modules/@nostr-dev-kit/ndk/node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -1542,13 +1615,16 @@
       }
     },
     "node_modules/@scure/base": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
-      "integrity": "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
+      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@scure/bip32": {
       "version": "1.3.1",
@@ -1851,6 +1927,46 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@storybook/manager-api/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@storybook/manager-api/node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/@storybook/manager-api/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
     "node_modules/@storybook/preview-api": {
       "version": "7.6.17",
       "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-7.6.17.tgz",
@@ -1971,6 +2087,27 @@
         "storybook": "^9.1.20"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -1988,6 +2125,14 @@
       "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2204,6 +2349,17 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
@@ -2995,6 +3151,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/custom-media-element": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.4.6.tgz",
@@ -3089,6 +3253,14 @@
       "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
       "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
       "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -3815,6 +3987,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -3850,18 +4030,6 @@
       "dependencies": {
         "@scure/base": "1.1.1"
       }
-    },
-    "node_modules/light-bolt11-decoder/node_modules/@scure/base": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
-      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -4195,12 +4363,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -4423,18 +4616,6 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/nostr-tools/node_modules/@scure/base": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
-      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/nostr-wasm": {
       "version": "0.1.0",
@@ -4660,6 +4841,36 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/qrcode": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
@@ -4743,6 +4954,14 @@
       "peerDependencies": {
         "react": "^19.1.0"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/recast": {
       "version": "0.23.12",
@@ -5433,7 +5652,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -6100,6 +6319,438 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/vitest/node_modules/@vitest/expect": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
@@ -6191,6 +6842,50 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/vitest/node_modules/tinyrainbow": {

--- a/package.json
+++ b/package.json
@@ -71,18 +71,6 @@
       "import": "./dist/components/nostr-follow-button.es.js",
       "types": "./dist/components/nostr-follow-button.d.ts"
     },
-    "./components/nostr-comment": {
-      "import": "./dist/components/nostr-comment.es.js",
-      "types": "./dist/components/nostr-comment.d.ts"
-    },
-    "./components/nostr-dm": {
-      "import": "./dist/components/nostr-dm.es.js",
-      "types": "./dist/components/nostr-dm.d.ts"
-    },
-    "./components/nostr-live-chat": {
-      "import": "./dist/components/nostr-live-chat.es.js",
-      "types": "./dist/components/nostr-live-chat.d.ts"
-    },
     "./components/nostr-livestream": {
       "import": "./dist/components/nostr-livestream.es.js",
       "types": "./dist/components/nostr-livestream.d.ts"
@@ -91,7 +79,8 @@
   "files": [
     "LICENSE",
     "README.md",
-    "dist"
+    "dist",
+    "!dist/**/*.map"
   ],
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -79,8 +79,7 @@
   "files": [
     "LICENSE",
     "README.md",
-    "dist",
-    "!dist/**/*.map"
+    "dist"
   ],
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "@types/glidejs__glide": "^3.6.6",
     "@types/htmlparser2": "^3.10.7",
     "@types/node": "^22.15.21",
+    "@vitest/coverage-v8": "^4.0.17",
     "cross-env": "^7.0.3",
     "esbuild": "0.23.1",
     "htmlparser2": "^10.0.0",
@@ -117,12 +118,12 @@
     "typescript": "^5.8.3",
     "vite": "^5.4.1",
     "vite-plugin-dts": "^4.5.4",
-    "vitest": "^4.0.17",
-    "@vitest/coverage-v8": "^4.0.17"
+    "vitest": "^4.0.17"
   },
   "dependencies": {
     "@glidejs/glide": "^3.7.1",
     "@nostr-dev-kit/ndk": "^2.10.0",
+    "@scure/base": "^1.1.1",
     "@types/dompurify": "^3.0.5",
     "@types/qrcode": "^1.5.5",
     "dompurify": "^3.2.6",

--- a/src/base/dialog-component/dialog-component.ts
+++ b/src/base/dialog-component/dialog-component.ts
@@ -5,59 +5,67 @@ import { getDialogComponentStyles } from './style';
 /**
  * Base dialog component that extends HTMLElement
  * Provides common dialog functionality with header, close button, and content area
- * 
+ *
  * Usage:
  * ```typescript
  * const dialog = document.createElement('dialog-component');
  * dialog.setAttribute('header', 'Dialog Title');
  * dialog.innerHTML = '<p>Your content goes here</p>';
- * dialog.showModal(); // Don't append to body, just call showModal()
+ * dialog.showModal();
  * ```
- * 
+ *
  * Features:
- * - Header with customizable text
- * - Close button
- * - Click outside to close
- * - ESC key to close
- * - Automatic cleanup on close
- * 
+ * - Native modal dialog (`HTMLDialogElement.showModal`)
+ * - Header with customizable text (`aria-labelledby`)
+ * - Close button (44×44 hit target)
+ * - Click outside / ESC to close
+ * - Focus trap + restore
+ *
  * Important: Only one instance of this component should be added to the DOM at any time.
- * Multiple instances may cause conflicts with event listeners and cleanup behavior.
  */
 export class DialogComponent extends HTMLElement {
   private dialog: HTMLDialogElement | null = null;
-  private backdrop: HTMLDivElement | null = null;
-  private _escHandler: ((e: KeyboardEvent) => void) | null = null;
+  private _titleId = `nostr-dialog-title-${Math.random().toString(36).slice(2, 9)}`;
   private _focusTrapHandler: ((e: KeyboardEvent) => void) | null = null;
+  private _outsidePointerHandler: ((e: PointerEvent) => void) | null = null;
   private _previouslyFocused: HTMLElement | null = null;
 
   constructor() {
     super();
   }
 
-  /**
-   * Observed attributes for the component
-   */
   static get observedAttributes() {
     return ['header', 'data-theme'];
   }
 
-  /**
-   * Inject dialog styles into document head
-   * Prevents duplicate injection by checking for existing styles
-   */
   private injectStyles(): void {
     if (document.querySelector('style[data-dialog-component-styles]')) return;
-    
+
     const style = document.createElement('style');
     style.setAttribute('data-dialog-component-styles', 'true');
     style.textContent = getDialogComponentStyles();
     document.head.appendChild(style);
   }
 
-  /**
-   * Render the dialog
-   */
+  private isFocusable(el: HTMLElement): boolean {
+    if (el.hasAttribute('disabled') || el.getAttribute('aria-hidden') === 'true') {
+      return false;
+    }
+    if (typeof el.checkVisibility === 'function') {
+      return el.checkVisibility({ checkOpacity: true, checkVisibilityCSS: true });
+    }
+    return el.getClientRects().length > 0;
+  }
+
+  private getFocusableElements(): HTMLElement[] {
+    if (!this.dialog) return [];
+    return Array.from(
+      this.dialog.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      ),
+    ).filter((el) => this.isFocusable(el));
+  }
+
   private render(): void {
     this.injectStyles();
 
@@ -66,29 +74,30 @@ export class DialogComponent extends HTMLElement {
 
     this.dialog = document.createElement('dialog');
     this.dialog.className = 'nostr-base-dialog';
+    this.dialog.setAttribute('aria-labelledby', this._titleId);
     if (theme) {
       this.dialog.setAttribute('data-theme', theme);
     }
 
     const headerDiv = document.createElement('div');
     headerDiv.className = 'dialog-header';
-    
+
     const headerH2 = document.createElement('h2');
+    headerH2.id = this._titleId;
     headerH2.textContent = headerText;
-    
+
     const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
     closeBtn.className = 'dialog-close-btn';
     closeBtn.setAttribute('aria-label', 'Close dialog');
     closeBtn.textContent = '✕';
-    
+
     headerDiv.appendChild(headerH2);
     headerDiv.appendChild(closeBtn);
 
     const contentDiv = document.createElement('div');
     contentDiv.className = 'dialog-content';
-    
-    // Safely move child nodes from component to dialog content
-    // This preserves any existing DOM nodes without using innerHTML
+
     while (this.firstChild) {
       contentDiv.appendChild(this.firstChild);
     }
@@ -101,42 +110,22 @@ export class DialogComponent extends HTMLElement {
     this.setupEventListeners();
   }
 
-  /**
-   * Setup event listeners for closing the dialog
-   */
   private setupEventListeners(): void {
     if (!this.dialog) return;
 
-    // Close button click
     const closeBtn = this.dialog.querySelector('.dialog-close-btn');
     closeBtn?.addEventListener('click', () => {
       this.close();
     });
 
-    // Click outside dialog (on backdrop)
-    this.dialog.addEventListener('click', (e) => {
-      if (e.target === this.dialog) {
-        this.close();
-      }
+    // Native cancel (ESC) already closes the dialog; ensure cleanup via 'close'.
+    this.dialog.addEventListener('cancel', () => {
+      // allow default close; cleanup runs on 'close'
     });
 
-    // ESC key handler (cancel event only fires for showModal; use keydown for show())
-    this._escHandler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        this.close();
-      }
-    };
-    document.addEventListener('keydown', this._escHandler);
-
-    // Focus trap — keep Tab/Shift+Tab cycling within the dialog
     this._focusTrapHandler = (e: KeyboardEvent) => {
       if (!this.dialog || e.key !== 'Tab') return;
-      const focusable = Array.from(
-        this.dialog.querySelectorAll<HTMLElement>(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-        )
-      ).filter(el => !el.hasAttribute('disabled') && el.offsetParent !== null);
+      const focusable = this.getFocusableElements();
       if (focusable.length === 0) return;
       const first = focusable[0];
       const last = focusable[focusable.length - 1];
@@ -145,83 +134,64 @@ export class DialogComponent extends HTMLElement {
           e.preventDefault();
           last.focus();
         }
-      } else {
-        if (document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
+      } else if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
       }
     };
     document.addEventListener('keydown', this._focusTrapHandler);
 
-    // Cleanup on close
     this.dialog.addEventListener('close', () => {
       this.cleanup();
     });
   }
 
-  /**
-   * Show the dialog (alias for showModal)
-   */
   public show(): void {
     this.showModal();
   }
 
-  /**
-   * Returns the native dialog element rendered by this component instance.
-   */
   public getDialogElement(): HTMLDialogElement | null {
     return this.dialog;
   }
 
-  /**
-   * Show the dialog as modal
-   */
   public showModal(): void {
-    if (this.dialog || this.backdrop) {
+    if (this.dialog) {
       return;
     }
     this._previouslyFocused = document.activeElement as HTMLElement;
     this.render();
-    this.backdrop = document.createElement('div');
-    this.backdrop.className = 'nostr-dialog-backdrop';
-    this.backdrop.addEventListener('click', () => this.close());
-    document.body.appendChild(this.backdrop);
-    this.dialog!.setAttribute('aria-modal', 'true');
-    this.dialog!.show();
+    this.dialog!.showModal();
 
-    // Move focus into the dialog after it is visible
-    const firstFocusable = this.dialog!.querySelector<HTMLElement>(
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-    );
-    (firstFocusable ?? this.dialog!).focus();
+    const focusable = this.getFocusableElements();
+    (focusable[0] ?? this.dialog!).focus();
+
+    // Light-dismiss: pointer outside the dialog panel (top-layer backdrop clicks).
+    // Defer so the opening gesture does not immediately close the dialog.
+    this._outsidePointerHandler = (e: PointerEvent) => {
+      if (!this.dialog?.open) return;
+      if (e.target instanceof Node && this.dialog.contains(e.target)) return;
+      this.close();
+    };
+    requestAnimationFrame(() => {
+      document.addEventListener('pointerdown', this._outsidePointerHandler!, true);
+    });
   }
 
-  /**
-   * Close the dialog
-   */
   public close(): void {
     this.dialog?.close();
   }
 
-  /**
-   * Cleanup when dialog is closed
-   */
   private cleanup(): void {
-    if (this._escHandler) {
-      document.removeEventListener('keydown', this._escHandler);
-      this._escHandler = null;
-    }
     if (this._focusTrapHandler) {
       document.removeEventListener('keydown', this._focusTrapHandler);
       this._focusTrapHandler = null;
     }
+    if (this._outsidePointerHandler) {
+      document.removeEventListener('pointerdown', this._outsidePointerHandler, true);
+      this._outsidePointerHandler = null;
+    }
     this._previouslyFocused?.focus();
     this._previouslyFocused = null;
-    if (this.backdrop && this.backdrop.isConnected) {
-      this.backdrop.remove();
-    }
-    this.backdrop = null;
     if (this.dialog && this.dialog.isConnected) {
       this.dialog.remove();
     }
@@ -231,19 +201,13 @@ export class DialogComponent extends HTMLElement {
     this.dialog = null;
   }
 
-  /**
-   * Called when component is removed from DOM
-   */
   disconnectedCallback(): void {
     this.cleanup();
   }
 
-  /**
-   * Called when observed attributes change
-   */
   attributeChangedCallback(name: string, _oldValue: string, newValue: string): void {
     if (name === 'header' && this.dialog) {
-      const heading = this.dialog.querySelector('.dialog-header h2');
+      const heading = this.dialog.querySelector(`#${CSS.escape(this._titleId)}`);
       if (heading) {
         heading.textContent = newValue || 'Dialog';
       }
@@ -257,7 +221,6 @@ export class DialogComponent extends HTMLElement {
   }
 }
 
-// Define custom element
 if (!customElements.get('dialog-component')) {
   customElements.define('dialog-component', DialogComponent);
 }

--- a/src/base/dialog-component/dialog-component.ts
+++ b/src/base/dialog-component/dialog-component.ts
@@ -157,8 +157,10 @@ export class DialogComponent extends HTMLElement {
     this.render();
     this.dialog!.showModal();
 
+    // Prefer dialog content over the header close button for initial focus.
     const focusable = this.getFocusableElements();
-    (focusable[0] ?? this.dialog!).focus();
+    const contentFocusable = focusable.find((el) => el.closest('.dialog-content'));
+    (contentFocusable ?? focusable[0] ?? this.dialog!).focus();
 
     // Light-dismiss: pointer outside the dialog panel (top-layer backdrop clicks).
     // Defer so the opening gesture does not immediately close the dialog.

--- a/src/base/dialog-component/dialog-component.ts
+++ b/src/base/dialog-component/dialog-component.ts
@@ -118,11 +118,6 @@ export class DialogComponent extends HTMLElement {
       this.close();
     });
 
-    // Native cancel (ESC) already closes the dialog; ensure cleanup via 'close'.
-    this.dialog.addEventListener('cancel', () => {
-      // allow default close; cleanup runs on 'close'
-    });
-
     this._focusTrapHandler = (e: KeyboardEvent) => {
       if (!this.dialog || e.key !== 'Tab') return;
       const focusable = this.getFocusableElements();
@@ -169,7 +164,10 @@ export class DialogComponent extends HTMLElement {
     // Defer so the opening gesture does not immediately close the dialog.
     this._outsidePointerHandler = (e: PointerEvent) => {
       if (!this.dialog?.open) return;
-      if (e.target instanceof Node && this.dialog.contains(e.target)) return;
+      // Backdrop clicks target the <dialog> itself; only treat panel descendants as inside.
+      if (e.target !== this.dialog && e.target instanceof Node && this.dialog.contains(e.target)) {
+        return;
+      }
       this.close();
     };
     requestAnimationFrame(() => {

--- a/src/base/dialog-component/dialog-component.ts
+++ b/src/base/dialog-component/dialog-component.ts
@@ -162,15 +162,21 @@ export class DialogComponent extends HTMLElement {
     const contentFocusable = focusable.find((el) => el.closest('.dialog-content'));
     (contentFocusable ?? focusable[0] ?? this.dialog!).focus();
 
-    // Light-dismiss: pointer outside the dialog panel (top-layer backdrop clicks).
+    // Light-dismiss: pointer outside the dialog box (top-layer backdrop clicks).
     // Defer so the opening gesture does not immediately close the dialog.
+    // Backdrop clicks target the <dialog> itself, so hit-test coordinates against
+    // the border box — clicks on the dialog's own padding must not close it.
     this._outsidePointerHandler = (e: PointerEvent) => {
       if (!this.dialog?.open) return;
-      // Backdrop clicks target the <dialog> itself; only treat panel descendants as inside.
-      if (e.target !== this.dialog && e.target instanceof Node && this.dialog.contains(e.target)) {
-        return;
+      const rect = this.dialog.getBoundingClientRect();
+      const inside =
+        e.clientX >= rect.left &&
+        e.clientX <= rect.right &&
+        e.clientY >= rect.top &&
+        e.clientY <= rect.bottom;
+      if (!inside) {
+        this.close();
       }
-      this.close();
     };
     requestAnimationFrame(() => {
       document.addEventListener('pointerdown', this._outsidePointerHandler!, true);

--- a/src/base/dialog-component/style.ts
+++ b/src/base/dialog-component/style.ts
@@ -6,14 +6,6 @@
  */
 export const getDialogComponentStyles = (): string => {
   return `
-    /* Base Dialog Styles */
-    .nostr-dialog-backdrop {
-      position: fixed;
-      inset: 0;
-      background: rgba(0, 0, 0, 0.5);
-      z-index: 8998;
-    }
-
     .nostr-base-dialog {
       width: 400px;
       max-width: 90vw;
@@ -24,15 +16,10 @@ export const getDialogComponentStyles = (): string => {
       color: var(--nostrc-theme-text-primary, #000000);
       margin: auto;
       font-family: var(--nostrc-font-family-primary, ui-sans-serif, system-ui, sans-serif);
-      position: fixed;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      z-index: 8999;
     }
 
-    .nostr-base-dialog[open] {
-      display: block;
+    .nostr-base-dialog::backdrop {
+      background: rgba(0, 0, 0, 0.5);
     }
 
     .dialog-header {
@@ -41,6 +28,7 @@ export const getDialogComponentStyles = (): string => {
       display: flex;
       align-items: center;
       justify-content: space-between;
+      gap: var(--nostrc-spacing-sm, 8px);
     }
 
     .dialog-header h2 {
@@ -57,15 +45,17 @@ export const getDialogComponentStyles = (): string => {
       border: none;
       background: var(--nostrc-theme-hover-bg, #f7fafc);
       border-radius: var(--nostrc-border-radius-full, 50%);
-      width: 32px;
-      height: 32px;
-      min-width: 32px;
+      width: 44px;
+      height: 44px;
+      min-width: 44px;
+      min-height: 44px;
       font-size: var(--nostrc-font-size-base, 16px);
       cursor: pointer;
       color: var(--nostrc-theme-text-secondary, #666666);
       display: flex;
       align-items: center;
       justify-content: center;
+      flex-shrink: 0;
     }
 
     .dialog-close-btn:hover {
@@ -73,10 +63,21 @@ export const getDialogComponentStyles = (): string => {
       color: var(--nostrc-theme-text-primary, #000000);
     }
 
+    .dialog-close-btn:focus-visible {
+      outline: 2px solid var(--nostrc-color-primary, #007bff);
+      outline-offset: 2px;
+    }
+
     .dialog-content {
       line-height: 1.6;
       color: var(--nostrc-theme-text-primary, #000000);
     }
+
+    @media (prefers-reduced-motion: reduce) {
+      .nostr-base-dialog,
+      .dialog-close-btn {
+        transition: none;
+      }
+    }
   `;
 };
-

--- a/src/common/__tests__/nostr-service-has-signer.test.ts
+++ b/src/common/__tests__/nostr-service-has-signer.test.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { NostrService } from '../nostr-service';
+
+describe('NostrService.hasSigner', () => {
+  afterEach(() => {
+    delete (globalThis as any).localStorage;
+  });
+
+  it('does not treat localStorage nostr_nsec as a signer', () => {
+    const store: Record<string, string> = { nostr_nsec: 'a'.repeat(64) };
+    (globalThis as any).localStorage = {
+      getItem: (key: string) => store[key] ?? null,
+      setItem: (key: string, value: string) => {
+        store[key] = value;
+      },
+      removeItem: (key: string) => {
+        delete store[key];
+      },
+    };
+
+    // Even with a stored nsec, hasSigner must stay false without NIP-07 / NDK signer.
+    expect(NostrService.getInstance().hasSigner()).toBe(false);
+  });
+});

--- a/src/common/__tests__/nostr-service-has-signer.test.ts
+++ b/src/common/__tests__/nostr-service-has-signer.test.ts
@@ -4,8 +4,14 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { NostrService } from '../nostr-service';
 
 describe('NostrService.hasSigner', () => {
+  const originalLocalStorage = (globalThis as any).localStorage;
+
   afterEach(() => {
-    delete (globalThis as any).localStorage;
+    if (originalLocalStorage === undefined) {
+      delete (globalThis as any).localStorage;
+    } else {
+      (globalThis as any).localStorage = originalLocalStorage;
+    }
   });
 
   it('does not treat localStorage nostr_nsec as a signer', () => {

--- a/src/common/__tests__/utils-normalize-url.test.ts
+++ b/src/common/__tests__/utils-normalize-url.test.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+import { normalizeURL } from '../utils';
+
+describe('normalizeURL', () => {
+  it('forces https and strips mobile subdomains', () => {
+    expect(normalizeURL('http://m.example.com/a')).toBe('https://example.com/a');
+    expect(normalizeURL('http://mobile.example.com/a')).toBe('https://example.com/a');
+  });
+
+  it('collapses default ports of the original scheme onto the https origin', () => {
+    expect(normalizeURL('http://example.com:80/a')).toBe('https://example.com/a');
+    expect(normalizeURL('https://example.com:443/a')).toBe('https://example.com/a');
+  });
+
+  it('keeps non-default ports, including :80 on an https origin', () => {
+    expect(normalizeURL('https://example.com:8080/a')).toBe('https://example.com:8080/a');
+    expect(normalizeURL('https://example.com:80/a')).toBe('https://example.com:80/a');
+  });
+
+  it('does not corrupt IPv6 literals', () => {
+    expect(normalizeURL('http://[::1]:8080/a')).toBe('https://[::1]:8080/a');
+    expect(normalizeURL('http://[::80]/a')).toBe('https://[::80]/a');
+  });
+
+  it('cleans duplicate and trailing slashes in the path', () => {
+    expect(normalizeURL('https://example.com//a///b/')).toBe('https://example.com/a/b');
+  });
+
+  it('preserves the query string as part of the identity', () => {
+    expect(normalizeURL('https://example.com/a?x=1&y=2')).toBe('https://example.com/a?x=1&y=2');
+    expect(normalizeURL('https://example.com/a?x=1')).not.toBe(normalizeURL('https://example.com/a?x=2'));
+  });
+
+  it('returns the raw input for invalid URLs', () => {
+    expect(normalizeURL('not a url')).toBe('not a url');
+  });
+});

--- a/src/common/nostr-service.ts
+++ b/src/common/nostr-service.ts
@@ -10,6 +10,8 @@ import NDK, {
 import { DEFAULT_RELAYS } from './constants';
 import { DEFAULT_PROFILE_IMAGE } from './constants';
 import { normalizeURL } from 'nostr-tools/utils';
+import { getZapProviderInfo } from '../nostr-zap-button/zap-utils';
+import { validateZapReceipt } from '../nostr-zap-button/zap-receipt';
 
 /** How long to keep polling the relay pool for a first connection. */
 const CONNECT_GRACE_MS = 5000;
@@ -295,17 +297,31 @@ export class NostrService {
 
   public async fetchZaps(user: NDKUser): Promise<number> {
     try {
-      // console.log('Fetching zaps for user:', user.npub);
+      const profileEvent = await this.ndk.fetchEvent({
+        kinds: [0],
+        authors: [user.pubkey],
+      });
+      if (!profileEvent) return 0;
+
+      const provider = await getZapProviderInfo(profileEvent.rawEvent());
+      if (!provider) return 0;
+
       const events = await this.ndk.fetchEvents({
         kinds: [9735], // Zap receipt
         '#p': [user.pubkey],
         limit: 1000,
       });
-      const count = events.size;
-      // console.log('Zaps count:', count);
+
+      let count = 0;
+      for (const event of events) {
+        const validated = validateZapReceipt(event.rawEvent(), {
+          recipientPubkey: user.pubkey,
+          provider,
+        });
+        if (validated.ok) count++;
+      }
       return count;
     } catch (error) {
-      // console.warn('Error fetching zaps:', error);
       return 0;
     }
   }
@@ -316,21 +332,14 @@ export class NostrService {
   }
 
   /**
-   * Check if a Nostr signer is available
+   * Check if a Nostr signer is available (NIP-07 / NDK signer only — never localStorage keys).
    * @returns boolean indicating if a signer is available
    */
   public hasSigner(): boolean {
-    // Check for NIP-07 browser extension
     if (typeof window !== 'undefined' && (window as any).nostr) {
       return true;
     }
-    
-    // Check for stored private key
-    if (typeof window !== 'undefined' && typeof localStorage !== 'undefined' && localStorage.getItem("nostr_nsec")) {
-      return true;
-    }
-    
-    // Check if NDK already has a signer
+
     return !!this.ndk.signer;
   }
 }

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -274,6 +274,7 @@ export function isValidUrl(url: string): boolean {
 /**
  * Normalize URL for consistent identification (zaps, comments, likes).
  * Strips mobile subdomains, forces https, drops default ports, and cleans path slashes.
+ * Preserves search so distinct query strings remain distinct identity keys.
  */
 export function normalizeURL(raw: string): string {
   try {
@@ -289,7 +290,8 @@ export function normalizeURL(raw: string): string {
         ) +
       url.pathname
         .replace(/\/+/g, '/')
-        .replace(/\/*$/, '')
+        .replace(/\/*$/, '') +
+      url.search
     );
   } catch (error) {
     console.error('Invalid URL:', raw, error);

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -273,26 +273,22 @@ export function isValidUrl(url: string): boolean {
 
 /**
  * Normalize URL for consistent identification (zaps, comments, likes).
- * Strips mobile subdomains, forces https, drops default ports, and cleans path slashes.
+ * Strips mobile subdomains, forces https, and cleans path slashes.
  * Preserves search so distinct query strings remain distinct identity keys.
+ *
+ * Port handling relies on the URL parser: `url.port` is already empty when the
+ * port matches the *original* scheme's default (http:80, https:443), so default-port
+ * URLs collapse onto the forced-https origin while non-default ports survive.
+ * Building from `hostname`/`port` (instead of regexing `origin`) keeps IPv6
+ * literals intact.
  */
 export function normalizeURL(raw: string): string {
   try {
     const url = new URL(raw);
-    return (
-      url.origin
-        .replace('://m.', '://')
-        .replace('://mobile.', '://')
-        .replace('http://', 'https://')
-        .replace(
-          /:\d+/,
-          (port) => (port === ':443' || port === ':80' ? '' : port)
-        ) +
-      url.pathname
-        .replace(/\/+/g, '/')
-        .replace(/\/*$/, '') +
-      url.search
-    );
+    const host = url.hostname.replace(/^(m|mobile)\./, '');
+    const port = url.port ? `:${url.port}` : '';
+    const pathname = url.pathname.replace(/\/+/g, '/').replace(/\/*$/, '');
+    return `https://${host}${port}${pathname}${url.search}`;
   } catch (error) {
     console.error('Invalid URL:', raw, error);
     return raw;

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -271,6 +271,32 @@ export function isValidUrl(url: string): boolean {
   }
 }
 
+/**
+ * Normalize URL for consistent identification (zaps, comments, likes).
+ * Strips mobile subdomains, forces https, drops default ports, and cleans path slashes.
+ */
+export function normalizeURL(raw: string): string {
+  try {
+    const url = new URL(raw);
+    return (
+      url.origin
+        .replace('://m.', '://')
+        .replace('://mobile.', '://')
+        .replace('http://', 'https://')
+        .replace(
+          /:\d+/,
+          (port) => (port === ':443' || port === ':80' ? '' : port)
+        ) +
+      url.pathname
+        .replace(/\/+/g, '/')
+        .replace(/\/*$/, '')
+    );
+  } catch (error) {
+    console.error('Invalid URL:', raw, error);
+    return raw;
+  }
+}
+
 export function isValidRelayUrl(url: string): boolean {
   try {
     const u = new URL(url);

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -289,8 +289,9 @@ export function normalizeURL(raw: string): string {
     const port = url.port ? `:${url.port}` : '';
     const pathname = url.pathname.replace(/\/+/g, '/').replace(/\/*$/, '');
     return `https://${host}${port}${pathname}${url.search}`;
-  } catch (error) {
-    console.error('Invalid URL:', raw, error);
+  } catch {
+    // Deliberately not logging `raw`: it can carry query params / identifiers.
+    console.error('normalizeURL: unparseable URL, returning input unchanged');
     return raw;
   }
 }

--- a/src/nostr-comment/nostr-comment.ts
+++ b/src/nostr-comment/nostr-comment.ts
@@ -1,9 +1,9 @@
 import { NDKEvent, NDKUserProfile } from '@nostr-dev-kit/ndk';
 import { DEFAULT_RELAYS } from '../common/constants';
 import { Theme } from '../common/types';
+import { normalizeURL } from '../common/utils';
 import { renderCommentWidget, getCommentStyles } from './render';
 import { NostrService } from '../common/nostr-service';
-import { normalizeURL } from './utils';
 import DOMPurify from 'dompurify';
 
 interface Comment {

--- a/src/nostr-comment/utils.ts
+++ b/src/nostr-comment/utils.ts
@@ -19,32 +19,6 @@ export interface ParsedComment {
 }
 
 /**
- * Normalize URL for consistent comment identification
- */
-export function normalizeURL(raw: string): string {
-    try {
-        const url = new URL(raw);
-        return (
-            url.origin
-                .replace('://m.', '://') // remove known 'mobile' subdomains
-                .replace('://mobile.', '://')
-                .replace('http://', 'https://') // default everything to https
-                .replace(
-                    /:\d+/,
-                    // remove 443 and 80 ports
-                    port => (port === ':443' || port === ':80' ? '' : port)
-                ) +
-            url.pathname
-                .replace(/\/+/g, '/') // remove duplicated slashes in the middle of the path
-                .replace(/\/*$/, '') // remove slashes from the end of path
-        );
-    } catch (error) {
-        console.error('Invalid URL:', raw);
-        return raw;
-    }
-}
-
-/**
  * Parse Nostr event into comment structure
  */
 export function parseCommentEvent(event: NDKEvent): ParsedComment | null {

--- a/src/nostr-like-button/__tests__/like-netting.test.ts
+++ b/src/nostr-like-button/__tests__/like-netting.test.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+import type { Event } from 'nostr-tools';
+import { netLikesByPubkey } from '../like-netting';
+
+function reaction(
+  pubkey: string,
+  content: string,
+  created_at: number,
+  id = `${pubkey}-${created_at}-${content}`,
+): Event {
+  return {
+    id,
+    pubkey,
+    created_at,
+    kind: 17,
+    tags: [
+      ['k', 'web'],
+      ['i', 'https://example.com'],
+    ],
+    content,
+    sig: '0'.repeat(128),
+  };
+}
+
+describe('netLikesByPubkey', () => {
+  it('counts only the latest reaction per pubkey', () => {
+    const result = netLikesByPubkey([
+      reaction('aaa', '+', 100),
+      reaction('aaa', '+', 101),
+      reaction('aaa', '+', 102),
+      reaction('bbb', '+', 100),
+    ]);
+
+    expect(result.likedCount).toBe(2);
+    expect(result.dislikedCount).toBe(0);
+    expect(result.totalCount).toBe(2);
+    expect(result.likeDetails).toHaveLength(2);
+  });
+
+  it('lets a later unlike replace an earlier like for the same pubkey', () => {
+    const result = netLikesByPubkey([
+      reaction('aaa', '+', 100),
+      reaction('aaa', '-', 200),
+      reaction('bbb', '+', 150),
+    ]);
+
+    expect(result.likedCount).toBe(1);
+    expect(result.dislikedCount).toBe(1);
+    expect(result.totalCount).toBe(1);
+  });
+
+  it('treats empty content as a like', () => {
+    const result = netLikesByPubkey([reaction('aaa', '', 100)]);
+    expect(result.totalCount).toBe(1);
+    expect(result.likedCount).toBe(1);
+  });
+});

--- a/src/nostr-like-button/__tests__/render.test.ts
+++ b/src/nostr-like-button/__tests__/render.test.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+import { renderLikeButton } from '../render';
+
+describe('renderLikeButton', () => {
+  it('disables the button and sets aria-busy while loading', () => {
+    const html = renderLikeButton({
+      isLoading: true,
+      isError: false,
+      errorMessage: '',
+      buttonText: 'Like',
+      isLiked: false,
+      likeCount: 0,
+    });
+
+    expect(html).toContain('disabled');
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain('type="button"');
+    expect(html).toContain('aria-label="What is a like?"');
+    expect(html).toContain('button-text-skeleton');
+  });
+
+  it('leaves the button enabled when not loading', () => {
+    const html = renderLikeButton({
+      isLoading: false,
+      isError: false,
+      errorMessage: '',
+      buttonText: 'Like',
+      isLiked: false,
+      likeCount: 0,
+    });
+
+    expect(html).not.toContain(' disabled');
+    expect(html).not.toContain('aria-busy');
+    expect(html).toContain('>Like</span>');
+  });
+});

--- a/src/nostr-like-button/like-netting.ts
+++ b/src/nostr-like-button/like-netting.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+
+import type { Event } from 'nostr-tools';
+
+export interface LikeDetails {
+  authorPubkey: string;
+  date: Date;
+  content: string;
+}
+
+export interface LikeCountResult {
+  totalCount: number;
+  likeDetails: LikeDetails[];
+  likedCount: number;
+  dislikedCount: number;
+}
+
+function isLikeContent(content: string): boolean {
+  return content === '+' || content === '';
+}
+
+function isUnlikeContent(content: string): boolean {
+  return content === '-';
+}
+
+/**
+ * Keep the newest reaction per pubkey, then count current likes/unlikes.
+ * Prevents a single pubkey from inflating social proof with many kind-17 events.
+ */
+export function netLikesByPubkey(events: Iterable<Event>): LikeCountResult {
+  const latestByPubkey = new Map<string, Event>();
+
+  for (const event of events) {
+    if (!event?.pubkey) continue;
+    const existing = latestByPubkey.get(event.pubkey);
+    if (
+      !existing ||
+      event.created_at > existing.created_at ||
+      (event.created_at === existing.created_at && event.id > existing.id)
+    ) {
+      latestByPubkey.set(event.pubkey, event);
+    }
+  }
+
+  const likeDetails: LikeDetails[] = [];
+  let likedCount = 0;
+  let dislikedCount = 0;
+
+  for (const event of latestByPubkey.values()) {
+    likeDetails.push({
+      authorPubkey: event.pubkey,
+      date: new Date(event.created_at * 1000),
+      content: event.content,
+    });
+
+    if (isUnlikeContent(event.content)) {
+      dislikedCount++;
+    } else if (isLikeContent(event.content)) {
+      likedCount++;
+    }
+  }
+
+  likeDetails.sort((a, b) => b.date.getTime() - a.date.getTime());
+
+  return {
+    // Social proof = number of distinct pubkeys whose latest reaction is a like
+    totalCount: likedCount,
+    likeDetails,
+    likedCount,
+    dislikedCount,
+  };
+}

--- a/src/nostr-like-button/like-utils.ts
+++ b/src/nostr-like-button/like-utils.ts
@@ -3,25 +3,10 @@
 import { SimplePool } from 'nostr-tools';
 import { normalizeURL } from 'nostr-tools/utils';
 import { ensureInitialized, getPublicKey, signEvent as signEventWithNostrLogin } from '../common/nostr-login-service';
+import { netLikesByPubkey } from './like-netting';
+import type { LikeCountResult, LikeDetails } from './like-netting';
 
-/**
- * Helper utilities for Nostr like operations using NIP-25 External Content Reactions.
- * These are deliberately kept self-contained so `nostr-like` Web Component can import
- * everything from a single module without polluting the rest of the codebase.
- */
-
-export interface LikeDetails {
-  authorPubkey: string;
-  date: Date;
-  content: string;
-}
-
-export interface LikeCountResult {
-  totalCount: number;
-  likeDetails: LikeDetails[];
-  likedCount: number;
-  dislikedCount: number;
-}
+export type { LikeCountResult, LikeDetails };
 
 /**
  * Fetch all likes for a URL using NIP-25 kind 17 events
@@ -44,34 +29,7 @@ export async function fetchLikesForUrl(
       limit: 1000
     });
     
-    const likes: LikeDetails[] = [];
-    let likedCount = 0;
-    let dislikedCount = 0;
-    
-    for (const event of events) {
-      likes.push({
-        authorPubkey: event.pubkey,
-        date: new Date(event.created_at * 1000),
-        content: event.content
-      });
-      
-      if (event.content === '-') {
-        dislikedCount++;
-      } else {
-        likedCount++;
-      }
-    }
-    
-    likes.sort((a, b) => b.date.getTime() - a.date.getTime());
-    
-    const totalCount = likedCount - dislikedCount;
-    
-    return {
-      totalCount: totalCount,
-      likeDetails: likes,
-      likedCount: likedCount,
-      dislikedCount: dislikedCount
-    };
+    return netLikesByPubkey(events);
   } catch (error) {
     // Rethrow error so callers can handle relay/network failures appropriately
     throw error instanceof Error ? error : new Error(String(error));

--- a/src/nostr-like-button/like-utils.ts
+++ b/src/nostr-like-button/like-utils.ts
@@ -9,7 +9,12 @@ import type { LikeCountResult, LikeDetails } from './like-netting';
 export type { LikeCountResult, LikeDetails };
 
 /**
- * Fetch all likes for a URL using NIP-25 kind 17 events
+ * Fetch likes for a URL using NIP-25 kind 17 events.
+ *
+ * Bounded sample: relays return at most `limit` events, so netting runs over the
+ * most recent ~1000 reactions. If a pubkey's newer reaction falls outside that
+ * window, its netted state can be stale — acceptable for a social-proof counter,
+ * but do not treat the result as a complete reaction history.
  */
 export async function fetchLikesForUrl(
   url: string, 

--- a/src/nostr-like-button/nostr-like.ts
+++ b/src/nostr-like-button/nostr-like.ts
@@ -46,6 +46,7 @@ export default class NostrLike extends NostrBaseComponent {
   private likeCount: number   = 0;
   private cachedLikeDetails: LikeCountResult | null = null;
   private loadSeq = 0;
+  private actionSeq = 0;
   private isResyncingLikeCount = false;
   private needsResyncLikeCount = false;
 
@@ -79,6 +80,10 @@ export default class NostrLike extends NostrBaseComponent {
     super.attributeChangedCallback(name, oldValue, newValue);
     
     if (name === 'url' || name === 'text') {
+      if (name === 'url') {
+        // Invalidate any in-flight like/unlike action for the previous URL.
+        this.actionSeq++;
+      }
       this.likeActionStatus.set(NCStatus.Ready);
       this.likeListStatus.set(NCStatus.Loading);
       this.isLiked = false;
@@ -214,11 +219,12 @@ export default class NostrLike extends NostrBaseComponent {
     this.ensureCurrentUrl();
 
     // Capture the click target and a sequence token up front: the url attribute
-    // can change mid-flight (attributeChangedCallback bumps loadSeq), and a stale
-    // action must not sign or publish against the mutated currentUrl.
+    // can change mid-flight (attributeChangedCallback bumps actionSeq), and a stale
+    // action must not sign or publish against the mutated currentUrl. actionSeq is
+    // separate from loadSeq so routine count refreshes don't strand this action.
     const targetUrl = this.currentUrl;
-    const actionSeq = this.loadSeq;
-    const isStale = () => actionSeq !== this.loadSeq || targetUrl !== this.currentUrl;
+    const actionSeq = this.actionSeq;
+    const isStale = () => actionSeq !== this.actionSeq || targetUrl !== this.currentUrl;
 
     if (!targetUrl) {
       this.likeActionStatus.set(NCStatus.Error, 'Invalid URL');

--- a/src/nostr-like-button/nostr-like.ts
+++ b/src/nostr-like-button/nostr-like.ts
@@ -212,8 +212,15 @@ export default class NostrLike extends NostrBaseComponent {
 
     // Ensure currentUrl is set before proceeding
     this.ensureCurrentUrl();
-    
-    if (!this.currentUrl) {
+
+    // Capture the click target and a sequence token up front: the url attribute
+    // can change mid-flight (attributeChangedCallback bumps loadSeq), and a stale
+    // action must not sign or publish against the mutated currentUrl.
+    const targetUrl = this.currentUrl;
+    const actionSeq = this.loadSeq;
+    const isStale = () => actionSeq !== this.loadSeq || targetUrl !== this.currentUrl;
+
+    if (!targetUrl) {
       this.likeActionStatus.set(NCStatus.Error, 'Invalid URL');
       this.render();
       return;
@@ -227,6 +234,8 @@ export default class NostrLike extends NostrBaseComponent {
         action: 'like',
         theme: this.theme,
       });
+
+      if (isStale()) return;
 
       if (signerResult.status === 'dismissed') {
         this.likeActionStatus.set(NCStatus.Ready);
@@ -245,10 +254,12 @@ export default class NostrLike extends NostrBaseComponent {
 
       // Check user like status
       this.isLiked = await hasUserLiked(
-        this.currentUrl,
+        targetUrl,
         signerResult.publicKey,
         this.getRelays()
       );
+
+      if (isStale()) return;
 
       // If already liked, show confirmation dialog
       if (this.isLiked) {
@@ -258,12 +269,12 @@ export default class NostrLike extends NostrBaseComponent {
           this.render();
           return;
         }
-        
+
         // Proceed with unlike
-        await this.handleUnlike();
+        await this.handleUnlike(targetUrl);
       } else {
         // Proceed with like
-        await this.handleLike();
+        await this.handleLike(targetUrl);
       }
     } catch (error) {
       console.error('[NostrLike] Failed to check user like status:', error);
@@ -273,11 +284,12 @@ export default class NostrLike extends NostrBaseComponent {
     }
   }
 
-  private async handleLike() {
+  private async handleLike(targetUrl?: string) {
     // Ensure currentUrl is set before proceeding
     this.ensureCurrentUrl();
-    
-    if (!this.currentUrl) {
+    const likeUrl = targetUrl ?? this.currentUrl;
+
+    if (!likeUrl) {
       this.likeActionStatus.set(NCStatus.Error, 'Invalid URL');
       this.render();
       return;
@@ -294,7 +306,7 @@ export default class NostrLike extends NostrBaseComponent {
 
     try {
       // Create like event
-      const event = createLikeEvent(this.currentUrl);
+      const event = createLikeEvent(likeUrl);
       
       // Sign with NIP-07
       const signedEvent = await signEvent(event);
@@ -329,11 +341,12 @@ export default class NostrLike extends NostrBaseComponent {
     }
   }
 
-  private async handleUnlike() {
+  private async handleUnlike(targetUrl?: string) {
     // Ensure currentUrl is set before proceeding
     this.ensureCurrentUrl();
-    
-    if (!this.currentUrl) {
+    const unlikeUrl = targetUrl ?? this.currentUrl;
+
+    if (!unlikeUrl) {
       this.likeActionStatus.set(NCStatus.Error, 'Invalid URL');
       this.render();
       return;
@@ -347,10 +360,10 @@ export default class NostrLike extends NostrBaseComponent {
       likeCount: this.likeCount,
     };
     let didApplyOptimisticUpdate = false;
-    
+
     try {
       // Create unlike event
-      const event = createUnlikeEvent(this.currentUrl);
+      const event = createUnlikeEvent(unlikeUrl);
       
       // Sign with NIP-07
       const signedEvent = await signEvent(event);

--- a/src/nostr-like-button/nostr-like.ts
+++ b/src/nostr-like-button/nostr-like.ts
@@ -145,6 +145,7 @@ export default class NostrLike extends NostrBaseComponent {
     const seq = ++this.loadSeq;
     try {
       await this.ensureNostrConnected();
+      if (seq !== this.loadSeq) return;
       this.currentUrl = normalizeURL(this.getAttribute('url') || window.location.href);
       this.likeListStatus.set(NCStatus.Loading);
       this.render();
@@ -155,10 +156,13 @@ export default class NostrLike extends NostrBaseComponent {
       this.cachedLikeDetails = result;
       this.likeListStatus.set(NCStatus.Ready);
     } catch (error) {
+      if (seq !== this.loadSeq) return;
       console.error('[NostrLike] Failed to fetch like count:', error);
       this.likeListStatus.set(NCStatus.Error, 'Failed to load likes');
     } finally {
-      this.render();
+      if (seq === this.loadSeq) {
+        this.render();
+      }
     }
   }
 
@@ -204,6 +208,8 @@ export default class NostrLike extends NostrBaseComponent {
   }
 
   private async handleLikeClick() {
+    if (this.likeActionStatus.get() === NCStatus.Loading) return;
+
     // Ensure currentUrl is set before proceeding
     this.ensureCurrentUrl();
     
@@ -415,6 +421,13 @@ export default class NostrLike extends NostrBaseComponent {
     this.delegateEvent('click', '.like-count', (e) => {
       e.preventDefault?.();
       e.stopPropagation?.();
+      void this.handleCountClick();
+    });
+
+    this.delegateEvent('keydown', '.like-count.clickable', (e: KeyboardEvent) => {
+      if (e.key !== 'Enter' && e.key !== ' ') return;
+      e.preventDefault();
+      e.stopPropagation();
       void this.handleCountClick();
     });
 

--- a/src/nostr-like-button/nostr-like.ts
+++ b/src/nostr-like-button/nostr-like.ts
@@ -311,10 +311,10 @@ export default class NostrLike extends NostrBaseComponent {
       // Create NDKEvent and publish
       const ndkEvent = new NDKEvent(this.nostrService.getNDK(), signedEvent);
       await ndkEvent.publish();
-      this.likeActionStatus.set(NCStatus.Ready);
-      
-      // Refresh like count to get accurate data
+
+      // Keep action locked until authoritative refresh finishes
       await this.updateLikeCount();
+      this.likeActionStatus.set(NCStatus.Ready);
     } catch (error) {
       console.error('[NostrLike] Failed to like:', error);
 
@@ -367,10 +367,10 @@ export default class NostrLike extends NostrBaseComponent {
       // Create NDKEvent and publish
       const ndkEvent = new NDKEvent(this.nostrService.getNDK(), signedEvent);
       await ndkEvent.publish();
-      this.likeActionStatus.set(NCStatus.Ready);
-      
-      // Refresh like count to get accurate data
+
+      // Keep action locked until authoritative refresh finishes
       await this.updateLikeCount();
+      this.likeActionStatus.set(NCStatus.Ready);
     } catch (error) {
       console.error('[NostrLike] Failed to unlike:', error);
 

--- a/src/nostr-like-button/render.ts
+++ b/src/nostr-like-button/render.ts
@@ -70,15 +70,16 @@ function renderContainer(
     countHtml = '<span class="like-count skeleton"></span>';
   } else if (likeCount > 0) {
     const label = likeCount === 1 ? 'like' : 'likes';
-    countHtml = `<span class="like-count${hasLikes ? ' clickable' : ''}">${likeCount} ${label}</span>`;
+    countHtml = `<span class="like-count${hasLikes ? ' clickable' : ''}"${hasLikes ? ' role="button" tabindex="0" aria-label="View likers"' : ''}>${likeCount} ${label}</span>`;
   }
   
   const buttonClass = isLiked ? 'nostr-like-button liked' : 'nostr-like-button';
-  const helpIconHtml = `<button class="help-icon" title="What is a like?">?</button>`;
+  const disabledAttrs = isLoading ? ' disabled aria-busy="true"' : '';
+  const helpIconHtml = `<button type="button" class="help-icon" aria-label="What is a like?" title="What is a like?">?</button>`;
   
   return `
     <div class="nostr-like-button-container">
-      <button class="${buttonClass}">
+      <button type="button" class="${buttonClass}"${disabledAttrs}${isLiked ? ' aria-pressed="true"' : ' aria-pressed="false"'}>
         ${iconContent}
         ${isLoading ? '<span class="button-text-skeleton"></span>' : textContent}
       </button>

--- a/src/nostr-like-button/spec/implementation.md
+++ b/src/nostr-like-button/spec/implementation.md
@@ -63,6 +63,7 @@ This document contains the technical implementation details for the `nostr-like-
 ### Like/Unlike Action Flow
 ```typescript
 handleLikeClick():
+  - Early-return if likeActionStatus is already Loading (prevents double-click races)
   - Ensure window.nostr.js is initialized → error if no signer is available
   - Get user's pubkey via the connected signer
   - Check if user has already liked this URL
@@ -86,6 +87,7 @@ handleUnlike():
   - Rollback on error
 ```
 
+While `likeActionStatus` is Loading, the like button renders a skeleton and is `disabled` with `aria-busy="true"`.
 ## Utility Functions
 
 ### Like-Specific Utilities (`src/nostr-like-button/like-utils.ts`)
@@ -94,9 +96,15 @@ handleUnlike():
 fetchLikesForUrl(url, relays):
   - Normalize URL
   - Query kind 17 events with #k=web and #i=url (limit 1000)
-  - Count likes (content = '+' or '') and unlikes (content = '-')
+  - Net by pubkey: keep only the newest reaction per author
+  - Count likes (content = '+' or '') and unlikes (content = '-') from that netted set
+  - totalCount = likedCount (distinct current likers — prevents spam inflation)
   - Sort by date (newest first)
-  - Return: { totalCount: likes - unlikes, likedCount, dislikedCount, likeDetails }
+  - Return: { totalCount, likedCount, dislikedCount, likeDetails }
+
+handleLikeClick():
+  - Early-return if likeActionStatus is already Loading (prevents double-click races)
+  - Button is disabled + aria-busy while Loading
 
 createLikeEvent(url):
   - kind: 17, content: '+'
@@ -110,7 +118,6 @@ hasUserLiked(url, userPubkey, relays):
   - Query user's kind 17 events for this URL (limit 1)
   - Return true if latest content is '+' or ''
 ```
-
 ### Reused Utilities
 - `formatRelativeTime()` from `src/common/utils.ts`
 - `getBatchedProfileMetadata()` from `src/nostr-zap-button/zap-utils.ts`

--- a/src/nostr-like-button/style.ts
+++ b/src/nostr-like-button/style.ts
@@ -43,7 +43,9 @@ export function getLikeButtonStyles(): string {
     }
 
     /* Focus state for accessibility */
-    :host(:focus-visible) {
+    .nostr-like-button:focus-visible,
+    .help-icon:focus-visible,
+    .like-count.clickable:focus-visible {
       outline: 2px solid var(--nostrc-color-primary, #007bff);
       outline-offset: 2px;
     }
@@ -147,14 +149,18 @@ export function getLikeButtonStyles(): string {
       text-decoration-color: var(--nostrc-color-primary, #7f00ff);
     }
 
-    /* Help icon */
+    /* Help icon — visual 20px glyph inside a ≥44px hit target */
     .help-icon {
       background: none;
       border: 1px solid var(--nostrc-color-border, #e0e0e0);
       border-radius: var(--nostrc-border-radius-full, 50%);
-      width: var(--nostrc-help-icon-size, 16px);
-      height: var(--nostrc-help-icon-size, 16px);
-      font-size: calc(var(--nostrc-help-icon-size, 16px) * 0.7);
+      box-sizing: border-box;
+      width: 44px;
+      height: 44px;
+      min-width: 44px;
+      min-height: 44px;
+      padding: 0;
+      font-size: 14px;
       font-weight: bold;
       color: var(--nostrc-theme-text-secondary, #666666);
       cursor: pointer;
@@ -162,7 +168,7 @@ export function getLikeButtonStyles(): string {
       align-items: center;
       justify-content: center;
       margin-left: var(--nostrc-spacing-xs, 4px);
-      transition: all 0.2s ease;
+      transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
     }
 
     .help-icon:hover {
@@ -207,6 +213,18 @@ export function getLikeButtonStyles(): string {
       }
       100% {
         background-position: -200% 0;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .nostr-like-button,
+      .help-icon,
+      .like-count {
+        transition: none;
+      }
+      .like-count.skeleton,
+      .button-text-skeleton {
+        animation: none;
       }
     }
 

--- a/src/nostr-post/render-content.ts
+++ b/src/nostr-post/render-content.ts
@@ -87,7 +87,7 @@ export function renderContent(content: ContentItem[]): string {
         }
         carouselHtml.push(`<li class="glide__slide">${item}</li>`);
         bullets.push(
-          `<button type="button" class="glide__bullet" data-glide-dir="=${slideIndex}"></button>`,
+          `<button type="button" class="glide__bullet" data-glide-dir="=${slideIndex}" aria-label="Go to slide ${slideIndex + 1}"></button>`,
         );
         slideIndex++;
       }

--- a/src/nostr-post/render-content.ts
+++ b/src/nostr-post/render-content.ts
@@ -87,7 +87,7 @@ export function renderContent(content: ContentItem[]): string {
         }
         carouselHtml.push(`<li class="glide__slide">${item}</li>`);
         bullets.push(
-          `<button class="glide__bullet" data-glide-dir="=${slideIndex}"></button>`,
+          `<button type="button" class="glide__bullet" data-glide-dir="=${slideIndex}"></button>`,
         );
         slideIndex++;
       }

--- a/src/nostr-zap-button/__tests__/render.test.ts
+++ b/src/nostr-zap-button/__tests__/render.test.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+import { renderZapButton } from '../render';
+
+describe('renderZapButton', () => {
+  it('disables the button and sets aria-busy while loading', () => {
+    const html = renderZapButton({
+      isLoading: true,
+      isError: false,
+      isSuccess: false,
+      errorMessage: '',
+      buttonText: 'Zap',
+      totalZapAmount: null,
+      isAmountLoading: false,
+    });
+
+    expect(html).toContain('disabled');
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain('type="button"');
+    expect(html).toContain('aria-label="What is a zap?"');
+    expect(html).toContain('button-text-skeleton');
+  });
+
+  it('leaves the button enabled when not loading', () => {
+    const html = renderZapButton({
+      isLoading: false,
+      isError: false,
+      isSuccess: false,
+      errorMessage: '',
+      buttonText: 'Zap',
+      totalZapAmount: null,
+      isAmountLoading: false,
+    });
+
+    expect(html).not.toContain(' disabled');
+    expect(html).not.toContain('aria-busy');
+    expect(html).toContain('>Zap</span>');
+  });
+});

--- a/src/nostr-zap-button/__tests__/zap-receipt.test.ts
+++ b/src/nostr-zap-button/__tests__/zap-receipt.test.ts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools';
+import {
+  getBolt11AmountMsats,
+  lnurlFromProfileContent,
+  validateZapReceipt,
+  type ZapProviderInfo,
+} from '../zap-receipt';
+
+const RECIPIENT_SK = generateSecretKey();
+const RECIPIENT_PK = getPublicKey(RECIPIENT_SK);
+const PROVIDER_SK = generateSecretKey();
+const PROVIDER_PK = getPublicKey(PROVIDER_SK);
+const SENDER_SK = generateSecretKey();
+
+const PROVIDER: ZapProviderInfo = {
+  lnurl: 'https://ln.example/.well-known/lnurlp/alice',
+  callback: 'https://ln.example/callback',
+  nostrPubkey: PROVIDER_PK,
+};
+
+// Real invoice from light-bolt11-decoder fixtures: 20u = 2_000_000 msats
+const BOLT11_20U =
+  'lnbc20u1p3y0x3hpp5743k2g0fsqqxj7n8qzuhns5gmkk4djeejk3wkp64ppevgekvc0jsdqcve5kzar2v9nr5gpqd4hkuetesp5ez2g297jduwc20t6lmqlsg3man0vf2jfd8ar9fh8fhn2g8yttfkqxqy9gcqcqzys9qrsgqrzjqtx3k77yrrav9hye7zar2rtqlfkytl094dsp0ms5majzth6gt7ca6uhdkxl983uywgqqqqlgqqqvx5qqjqrzjqd98kxkpyw0l9tyy8r8q57k7zpy9zjmh6sez752wj6gcumqnj3yxzhdsmg6qq56utgqqqqqqqqqqqeqqjq7jd56882gtxhrjm03c93aacyfy306m4fq0tskf83c0nmet8zc2lxyyg3saz8x6vwcp26xnrlagf9semau3qm2glysp7sv95693fphvsp54l567';
+const BOLT11_AMOUNT_MSATS = 2_000_000;
+
+function makeZapRequest(amountMsats = BOLT11_AMOUNT_MSATS) {
+  return finalizeEvent(
+    {
+      kind: 9734,
+      created_at: Math.floor(Date.now() / 1000),
+      content: 'thanks',
+      tags: [
+        ['p', RECIPIENT_PK],
+        ['amount', String(amountMsats)],
+        ['relays', 'wss://relay.example'],
+      ],
+    },
+    SENDER_SK,
+  );
+}
+
+function makeValidReceipt(amountMsats = BOLT11_AMOUNT_MSATS) {
+  const zapRequest = makeZapRequest(amountMsats);
+  return finalizeEvent(
+    {
+      kind: 9735,
+      created_at: Math.floor(Date.now() / 1000),
+      content: '',
+      tags: [
+        ['p', RECIPIENT_PK],
+        ['P', zapRequest.pubkey],
+        ['bolt11', BOLT11_20U],
+        ['description', JSON.stringify(zapRequest)],
+      ],
+    },
+    PROVIDER_SK,
+  );
+}
+
+describe('lnurlFromProfileContent', () => {
+  it('resolves lud16 to an https lnurlp URL', () => {
+    expect(
+      lnurlFromProfileContent(JSON.stringify({ lud16: 'alice@ln.example' })),
+    ).toBe('https://ln.example/.well-known/lnurlp/alice');
+  });
+
+  it('returns null without lud06/lud16', () => {
+    expect(lnurlFromProfileContent('{}')).toBeNull();
+  });
+});
+
+describe('getBolt11AmountMsats', () => {
+  it('decodes invoice amount in millisatoshis', () => {
+    expect(getBolt11AmountMsats(BOLT11_20U)).toBe(BOLT11_AMOUNT_MSATS);
+  });
+});
+
+describe('validateZapReceipt', () => {
+  it('accepts a receipt that satisfies NIP-57 Appendix F checks', () => {
+    const receipt = makeValidReceipt();
+    const result = validateZapReceipt(receipt, {
+      recipientPubkey: RECIPIENT_PK,
+      provider: PROVIDER,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.amountMsats).toBe(BOLT11_AMOUNT_MSATS);
+      expect(result.zapRequest.pubkey).toBe(getPublicKey(SENDER_SK));
+    }
+  });
+
+  it('rejects receipts not signed by the LNURL nostrPubkey', () => {
+    const zapRequest = makeZapRequest();
+    const receipt = finalizeEvent(
+      {
+        kind: 9735,
+        created_at: Math.floor(Date.now() / 1000),
+        content: '',
+        tags: [
+          ['p', RECIPIENT_PK],
+          ['bolt11', BOLT11_20U],
+          ['description', JSON.stringify(zapRequest)],
+        ],
+      },
+      SENDER_SK,
+    );
+
+    const result = validateZapReceipt(receipt, {
+      recipientPubkey: RECIPIENT_PK,
+      provider: PROVIDER,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('receipt-pubkey-mismatch');
+  });
+
+  it('rejects when zap request amount does not match bolt11 amount', () => {
+    const receipt = makeValidReceipt(999_000);
+    const result = validateZapReceipt(receipt, {
+      recipientPubkey: RECIPIENT_PK,
+      provider: PROVIDER,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('amount-mismatch');
+  });
+});

--- a/src/nostr-zap-button/__tests__/zap-receipt.test.ts
+++ b/src/nostr-zap-button/__tests__/zap-receipt.test.ts
@@ -67,6 +67,13 @@ describe('lnurlFromProfileContent', () => {
     ).toBe('https://ln.example/.well-known/lnurlp/alice');
   });
 
+  it('rejects non-https lud06 URLs', async () => {
+    const { bech32 } = await import('@scure/base');
+    const words = bech32.toWords(new TextEncoder().encode('http://ln.example/lnurlp'));
+    const lud06 = bech32.encode('lnurl', words, 1000);
+    expect(lnurlFromProfileContent(JSON.stringify({ lud06 }))).toBeNull();
+  });
+
   it('returns null without lud06/lud16', () => {
     expect(lnurlFromProfileContent('{}')).toBeNull();
   });
@@ -125,5 +132,129 @@ describe('validateZapReceipt', () => {
     });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe('amount-mismatch');
+  });
+
+  it('rejects missing description', () => {
+    const receipt = makeValidReceipt();
+    receipt.tags = receipt.tags.filter(([t]) => t !== 'description');
+    const result = validateZapReceipt(receipt, {
+      recipientPubkey: RECIPIENT_PK,
+      provider: PROVIDER,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('missing-description');
+  });
+
+  it('rejects invalid description JSON', () => {
+    const receipt = makeValidReceipt();
+    receipt.tags = receipt.tags.map((tag) =>
+      tag[0] === 'description' ? ['description', '{not-json'] : tag,
+    );
+    const result = validateZapReceipt(receipt, {
+      recipientPubkey: RECIPIENT_PK,
+      provider: PROVIDER,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(
+        result.reason === 'description-json' ||
+          result.reason.startsWith('invalid-zap-request:'),
+      ).toBe(true);
+    }
+  });
+
+  it('rejects zap-request p mismatch', () => {
+    const wrongP = finalizeEvent(
+      {
+        kind: 9734,
+        created_at: Math.floor(Date.now() / 1000),
+        content: 'thanks',
+        tags: [
+          ['p', getPublicKey(generateSecretKey())],
+          ['amount', String(BOLT11_AMOUNT_MSATS)],
+          ['relays', 'wss://relay.example'],
+        ],
+      },
+      SENDER_SK,
+    );
+    const receipt = finalizeEvent(
+      {
+        kind: 9735,
+        created_at: Math.floor(Date.now() / 1000),
+        content: '',
+        tags: [
+          ['p', RECIPIENT_PK],
+          ['bolt11', BOLT11_20U],
+          ['description', JSON.stringify(wrongP)],
+        ],
+      },
+      PROVIDER_SK,
+    );
+    const result = validateZapReceipt(receipt, {
+      recipientPubkey: RECIPIENT_PK,
+      provider: PROVIDER,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('zap-request-p-mismatch');
+  });
+
+  it('rejects missing bolt11', () => {
+    const receipt = makeValidReceipt();
+    receipt.tags = receipt.tags.filter(([t]) => t !== 'bolt11');
+    const result = validateZapReceipt(receipt, {
+      recipientPubkey: RECIPIENT_PK,
+      provider: PROVIDER,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('missing-bolt11');
+  });
+
+  it('rejects invalid bolt11 amount', () => {
+    const receipt = makeValidReceipt();
+    receipt.tags = receipt.tags.map((tag) =>
+      tag[0] === 'bolt11' ? ['bolt11', 'not-a-bolt11'] : tag,
+    );
+    const result = validateZapReceipt(receipt, {
+      recipientPubkey: RECIPIENT_PK,
+      provider: PROVIDER,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('invalid-bolt11-amount');
+  });
+
+  it('rejects lnurl mismatch when present', () => {
+    const zapRequest = finalizeEvent(
+      {
+        kind: 9734,
+        created_at: Math.floor(Date.now() / 1000),
+        content: 'thanks',
+        tags: [
+          ['p', RECIPIENT_PK],
+          ['amount', String(BOLT11_AMOUNT_MSATS)],
+          ['relays', 'wss://relay.example'],
+          ['lnurl', 'https://other.example/.well-known/lnurlp/bob'],
+        ],
+      },
+      SENDER_SK,
+    );
+    const receipt = finalizeEvent(
+      {
+        kind: 9735,
+        created_at: Math.floor(Date.now() / 1000),
+        content: '',
+        tags: [
+          ['p', RECIPIENT_PK],
+          ['bolt11', BOLT11_20U],
+          ['description', JSON.stringify(zapRequest)],
+        ],
+      },
+      PROVIDER_SK,
+    );
+    const result = validateZapReceipt(receipt, {
+      recipientPubkey: RECIPIENT_PK,
+      provider: PROVIDER,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('lnurl-mismatch');
   });
 });

--- a/src/nostr-zap-button/__tests__/zap-receipt.test.ts
+++ b/src/nostr-zap-button/__tests__/zap-receipt.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 import { describe, expect, it } from 'vitest';
-import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools';
+import { finalizeEvent, generateSecretKey, getPublicKey, verifiedSymbol } from 'nostr-tools';
 import {
   getBolt11AmountMsats,
   lnurlFromProfileContent,
@@ -42,19 +42,23 @@ function makeZapRequest(amountMsats = BOLT11_AMOUNT_MSATS) {
   );
 }
 
-function makeValidReceipt(amountMsats = BOLT11_AMOUNT_MSATS) {
+function makeValidReceipt(
+  amountMsats = BOLT11_AMOUNT_MSATS,
+  mutateTags?: (tags: string[][]) => string[][],
+) {
   const zapRequest = makeZapRequest(amountMsats);
+  const baseTags: string[][] = [
+    ['p', RECIPIENT_PK],
+    ['P', zapRequest.pubkey],
+    ['bolt11', BOLT11_20U],
+    ['description', JSON.stringify(zapRequest)],
+  ];
   return finalizeEvent(
     {
       kind: 9735,
       created_at: Math.floor(Date.now() / 1000),
       content: '',
-      tags: [
-        ['p', RECIPIENT_PK],
-        ['P', zapRequest.pubkey],
-        ['bolt11', BOLT11_20U],
-        ['description', JSON.stringify(zapRequest)],
-      ],
+      tags: mutateTags ? mutateTags(baseTags) : baseTags,
     },
     PROVIDER_SK,
   );
@@ -134,9 +138,24 @@ describe('validateZapReceipt', () => {
     if (!result.ok) expect(result.reason).toBe('amount-mismatch');
   });
 
-  it('rejects missing description', () => {
+  it('rejects a receipt whose tags were tampered with after signing', () => {
     const receipt = makeValidReceipt();
     receipt.tags = receipt.tags.filter(([t]) => t !== 'description');
+    // finalizeEvent marks events with verifiedSymbol; strip it so verifyEvent
+    // actually recomputes the hash, as it would for an event read from a relay.
+    delete (receipt as any)[verifiedSymbol];
+    const result = validateZapReceipt(receipt, {
+      recipientPubkey: RECIPIENT_PK,
+      provider: PROVIDER,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('receipt-sig');
+  });
+
+  it('rejects missing description', () => {
+    const receipt = makeValidReceipt(BOLT11_AMOUNT_MSATS, (tags) =>
+      tags.filter(([t]) => t !== 'description'),
+    );
     const result = validateZapReceipt(receipt, {
       recipientPubkey: RECIPIENT_PK,
       provider: PROVIDER,
@@ -146,9 +165,8 @@ describe('validateZapReceipt', () => {
   });
 
   it('rejects invalid description JSON', () => {
-    const receipt = makeValidReceipt();
-    receipt.tags = receipt.tags.map((tag) =>
-      tag[0] === 'description' ? ['description', '{not-json'] : tag,
+    const receipt = makeValidReceipt(BOLT11_AMOUNT_MSATS, (tags) =>
+      tags.map((tag) => (tag[0] === 'description' ? ['description', '{not-json'] : tag)),
     );
     const result = validateZapReceipt(receipt, {
       recipientPubkey: RECIPIENT_PK,
@@ -199,8 +217,9 @@ describe('validateZapReceipt', () => {
   });
 
   it('rejects missing bolt11', () => {
-    const receipt = makeValidReceipt();
-    receipt.tags = receipt.tags.filter(([t]) => t !== 'bolt11');
+    const receipt = makeValidReceipt(BOLT11_AMOUNT_MSATS, (tags) =>
+      tags.filter(([t]) => t !== 'bolt11'),
+    );
     const result = validateZapReceipt(receipt, {
       recipientPubkey: RECIPIENT_PK,
       provider: PROVIDER,
@@ -210,9 +229,8 @@ describe('validateZapReceipt', () => {
   });
 
   it('rejects invalid bolt11 amount', () => {
-    const receipt = makeValidReceipt();
-    receipt.tags = receipt.tags.map((tag) =>
-      tag[0] === 'bolt11' ? ['bolt11', 'not-a-bolt11'] : tag,
+    const receipt = makeValidReceipt(BOLT11_AMOUNT_MSATS, (tags) =>
+      tags.map((tag) => (tag[0] === 'bolt11' ? ['bolt11', 'not-a-bolt11'] : tag)),
     );
     const result = validateZapReceipt(receipt, {
       recipientPubkey: RECIPIENT_PK,
@@ -256,5 +274,44 @@ describe('validateZapReceipt', () => {
     });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe('lnurl-mismatch');
+  });
+
+  it('accepts a bech32-encoded lnurl tag that decodes to the provider LNURL', async () => {
+    const { bech32 } = await import('@scure/base');
+    const words = bech32.toWords(new TextEncoder().encode(PROVIDER.lnurl));
+    const lnurlTag = bech32.encode('lnurl', words, 1000);
+
+    const zapRequest = finalizeEvent(
+      {
+        kind: 9734,
+        created_at: Math.floor(Date.now() / 1000),
+        content: 'thanks',
+        tags: [
+          ['p', RECIPIENT_PK],
+          ['amount', String(BOLT11_AMOUNT_MSATS)],
+          ['relays', 'wss://relay.example'],
+          ['lnurl', lnurlTag],
+        ],
+      },
+      SENDER_SK,
+    );
+    const receipt = finalizeEvent(
+      {
+        kind: 9735,
+        created_at: Math.floor(Date.now() / 1000),
+        content: '',
+        tags: [
+          ['p', RECIPIENT_PK],
+          ['bolt11', BOLT11_20U],
+          ['description', JSON.stringify(zapRequest)],
+        ],
+      },
+      PROVIDER_SK,
+    );
+    const result = validateZapReceipt(receipt, {
+      recipientPubkey: RECIPIENT_PK,
+      provider: PROVIDER,
+    });
+    expect(result.ok).toBe(true);
   });
 });

--- a/src/nostr-zap-button/__tests__/zap-receipt.test.ts
+++ b/src/nostr-zap-button/__tests__/zap-receipt.test.ts
@@ -216,6 +216,41 @@ describe('validateZapReceipt', () => {
     if (!result.ok) expect(result.reason).toBe('zap-request-p-mismatch');
   });
 
+  it('rejects an embedded request that is not kind 9734', () => {
+    const notAZapRequest = finalizeEvent(
+      {
+        kind: 1,
+        created_at: Math.floor(Date.now() / 1000),
+        content: 'thanks',
+        tags: [
+          ['p', RECIPIENT_PK],
+          ['amount', String(BOLT11_AMOUNT_MSATS)],
+          ['relays', 'wss://relay.example'],
+        ],
+      },
+      SENDER_SK,
+    );
+    const receipt = finalizeEvent(
+      {
+        kind: 9735,
+        created_at: Math.floor(Date.now() / 1000),
+        content: '',
+        tags: [
+          ['p', RECIPIENT_PK],
+          ['bolt11', BOLT11_20U],
+          ['description', JSON.stringify(notAZapRequest)],
+        ],
+      },
+      PROVIDER_SK,
+    );
+    const result = validateZapReceipt(receipt, {
+      recipientPubkey: RECIPIENT_PK,
+      provider: PROVIDER,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('zap-request-kind');
+  });
+
   it('rejects missing bolt11', () => {
     const receipt = makeValidReceipt(BOLT11_AMOUNT_MSATS, (tags) =>
       tags.filter(([t]) => t !== 'bolt11'),

--- a/src/nostr-zap-button/dialog-zap.ts
+++ b/src/nostr-zap-button/dialog-zap.ts
@@ -21,7 +21,7 @@ import { decodeNpub } from '../common/utils';
 import { 
   fetchInvoice, 
   getProfileMetadata, 
-  getZapEndpoint, 
+  getZapProviderInfo, 
   listenForZapReceipt 
 } from './zap-utils';
 import * as QRCode from 'qrcode';
@@ -130,13 +130,13 @@ export async function init(params: OpenZapModalParams): Promise<DialogComponent>
       throw new Error('Profile not found. The user may not have a profile set up on the relays.');
     }
     
-    const endpoint = await getZapEndpoint(meta);
-    if (!endpoint) {
+    const provider = await getZapProviderInfo(meta);
+    if (!provider) {
       throw new Error('Zap endpoint not found. The user may not have a Lightning address configured.');
     }
     
     const invoice = await fetchInvoice({
-      zapEndpoint: endpoint,
+      zapEndpoint: provider.callback,
       amount: amountSats * 1000, // -> msats
       comment,
       authorId,
@@ -153,6 +153,7 @@ export async function init(params: OpenZapModalParams): Promise<DialogComponent>
       relays: relaysArray,
       receiversPubKey: npubHex,
       invoice,
+      provider,
       onSuccess: markSuccess
     });
   }

--- a/src/nostr-zap-button/nostr-zap.ts
+++ b/src/nostr-zap-button/nostr-zap.ts
@@ -32,6 +32,7 @@ export default class NostrZap extends NostrUserComponent {
   private totalZapAmount: number | null = null;
   private cachedZapDetails: ZapDetails[] = [];
   private cachedAmountDialog: DialogComponent | null = null;
+  private zapCountLoadSeq = 0;
 
   constructor() {
     super();
@@ -134,6 +135,7 @@ export default class NostrZap extends NostrUserComponent {
   /** Private functions */
   private async handleZapClick() {
     if (this.userStatus.get() !== NCStatus.Ready) return;
+    if (this.zapActionStatus.get() === NCStatus.Loading) return;
 
     this.zapActionStatus.set(NCStatus.Loading);
     this.render();
@@ -246,42 +248,58 @@ export default class NostrZap extends NostrUserComponent {
       e.stopPropagation?.();
       void this.handleZappersClick();
     });
+
+    this.delegateEvent('keydown', '.total-zap-amount.clickable', (e: KeyboardEvent) => {
+      if (e.key !== 'Enter' && e.key !== ' ') return;
+      e.preventDefault();
+      e.stopPropagation();
+      void this.handleZappersClick();
+    });
   }
 
   private async updateZapCount() {
     if (!this.user) return;
+    const seq = ++this.zapCountLoadSeq;
 
     try {
       this.zapListStatus.set(NCStatus.Loading);
       this.render();
       
       await this.ensureNostrConnected();
+      if (seq !== this.zapCountLoadSeq) return;
+
       const result = await fetchTotalZapAmount({ 
         pubkey: this.user.pubkey, 
         relays: this.getRelays(),
         url: this.getAttribute("url") || undefined
       });
+      if (seq !== this.zapCountLoadSeq) return;
+
       this.totalZapAmount = result.totalAmount;
       this.cachedZapDetails = result.zapDetails;
       this.zapListStatus.set(NCStatus.Ready);
     } catch (e) {
+      if (seq !== this.zapCountLoadSeq) return;
       console.error("Nostr-Components: Zap button: Failed to fetch zap count", e);
       this.totalZapAmount = null;
       this.zapListStatus.set(NCStatus.Error);
     } finally {
-      this.render();
+      if (seq === this.zapCountLoadSeq) {
+        this.render();
+      }
     }
   }
 
   protected renderContent() {
     const isUserLoading = this.userStatus.get() == NCStatus.Loading;
+    const isActionLoading = this.zapActionStatus.get() == NCStatus.Loading;
     const isAmountLoading = this.zapListStatus.get() == NCStatus.Loading;
     const isError = this.computeOverall() === NCStatus.Error;
     const errorMessage = this.errorMessage;
     const buttonText = this.getAttribute('text') || 'Zap';
 
     const renderOptions: RenderZapButtonOptions = {
-      isLoading: isUserLoading,
+      isLoading: isUserLoading || isActionLoading,
       isAmountLoading: isAmountLoading,
       isError: isError,
       isSuccess: false, // TODO: Add success state handling

--- a/src/nostr-zap-button/render-zap-entry.ts
+++ b/src/nostr-zap-button/render-zap-entry.ts
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 import { ZapDetails } from './zap-utils';
-import { escapeHtml, formatRelativeTime } from '../common/utils';
-import { isValidPublicKey } from '../nostr-comment/utils';
+import { escapeHtml, formatRelativeTime, validateNpub } from '../common/utils';
 import { sanitizeHttpUrl, sanitizeMultilineText } from '../common/sanitize';
 
 export interface EnhancedZapDetails extends ZapDetails {
@@ -13,7 +12,7 @@ export interface EnhancedZapDetails extends ZapDetails {
 
 export function renderZapEntry(zap: EnhancedZapDetails, index: number): string {
   const authorNameSafe = escapeHtml(zap.authorName || 'Unknown zapper');
-  const npubSafe = isValidPublicKey(zap.authorNpub || '') ? zap.authorNpub : '';
+  const npubSafe = validateNpub(zap.authorNpub || '') ? zap.authorNpub : '';
   const njumpUrl = npubSafe
     ? sanitizeHttpUrl(`https://njump.me/${npubSafe}`)
     : '';

--- a/src/nostr-zap-button/render.ts
+++ b/src/nostr-zap-button/render.ts
@@ -38,7 +38,7 @@ export function renderZapButton({
     ? `<span>Zapped</span>`
     : `<span>${escapeHtml(buttonText)}</span>`;
 
-  return renderContainer(iconContent, textContent, totalZapAmount, isAmountLoading, hasZaps);
+  return renderContainer(iconContent, textContent, totalZapAmount, isAmountLoading, hasZaps, false);
 }
 
 function renderLoading(isAmountLoading: boolean): string {
@@ -46,7 +46,9 @@ function renderLoading(isAmountLoading: boolean): string {
     getLightningIcon(),
     '<span class="button-text-skeleton"></span>',
     null,
-    isAmountLoading
+    isAmountLoading,
+    false,
+    true
   );
 }
 
@@ -70,16 +72,24 @@ function renderErrorContainer(leftContent: string, rightContent: string): string
   `;
 }
 
-function renderContainer(iconContent: string, textContent: string, totalZapAmount: number | null, isAmountLoading: boolean, hasZaps: boolean = false): string {
+function renderContainer(
+  iconContent: string,
+  textContent: string,
+  totalZapAmount: number | null,
+  isAmountLoading: boolean,
+  hasZaps: boolean = false,
+  isButtonLoading: boolean = false
+): string {
   const zapAmountHtml = isAmountLoading 
     ? `<span class="total-zap-amount skeleton"></span>` 
-    : (totalZapAmount !== null ? `<span class="total-zap-amount${hasZaps ? ' clickable' : ''}">${totalZapAmount.toLocaleString()} ⚡ sats received</span>` : '');
+    : (totalZapAmount !== null ? `<span class="total-zap-amount${hasZaps ? ' clickable' : ''}"${hasZaps ? ' role="button" tabindex="0" aria-label="View zappers"' : ''}>${totalZapAmount.toLocaleString()} ⚡ sats received</span>` : '');
   
-  const helpIconHtml = `<button class="help-icon" title="What is a zap?">?</button>`;
+  const disabledAttrs = isButtonLoading ? ' disabled aria-busy="true"' : '';
+  const helpIconHtml = `<button type="button" class="help-icon" aria-label="What is a zap?" title="What is a zap?">?</button>`;
   
   return `
     <div class="nostr-zap-button-container">
-      <button class="nostr-zap-button">
+      <button type="button" class="nostr-zap-button"${disabledAttrs}>
         ${iconContent}
         ${textContent}
       </button>

--- a/src/nostr-zap-button/spec/implementation.md
+++ b/src/nostr-zap-button/spec/implementation.md
@@ -24,6 +24,7 @@ This document contains the technical implementation details for the `nostr-zap-b
 - Delegated Events: Uses `delegateEvent()` for efficient Shadow DOM event handling
 - Click Handler: Delegated to `.nostr-zap-button` class
 - Event Delegation: Prevents memory leaks and improves performance
+- Double-click guard: `handleZapClick` early-returns while `zapActionStatus` is Loading; render treats action Loading as `isLoading` and disables the button with `aria-busy="true"`
 
 ### Rendering Architecture
 - Separation of Concerns: 
@@ -119,7 +120,7 @@ All dialogs use the shared `DialogComponent` base class (see `src/base/dialog-co
 - Function: `listenForZapReceipt()` in `zap-utils.ts`
 - Purpose: Listen for zap receipt events (kind 9735) matching the invoice
 - Status: ACTIVELY USED in dialog implementation
-- Behavior: Shows success overlay when payment is detected
+- Behavior: Shows success overlay only after NIP-57 Appendix F validation succeeds
 
 ### Close Behavior
 - ESC Key: Closes dialog
@@ -163,13 +164,22 @@ All dialogs use the shared `DialogComponent` base class (see `src/base/dialog-co
 - The `a` tag value is a valid NIP-01 addressable event coordinate (kind 39735 is in the 30000–39999 addressable range); per NIP-57 Appendix E, relays copy the `a` tag from the zap request to the receipt, making relay-side `#a` filtering reliable
 
 ### Amount Calculation
-- Extracts amounts from zap request description tags
-- Aggregates and converts msats to sats
-- Real-time data (no caching)
+- Resolves recipient LNURL-pay metadata (`allowsNostr` + `nostrPubkey`)
+- Validates each kind-9735 receipt per NIP-57 Appendix F before counting:
+  - Receipt `pubkey` must equal LNURL `nostrPubkey`
+  - Embedded zap request must pass `nip57.validateZapRequest` + signature verify
+  - Receipt/`zap request` `p` tags must match the recipient
+  - `bolt11` invoice amount must equal the zap-request `amount` tag when present
+  - Optional zap-request `lnurl` tag must match the recipient LNURL when present
+- Aggregates validated bolt11 amounts and converts msats to sats
+- Fail closed: if LNURL provider metadata cannot be resolved, totals are `0`
+- Provider metadata cached for component lifetime
 
 ### Interactivity
 - Clickable total opens zappers dialog
 - Delegated click handler on `.total-zap-amount` class
+- `handleZapClick` early-returns while `zapActionStatus` is Loading
+- Primary zap button is `disabled` + `aria-busy` during the action
 
 ## Individual Zaps
 
@@ -184,9 +194,9 @@ All dialogs use the shared `DialogComponent` base class (see `src/base/dialog-co
 - Each entry updates independently as profile data loads
 
 ### Zap Details
-- Amount from zap request description tags
+- Amount from validated bolt11 invoice (msats → sats)
 - Date from event `created_at` timestamp
-- Author from zap request `pubkey` field
+- Author from validated zap request `pubkey` field
 - Sorted chronologically (newest first)
 
 ### Profile Display

--- a/src/nostr-zap-button/spec/implementation.md
+++ b/src/nostr-zap-button/spec/implementation.md
@@ -166,6 +166,7 @@ All dialogs use the shared `DialogComponent` base class (see `src/base/dialog-co
 ### Amount Calculation
 - Resolves recipient LNURL-pay metadata (`allowsNostr` + `nostrPubkey`)
 - Validates each kind-9735 receipt per NIP-57 Appendix F before counting:
+  - Receipt event signature is verified explicitly (`verifyEvent`), independent of pool/NDK defaults
   - Receipt `pubkey` must equal LNURL `nostrPubkey`
   - Embedded zap request must pass `nip57.validateZapRequest` + signature verify
   - Receipt/`zap request` `p` tags must match the recipient

--- a/src/nostr-zap-button/style.ts
+++ b/src/nostr-zap-button/style.ts
@@ -37,7 +37,9 @@ export function getZapButtonStyles(): string {
     }
 
     /* Focus state for accessibility */
-    :host(:focus-visible) {
+    .nostr-zap-button:focus-visible,
+    .help-icon:focus-visible,
+    .total-zap-amount.clickable:focus-visible {
       outline: 2px solid var(--nostrc-color-primary, #007bff);
       outline-offset: 2px;
     }
@@ -126,14 +128,18 @@ export function getZapButtonStyles(): string {
       color: var(--nostrc-color-primary, #7f00ff);
     }
 
-    /* Help icon */
+    /* Help icon — visual glyph inside a ≥44px hit target */
     .help-icon {
       background: none;
       border: 1px solid var(--nostrc-color-border, #e0e0e0);
       border-radius: var(--nostrc-border-radius-full, 50%);
-      width: var(--nostrc-help-icon-size, 16px);
-      height: var(--nostrc-help-icon-size, 16px);
-      font-size: calc(var(--nostrc-help-icon-size, 16px) * 0.7);
+      box-sizing: border-box;
+      width: 44px;
+      height: 44px;
+      min-width: 44px;
+      min-height: 44px;
+      padding: 0;
+      font-size: 14px;
       font-weight: bold;
       color: var(--nostrc-theme-text-secondary, #666666);
       cursor: pointer;
@@ -141,7 +147,7 @@ export function getZapButtonStyles(): string {
       align-items: center;
       justify-content: center;
       margin-left: var(--nostrc-spacing-xs, 4px);
-      transition: all 0.2s ease;
+      transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
     }
 
     .help-icon:hover {
@@ -186,6 +192,18 @@ export function getZapButtonStyles(): string {
       }
       100% {
         background-position: -200% 0;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .nostr-zap-button,
+      .help-icon,
+      .total-zap-amount {
+        transition: none;
+      }
+      .total-zap-amount.skeleton,
+      .button-text-skeleton {
+        animation: none;
       }
     }
 

--- a/src/nostr-zap-button/zap-receipt.ts
+++ b/src/nostr-zap-button/zap-receipt.ts
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MIT
+
+import { bech32 } from '@scure/base';
+import { decode as decodeBolt11 } from 'light-bolt11-decoder';
+import type { Event } from 'nostr-tools';
+import { nip57, verifyEvent } from 'nostr-tools';
+
+export interface ZapProviderInfo {
+  lnurl: string;
+  callback: string;
+  nostrPubkey: string;
+}
+
+export type ZapReceiptValidationResult =
+  | {
+      ok: true;
+      amountMsats: number;
+      zapRequest: Event;
+    }
+  | {
+      ok: false;
+      reason: string;
+    };
+
+function getTagValue(tags: string[][] | undefined, name: string): string | undefined {
+  const tag = tags?.find((t) => t[0] === name && t[1]);
+  return tag?.[1];
+}
+
+/**
+ * Resolve LNURL-pay URL from kind-0 lud06 / lud16 (same rules as nostr-tools nip57).
+ */
+export function lnurlFromProfileContent(content: string): string | null {
+  try {
+    const { lud06, lud16 } = JSON.parse(content || '{}');
+    if (lud16 && typeof lud16 === 'string') {
+      const [name, domain] = lud16.split('@');
+      if (!name || !domain) return null;
+      return new URL(`/.well-known/lnurlp/${name}`, `https://${domain}`).toString();
+    }
+    if (lud06 && typeof lud06 === 'string') {
+      const { words } = bech32.decode(lud06, 1000);
+      const data = bech32.fromWords(words);
+      return new TextDecoder().decode(Uint8Array.from(data));
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+/**
+ * Resolve the recipient LNURL-pay metadata used for NIP-57 Appendix F checks.
+ */
+export async function resolveZapProviderInfo(
+  profileMetadata: Event,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ZapProviderInfo | null> {
+  try {
+    const lnurl = lnurlFromProfileContent(profileMetadata.content || '');
+    if (!lnurl) return null;
+
+    const res = await fetchImpl(lnurl);
+    if (!res.ok) return null;
+    const body = await res.json();
+
+    if (!body?.allowsNostr || typeof body.nostrPubkey !== 'string' || !body.callback) {
+      return null;
+    }
+
+    if (!/^[a-f0-9]{64}$/i.test(body.nostrPubkey)) {
+      return null;
+    }
+
+    return {
+      lnurl,
+      callback: String(body.callback),
+      nostrPubkey: String(body.nostrPubkey).toLowerCase(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function getBolt11AmountMsats(bolt11: string): number | null {
+  try {
+    const decoded = decodeBolt11(bolt11);
+    const amountSection = decoded.sections.find(
+      (section) => section.name === 'amount',
+    ) as { name: 'amount'; value?: string } | undefined;
+    if (!amountSection?.value) return null;
+    const amount = Number(amountSection.value);
+    return Number.isFinite(amount) && amount > 0 ? amount : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validate a kind-9735 zap receipt per NIP-57 Appendix F (plus zap-request signature).
+ */
+export function validateZapReceipt(
+  receipt: Event,
+  opts: {
+    recipientPubkey: string;
+    provider: ZapProviderInfo;
+  },
+): ZapReceiptValidationResult {
+  if (receipt.kind !== 9735) {
+    return { ok: false, reason: 'not-kind-9735' };
+  }
+
+  if (receipt.pubkey.toLowerCase() !== opts.provider.nostrPubkey.toLowerCase()) {
+    return { ok: false, reason: 'receipt-pubkey-mismatch' };
+  }
+
+  const receiptP = getTagValue(receipt.tags, 'p');
+  if (!receiptP || receiptP.toLowerCase() !== opts.recipientPubkey.toLowerCase()) {
+    return { ok: false, reason: 'receipt-p-mismatch' };
+  }
+
+  const description = getTagValue(receipt.tags, 'description');
+  if (!description) {
+    return { ok: false, reason: 'missing-description' };
+  }
+
+  const zapRequestError = nip57.validateZapRequest(description);
+  if (zapRequestError) {
+    return { ok: false, reason: `invalid-zap-request:${zapRequestError}` };
+  }
+
+  let zapRequest: Event;
+  try {
+    zapRequest = JSON.parse(description);
+  } catch {
+    return { ok: false, reason: 'description-json' };
+  }
+
+  if (!verifyEvent(zapRequest)) {
+    return { ok: false, reason: 'zap-request-sig' };
+  }
+
+  const requestP = getTagValue(zapRequest.tags, 'p');
+  if (!requestP || requestP.toLowerCase() !== opts.recipientPubkey.toLowerCase()) {
+    return { ok: false, reason: 'zap-request-p-mismatch' };
+  }
+
+  const bolt11 = getTagValue(receipt.tags, 'bolt11');
+  if (!bolt11) {
+    return { ok: false, reason: 'missing-bolt11' };
+  }
+
+  const invoiceAmountMsats = getBolt11AmountMsats(bolt11);
+  if (invoiceAmountMsats == null) {
+    return { ok: false, reason: 'invalid-bolt11-amount' };
+  }
+
+  const amountTag = getTagValue(zapRequest.tags, 'amount');
+  if (amountTag) {
+    const requestAmount = Number(amountTag);
+    if (!Number.isFinite(requestAmount) || requestAmount !== invoiceAmountMsats) {
+      return { ok: false, reason: 'amount-mismatch' };
+    }
+  }
+
+  const requestLnurl = getTagValue(zapRequest.tags, 'lnurl');
+  if (requestLnurl && requestLnurl !== opts.provider.lnurl) {
+    return { ok: false, reason: 'lnurl-mismatch' };
+  }
+
+  return {
+    ok: true,
+    amountMsats: invoiceAmountMsats,
+    zapRequest,
+  };
+}

--- a/src/nostr-zap-button/zap-receipt.ts
+++ b/src/nostr-zap-button/zap-receipt.ts
@@ -29,6 +29,7 @@ function getTagValue(tags: string[][] | undefined, name: string): string | undef
 
 /**
  * Resolve LNURL-pay URL from kind-0 lud06 / lud16 (same rules as nostr-tools nip57).
+ * Only HTTPS LNURLs are accepted so nostrPubkey cannot be MITM'd over cleartext.
  */
 export function lnurlFromProfileContent(content: string): string | null {
   try {
@@ -41,7 +42,9 @@ export function lnurlFromProfileContent(content: string): string | null {
     if (lud06 && typeof lud06 === 'string') {
       const { words } = bech32.decode(lud06, 1000);
       const data = bech32.fromWords(words);
-      return new TextDecoder().decode(Uint8Array.from(data));
+      const decodedUrl = new TextDecoder().decode(Uint8Array.from(data));
+      const parsed = new URL(decodedUrl);
+      return parsed.protocol === 'https:' ? parsed.toString() : null;
     }
   } catch {
     return null;
@@ -60,7 +63,7 @@ export async function resolveZapProviderInfo(
     const lnurl = lnurlFromProfileContent(profileMetadata.content || '');
     if (!lnurl) return null;
 
-    const res = await fetchImpl(lnurl);
+    const res = await fetchImpl(lnurl, { signal: AbortSignal.timeout(10_000) });
     if (!res.ok) return null;
     const body = await res.json();
 
@@ -72,9 +75,14 @@ export async function resolveZapProviderInfo(
       return null;
     }
 
+    const callback = String(body.callback);
+    if (!callback.startsWith('https://')) {
+      return null;
+    }
+
     return {
       lnurl,
-      callback: String(body.callback),
+      callback,
       nostrPubkey: String(body.nostrPubkey).toLowerCase(),
     };
   } catch {

--- a/src/nostr-zap-button/zap-receipt.ts
+++ b/src/nostr-zap-button/zap-receipt.ts
@@ -90,6 +90,24 @@ export async function resolveZapProviderInfo(
   }
 }
 
+/**
+ * Normalize a zap-request `lnurl` tag for comparison against the provider LNURL.
+ * NIP-57 clients write the bech32-encoded LNURL (lud06 style), but some write the
+ * plain https URL; accept both by decoding bech32 and URL-normalizing.
+ */
+function normalizeLnurlTag(value: string): string | null {
+  try {
+    let urlString = value;
+    if (/^lnurl1/i.test(value)) {
+      const { words } = bech32.decode(value.toLowerCase() as `${string}1${string}`, 1000);
+      urlString = new TextDecoder().decode(Uint8Array.from(bech32.fromWords(words)));
+    }
+    return new URL(urlString).toString();
+  } catch {
+    return null;
+  }
+}
+
 export function getBolt11AmountMsats(bolt11: string): number | null {
   try {
     const decoded = decodeBolt11(bolt11);
@@ -116,6 +134,12 @@ export function validateZapReceipt(
 ): ZapReceiptValidationResult {
   if (receipt.kind !== 9735) {
     return { ok: false, reason: 'not-kind-9735' };
+  }
+
+  // Verify the receipt's own signature here rather than relying on the pool/NDK
+  // caller's verification config — this function is the fail-closed gate.
+  if (!verifyEvent(receipt)) {
+    return { ok: false, reason: 'receipt-sig' };
   }
 
   if (receipt.pubkey.toLowerCase() !== opts.provider.nostrPubkey.toLowerCase()) {
@@ -172,8 +196,11 @@ export function validateZapReceipt(
   }
 
   const requestLnurl = getTagValue(zapRequest.tags, 'lnurl');
-  if (requestLnurl && requestLnurl !== opts.provider.lnurl) {
-    return { ok: false, reason: 'lnurl-mismatch' };
+  if (requestLnurl) {
+    const normalized = normalizeLnurlTag(requestLnurl);
+    if (!normalized || normalized !== opts.provider.lnurl) {
+      return { ok: false, reason: 'lnurl-mismatch' };
+    }
   }
 
   return {

--- a/src/nostr-zap-button/zap-receipt.ts
+++ b/src/nostr-zap-button/zap-receipt.ts
@@ -168,6 +168,11 @@ export function validateZapReceipt(
     return { ok: false, reason: 'description-json' };
   }
 
+  // nip57.validateZapRequest does not check the kind; NIP-57 zap requests are 9734.
+  if (zapRequest.kind !== 9734) {
+    return { ok: false, reason: 'zap-request-kind' };
+  }
+
   if (!verifyEvent(zapRequest)) {
     return { ok: false, reason: 'zap-request-sig' };
   }

--- a/src/nostr-zap-button/zap-utils.ts
+++ b/src/nostr-zap-button/zap-utils.ts
@@ -6,7 +6,8 @@ import {
   finalizeEvent,
   SimplePool,
 } from 'nostr-tools';
-import { decodeNip19Entity } from '../common/utils';
+import type { Filter, Event } from 'nostr-tools';
+import { normalizeURL } from '../common/utils';
 import { ensureInitialized, signEvent as signEventWithNostrLogin } from '../common/nostr-login-service';
 import { DEFAULT_RELAYS } from '../common/constants';
 
@@ -252,10 +253,6 @@ export async function resolveNip05(nip05Identifier: string): Promise<string | nu
     return null;
   }
 }
-
-// Import necessary types from nostr-tools
-import type { Filter, Event } from 'nostr-tools';
-import { normalizeURL } from '../nostr-comment/utils';
 
 // Augment the SimplePool type to include our usage
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/src/nostr-zap-button/zap-utils.ts
+++ b/src/nostr-zap-button/zap-utils.ts
@@ -10,6 +10,11 @@ import type { Filter, Event } from 'nostr-tools';
 import { normalizeURL } from '../common/utils';
 import { ensureInitialized, signEvent as signEventWithNostrLogin } from '../common/nostr-login-service';
 import { DEFAULT_RELAYS } from '../common/constants';
+import {
+  resolveZapProviderInfo,
+  validateZapReceipt,
+  type ZapProviderInfo,
+} from './zap-receipt';
 
 /**
  * Helper utilities for Nostr zap operations (adapted from the original `nostr-zap` repo).
@@ -19,6 +24,7 @@ import { DEFAULT_RELAYS } from '../common/constants';
 
 // Basic in-memory cache – sufficient for component lifetime.
 const profileCache: Record<string, any> = {};
+const zapProviderCache: Record<string, ZapProviderInfo | null> = {};
 
 export const getProfileMetadata = async (authorId: string, relays?: string[]) => {
   if (profileCache[authorId]) return profileCache[authorId];
@@ -83,9 +89,24 @@ export const extractProfileMetadataContent = (profileMetadata: any) => {
 };
 
 export const getZapEndpoint = async (profileMetadata: any) => {
-  const endpoint = await nip57.getZapEndpoint(profileMetadata);
-  if (!endpoint) throw new Error('Failed to retrieve zap LNURL');
-  return endpoint;
+  const provider = await getZapProviderInfo(profileMetadata);
+  if (!provider) throw new Error('Failed to retrieve zap LNURL');
+  return provider.callback;
+};
+
+export const getZapProviderInfo = async (
+  profileMetadata: Event,
+): Promise<ZapProviderInfo | null> => {
+  const cacheKey = profileMetadata.pubkey || profileMetadata.id || '';
+  if (cacheKey && cacheKey in zapProviderCache) {
+    return zapProviderCache[cacheKey];
+  }
+
+  const provider = await resolveZapProviderInfo(profileMetadata);
+  if (cacheKey) {
+    zapProviderCache[cacheKey] = provider;
+  }
+  return provider;
 };
 
 /**
@@ -217,14 +238,11 @@ export const fetchInvoice = async ({
 };
 
 const generateRandomPrivKey = (): Uint8Array => {
-  const bytes = new Uint8Array(32);
-  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
-    crypto.getRandomValues(bytes);
-  } else {
-    // Node.js fallback during build – use Math.random (not cryptographically strong but acceptable for anon zaps)
-    console.warn('crypto.getRandomValues not available, using Math.random as fallback');
-    for (let i = 0; i < 32; i++) bytes[i] = Math.floor(Math.random() * 256);
+  if (typeof crypto === 'undefined' || typeof crypto.getRandomValues !== 'function') {
+    throw new Error('Secure random unavailable: crypto.getRandomValues is required for anonymous zaps');
   }
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
   return bytes;
 };
 
@@ -299,6 +317,17 @@ export const fetchTotalZapAmount = async ({
   const zapDetails: ZapDetails[] = [];
 
   try {
+    const profileMetadata = await getProfileMetadata(pubkey, relays);
+    if (!profileMetadata) {
+      return { totalAmount: 0, zapDetails: [] };
+    }
+
+    const provider = await getZapProviderInfo(profileMetadata);
+    if (!provider) {
+      // Fail closed: without LNURL nostrPubkey we cannot authenticate receipts.
+      return { totalAmount: 0, zapDetails: [] };
+    }
+
     const filter: any = {
       kinds: [9735],
       '#p': [pubkey],
@@ -316,26 +345,19 @@ export const fetchTotalZapAmount = async ({
     const events = await pool.querySync(relays, filter);
 
     for (const event of events) {
-      const descriptionTag = event.tags?.find((tag: string[]) => tag[0] === 'description');
-      if (!descriptionTag?.[1]) continue;
-      try {
-        const zapRequest = JSON.parse(descriptionTag[1]);
-        const amountTag = zapRequest?.tags?.find((tag: string[]) => tag[0] === 'amount');
-        if (amountTag?.[1]) {
-          const amount = parseInt(amountTag[1], 10);
-          if (amount > 0) {
-            totalAmount += amount;
-            zapDetails.push({
-              amount: amount / 1000, // convert from msats to sats
-              date: new Date(event.created_at * 1000),
-              authorPubkey: zapRequest.pubkey,
-              comment: zapRequest.content,
-            });
-          }
-        }
-      } catch (e) {
-        console.error("Nostr-Components: Zap button: Could not parse zap request from description tag", e);
-      }
+      const validated = validateZapReceipt(event, {
+        recipientPubkey: pubkey,
+        provider,
+      });
+      if (!validated.ok) continue;
+
+      totalAmount += validated.amountMsats;
+      zapDetails.push({
+        amount: validated.amountMsats / 1000, // convert from msats to sats
+        date: new Date(event.created_at * 1000),
+        authorPubkey: validated.zapRequest.pubkey,
+        comment: validated.zapRequest.content,
+      });
     }
   } catch (error) {
     console.error("Nostr-Components: Zap button: Error fetching zap receipts", error);
@@ -356,11 +378,13 @@ export const listenForZapReceipt = ({
   relays,
   receiversPubKey,
   invoice,
+  provider,
   onSuccess,
 }: {
   relays: string[];
-  receiversPubKey: string,
+  receiversPubKey: string;
   invoice: string;
+  provider: ZapProviderInfo;
   onSuccess: () => void;
 }) => {
   const pool = new SimplePool();
@@ -377,10 +401,18 @@ export const listenForZapReceipt = ({
     {
       onevent(event: Event) {
         const tags = event.tags as [string, string][];
-        if (tags.some(t => t[0] === 'bolt11' && t[1] === invoice)) {
-          onSuccess();
-          cleanup();
+        if (!tags.some(t => t[0] === 'bolt11' && t[1] === invoice)) {
+          return;
         }
+
+        const validated = validateZapReceipt(event, {
+          recipientPubkey: receiversPubKey,
+          provider,
+        });
+        if (!validated.ok) return;
+
+        onSuccess();
+        cleanup();
       }
     }
   );

--- a/src/nostr-zap-button/zap-utils.ts
+++ b/src/nostr-zap-button/zap-utils.ts
@@ -24,7 +24,12 @@ import {
 
 // Basic in-memory cache – sufficient for component lifetime.
 const profileCache: Record<string, any> = {};
-const zapProviderCache: Record<string, ZapProviderInfo | null> = {};
+const ZAP_PROVIDER_CACHE_TTL_MS = 5 * 60 * 1000;
+const ZAP_PROVIDER_NEGATIVE_TTL_MS = 30 * 1000;
+const zapProviderCache: Record<
+  string,
+  { value: ZapProviderInfo | null; expiresAt: number }
+> = {};
 
 export const getProfileMetadata = async (authorId: string, relays?: string[]) => {
   if (profileCache[authorId]) return profileCache[authorId];
@@ -98,13 +103,18 @@ export const getZapProviderInfo = async (
   profileMetadata: Event,
 ): Promise<ZapProviderInfo | null> => {
   const cacheKey = profileMetadata.pubkey || profileMetadata.id || '';
-  if (cacheKey && cacheKey in zapProviderCache) {
-    return zapProviderCache[cacheKey];
+  const cached = cacheKey ? zapProviderCache[cacheKey] : undefined;
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.value;
   }
 
   const provider = await resolveZapProviderInfo(profileMetadata);
   if (cacheKey) {
-    zapProviderCache[cacheKey] = provider;
+    const ttl = provider ? ZAP_PROVIDER_CACHE_TTL_MS : ZAP_PROVIDER_NEGATIVE_TTL_MS;
+    zapProviderCache[cacheKey] = {
+      value: provider,
+      expiresAt: Date.now() + ttl,
+    };
   }
   return provider;
 };

--- a/vite.config.esm.ts
+++ b/vite.config.esm.ts
@@ -2,11 +2,18 @@ import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+const DISABLED_COMPONENT_GLOBS = [
+  'src/nostr-comment/**',
+  'src/nostr-dm/**',
+  'src/nostr-live-chat/**',
+];
+
 export default defineConfig({
   plugins: [
     dts({
       insertTypesEntry: true, // Creates a single index.d.ts entry file
       outDir: 'dist',
+      exclude: DISABLED_COMPONENT_GLOBS,
     })
   ],
   build: {
@@ -45,6 +52,7 @@ export default defineConfig({
           format: 'es',
           inlineDynamicImports: false,
           exports: 'auto',
+          sourcemapExcludeSources: true,
         },
       ],
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,10 +2,17 @@ import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+const DISABLED_COMPONENT_GLOBS = [
+  'src/nostr-comment/**',
+  'src/nostr-dm/**',
+  'src/nostr-live-chat/**',
+];
+
 export default defineConfig({
   plugins: [
     dts({
       insertTypesEntry: true, // Creates a single index.d.ts entry file
+      exclude: DISABLED_COMPONENT_GLOBS,
       //   // Optional: Specify the tsconfig file if it's not standard
       //   // tsConfigFilePath: './tsconfig.build.json'
     })
@@ -45,6 +52,7 @@ export default defineConfig({
           },
           format: 'es',
           inlineDynamicImports: false,
+          sourcemapExcludeSources: true,
         },
         {
           // UMD output ONLY for the main entry
@@ -52,6 +60,7 @@ export default defineConfig({
           format: 'umd',
           inlineDynamicImports: false,
           name: 'NostrComponents',
+          sourcemapExcludeSources: true,
         },
       ],
     },

--- a/vite.config.umd.ts
+++ b/vite.config.umd.ts
@@ -39,9 +39,6 @@ function ensureUMDDefaultExport(): Plugin {
         NostrProfile: nc.NostrProfile,
         NostrFollowButton: nc.NostrFollowButton,
         NostrZap: nc.NostrZap,
-        NostrComment: nc.NostrComment,
-        NostrDm: nc.NostrDm,
-        NostrLiveChat: nc.NostrLiveChat,
         NostrLike: nc.NostrLike,
         NostrLivestream: nc.NostrLivestream,
       };
@@ -73,6 +70,7 @@ export default defineConfig({
       // Use 'auto' to include both named and default exports
       output: {
         exports: 'auto',
+        sourcemapExcludeSources: true,
       },
     },
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- Stop publishing insecure disabled-component APIs (`nostr-comment` / `nostr-dm` / `nostr-live-chat` exports) and decouple zap utils from comment `normalizeURL`.
- Validate zap receipts with NIP-57 Appendix F checks; fail closed when LNURL `nostrPubkey` cannot be resolved. Net like counts by pubkey so spam reactions cannot inflate social proof.
- Harden interaction UX: serialize like/zap clicks, load-seq guards, `type="button"`, reduced-motion, and native `showModal` dialogs with focus trap / labelled title / 44px targets.
- Prefer crypto for anonymous zap keys; stop treating `localStorage` nsec as a signer. Expand `.gitignore` for env/key/credential globs.

## Test plan
- [ ] `npm test` (frontend) — zap-receipt, like-netting, hasSigner, render a11y suites pass
- [ ] Manually: zap button shows count only for validated receipts; double-click does not fire two actions
- [ ] Manually: like count stays stable under repeated +/− from one pubkey; likers dialog opens
- [ ] Manually: dialog opens via `showModal`, ESC closes, focus returns to trigger; keyboard on zap/like counts
- [ ] Confirm package exports no longer reference disabled comment/dm/live-chat components

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved like tracking with accurate per-person like/unlike totals.
  - Added normalized URL handling for consistent content linking.
  - Added keyboard support for opening likers and zappers lists.

- **Bug Fixes**
  - Prevented duplicate actions and ignored outdated results.
  - Zap totals and confirmations now count only validated receipts.
  - Improved signer detection and secure anonymous key generation.

- **Accessibility & UX**
  - Enhanced dialog focus management, loading states, labels, focus indicators, and reduced-motion support.
  - Improved button sizing and keyboard navigation.

- **Breaking Changes**
  - Removed exports for disabled comment, direct-message, and live-chat components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->