### PR TITLE
fix: share one relay connection attempt across concurrently mounting components

### DIFF
--- a/src/common/__tests__/nostr-service-connect.test.ts
+++ b/src/common/__tests__/nostr-service-connect.test.ts
@@ -136,6 +136,28 @@ describe('NostrService.connectToNostr concurrency', () => {
     expect(ndk.addExplicitRelayCalls).toEqual([]);
   });
 
+  it('lets a piggybacking caller add only genuinely new relays after the shared attempt', async () => {
+    const { service, ndk } = await freshService();
+
+    // Second caller starts while the first attempt is still in flight, with
+    // trailing-slash variants of the known relays plus one new relay. It must
+    // not restart the pool, and must add only the new relay exactly once
+    // (listed twice here under different spellings).
+    const first = service.connectToNostr([...RELAYS]);
+    const second = service.connectToNostr([
+      ...RELAYS.map(r => `${r}/`),
+      'wss://relay.four',
+      'wss://relay.four/',
+    ]);
+
+    await vi.runAllTimersAsync();
+    await Promise.all([first, second]);
+
+    expect(ndk.explicitRelayUrlAssignments).toBe(1);
+    expect(ndk.addExplicitRelayCalls).toEqual(['wss://relay.four']);
+    expect(ndk.pool.relays.size).toBe(RELAYS.length + 1);
+  });
+
   it('adds genuinely new relays without restarting the pool', async () => {
     const { service, ndk } = await freshService();
 

--- a/src/common/__tests__/nostr-service-connect.test.ts
+++ b/src/common/__tests__/nostr-service-connect.test.ts
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: MIT
+
+// Regression tests for the "Failed to connect to relays" bug: when several
+// components mount on one page, they all call NostrService.connectToNostr()
+// concurrently. Each call used to reassign ndk.explicitRelayUrls, whose NDK
+// setter clears the relay pool and reopens every socket. With N components
+// that meant N x 8 handshakes racing each other, the pool never looked
+// connected at check time, and every component errored out.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Emulates NDK 2.13 semantics faithfully for the parts NostrService touches:
+// - `set explicitRelayUrls(urls)` clears the pool and recreates all relays
+//   (this is the destructive behavior at the heart of the bug)
+// - relays transition to CONNECTED (5) asynchronously after a delay
+const CONNECTED = 5;
+// Tests can raise this beyond the service's grace period to simulate
+// unreachable relays.
+let relayConnectDelayMs = 300;
+
+class FakeRelay {
+  status = 4; // CONNECTING
+  constructor(public url: string) {
+    setTimeout(() => {
+      this.status = CONNECTED;
+    }, relayConnectDelayMs);
+  }
+}
+
+const normalize = (url: string) => (url.endsWith('/') ? url : `${url}/`);
+
+class FakeNDK {
+  pool = { relays: new Map<string, FakeRelay>() };
+  signer = undefined;
+  explicitRelayUrlAssignments = 0;
+  addExplicitRelayCalls: string[] = [];
+  private _explicitRelayUrls: string[] = [];
+
+  set explicitRelayUrls(urls: string[]) {
+    this.explicitRelayUrlAssignments++;
+    this._explicitRelayUrls = urls.map(normalize);
+    this.pool.relays.clear();
+    for (const url of urls) {
+      this.pool.relays.set(normalize(url), new FakeRelay(normalize(url)));
+    }
+  }
+
+  get explicitRelayUrls(): string[] {
+    return this._explicitRelayUrls;
+  }
+
+  addExplicitRelay(url: string) {
+    this.addExplicitRelayCalls.push(url);
+    const normalized = normalize(url);
+    if (!this.pool.relays.has(normalized)) {
+      this.pool.relays.set(normalized, new FakeRelay(normalized));
+    }
+    this._explicitRelayUrls.push(normalized);
+  }
+
+  async connect(_timeoutMs?: number): Promise<void> {
+    // Like real NDK, resolves without waiting for sockets to open.
+  }
+}
+
+vi.mock('@nostr-dev-kit/ndk', () => ({
+  default: FakeNDK,
+  NDKRelayStatus: { CONNECTED },
+  NDKKind: {},
+  NDKUser: class {},
+  NDKEvent: class {},
+}));
+
+const RELAYS = [
+  'wss://relay.one',
+  'wss://relay.two',
+  'wss://relay.three',
+];
+
+async function freshService() {
+  vi.resetModules();
+  const { NostrService } = await import('../nostr-service');
+  (NostrService as any).instance = undefined;
+  const service = NostrService.getInstance();
+  const ndk = (service as any).ndk as FakeNDK;
+  return { service, ndk };
+}
+
+describe('NostrService.connectToNostr concurrency', () => {
+  beforeEach(() => {
+    relayConnectDelayMs = 300;
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('shares a single connection attempt across concurrent callers', async () => {
+    const { service, ndk } = await freshService();
+
+    // Five components mounting at once, as on a real blog page.
+    const attempts = Promise.all(
+      Array.from({ length: 5 }, () => service.connectToNostr([...RELAYS]))
+    );
+
+    await vi.runAllTimersAsync();
+    await expect(attempts).resolves.toBeDefined();
+
+    // The pool-clearing setter must have run exactly once; every extra
+    // assignment drops all in-flight sockets and restarts the handshakes.
+    expect(ndk.explicitRelayUrlAssignments).toBe(1);
+    expect(ndk.pool.relays.size).toBe(RELAYS.length);
+    // Piggybacking callers carried the same relay list, so none of them
+    // should have re-added relays after the shared attempt settled.
+    expect(ndk.addExplicitRelayCalls).toEqual([]);
+  });
+
+  it('does not reset the pool when called again after a successful connect', async () => {
+    const { service, ndk } = await freshService();
+
+    const first = service.connectToNostr([...RELAYS]);
+    await vi.runAllTimersAsync();
+    await first;
+
+    // Same list again (e.g. one more component mounts later). URL spelling
+    // differs only by trailing slash, which NDK normalization adds.
+    const second = service.connectToNostr([...RELAYS]);
+    await vi.runAllTimersAsync();
+    await second;
+
+    expect(ndk.explicitRelayUrlAssignments).toBe(1);
+    expect(ndk.addExplicitRelayCalls).toEqual([]);
+  });
+
+  it('adds genuinely new relays without restarting the pool', async () => {
+    const { service, ndk } = await freshService();
+
+    const first = service.connectToNostr([...RELAYS]);
+    await vi.runAllTimersAsync();
+    await first;
+
+    const second = service.connectToNostr([...RELAYS, 'wss://relay.four']);
+    await vi.runAllTimersAsync();
+    await second;
+
+    expect(ndk.explicitRelayUrlAssignments).toBe(1);
+    expect(ndk.addExplicitRelayCalls).toEqual(['wss://relay.four']);
+    expect(ndk.pool.relays.size).toBe(4);
+  });
+
+  it('rejects all concurrent callers when no relay ever connects, then allows a retry', async () => {
+    const { service } = await freshService();
+
+    // Relays "connect" only long after the service's grace period expires,
+    // which is indistinguishable from being unreachable.
+    relayConnectDelayMs = 60_000;
+
+    const attempts = Array.from({ length: 3 }, () =>
+      service.connectToNostr(['wss://dead.relay']).catch((e: Error) => e)
+    );
+
+    await vi.runAllTimersAsync();
+
+    const results = await Promise.all(attempts);
+    for (const result of results) {
+      expect(result).toBeInstanceOf(Error);
+      expect((result as Error).message).toContain('Failed to connect');
+    }
+
+    // The in-flight promise must be cleared so a later attempt can run.
+    expect((service as any).connectPromise).toBeNull();
+
+    // A retry after the failure gets a fresh attempt that can succeed.
+    relayConnectDelayMs = 300;
+    const retry = service.connectToNostr(['wss://dead.relay']);
+    await vi.runAllTimersAsync();
+    await expect(retry).resolves.toBeUndefined();
+  });
+});

--- a/src/common/nostr-service.ts
+++ b/src/common/nostr-service.ts
@@ -70,10 +70,14 @@ export class NostrService {
    * same relay under a different spelling.
    */
   private addNewRelays(relays: string[]): void {
-    const knownRelays = this.getRelays().map(r => normalizeURL(r));
-    relays
-      .filter(r => !knownRelays.includes(normalizeURL(r)))
-      .forEach(url => this.ndk.addExplicitRelay(url));
+    const knownRelays = new Set(this.getRelays().map(r => normalizeURL(r)));
+    for (const url of relays) {
+      const normalized = normalizeURL(url);
+      if (!knownRelays.has(normalized)) {
+        this.ndk.addExplicitRelay(url);
+        knownRelays.add(normalized);
+      }
+    }
   }
 
   private async establishConnection(relays: string[]): Promise<void> {

--- a/src/common/nostr-service.ts
+++ b/src/common/nostr-service.ts
@@ -11,12 +11,17 @@ import { DEFAULT_RELAYS } from './constants';
 import { DEFAULT_PROFILE_IMAGE } from './constants';
 import { normalizeURL } from 'nostr-tools/utils';
 
+/** How long to keep polling the relay pool for a first connection. */
+const CONNECT_GRACE_MS = 5000;
+const CONNECT_POLL_INTERVAL_MS = 250;
+
 // TODO: Is this class doing too much work? Time to split into smaller services?
 export class NostrService {
 
   private static instance: NostrService;
   private ndk: NDK;
   private isConnected: boolean = false;
+  private connectPromise: Promise<void> | null = null;
 
   private constructor() {
     this.ndk = new NDK();
@@ -32,27 +37,66 @@ export class NostrService {
   public async connectToNostr(
     relays: string[] = [...DEFAULT_RELAYS]
   ): Promise<void> {
-    const newRelays = relays.filter(r => !this.getRelays().includes(r));
-
-    if (this.isConnected && newRelays.length) {
-      newRelays.forEach(url => this.ndk.addExplicitRelay(url));
+    if (this.isConnected) {
+      // addNewRelays appends to the pool without touching existing
+      // connections. Never reassign ndk.explicitRelayUrls here: its setter
+      // clears the whole pool and drops every open socket.
+      this.addNewRelays(relays);
       return;
     }
 
+    if (this.connectPromise) {
+      // A connection attempt is already in flight (multiple components mount
+      // concurrently on page load). Piggyback on it instead of restarting the
+      // pool, then register any relays the first caller didn't know about.
+      await this.connectPromise;
+      this.addNewRelays(relays);
+      return;
+    }
+
+    this.connectPromise = this.establishConnection(relays);
+    try {
+      await this.connectPromise;
+      this.isConnected = true;
+    } finally {
+      // On failure, clear so a later attempt (e.g. component retry) can run.
+      this.connectPromise = null;
+    }
+  }
+
+  /**
+   * Adds relays that aren't already in the pool. NDK normalizes relay URLs
+   * (trailing slash), so compare normalized forms to avoid re-adding the
+   * same relay under a different spelling.
+   */
+  private addNewRelays(relays: string[]): void {
+    const knownRelays = this.getRelays().map(r => normalizeURL(r));
+    relays
+      .filter(r => !knownRelays.includes(normalizeURL(r)))
+      .forEach(url => this.ndk.addExplicitRelay(url));
+  }
+
+  private async establishConnection(relays: string[]): Promise<void> {
     this.ndk.explicitRelayUrls = relays;
-    
+
     try {
       await this.ndk.connect(3000);
     } catch (error) {
       console.warn('[NostrService] ndk.connect() threw an error (unexpected):', error);
     }
-    
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    
+
+    // ndk.connect() can resolve before any socket is actually open, so poll
+    // the pool until at least one relay is connected or the grace period ends.
+    const deadline = Date.now() + CONNECT_GRACE_MS;
+    let connectedRelays = this.getConnectedRelays();
+    while (connectedRelays.length === 0 && Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, CONNECT_POLL_INTERVAL_MS));
+      connectedRelays = this.getConnectedRelays();
+    }
+
     const normalizedInputRelays = relays.map(r => normalizeURL(r));
-    const connectedRelays = this.getConnectedRelays();
     const failedRelays = normalizedInputRelays.filter(r => !connectedRelays.includes(r));
-    
+
     if (connectedRelays.length === 0) {
       const error = new Error(`Failed to connect to any of ${relays.length} relay(s): ${relays.join(', ')}`);
       console.error('[NostrService]', error.message);
@@ -64,8 +108,6 @@ export class NostrService {
         `Failed: ${failedRelays.join(', ')}`
       );
     }
-    
-    this.isConnected = true;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fixes every component on a multi-component page failing with "Failed to connect to relays" (reproduced on saiy2k.in blog posts with the deployed v0.6.1 bundle).
- Root cause: `NostrService.connectToNostr()` had no in-flight guard, so N components mounting together each reassigned `ndk.explicitRelayUrls`. NDK's setter clears the whole relay pool and reopens every socket, so N x 8 handshakes raced each other and the pool reported zero connected relays at the readiness check.
- Fix: concurrent callers now share a single in-flight connect promise; relays arriving later are appended via `addExplicitRelay()` with normalized URL comparison (never resetting the pool); readiness polls the pool with a 5s grace window instead of a blind 2s sleep.

## Test plan
- [x] New regression tests in `src/common/__tests__/nostr-service-connect.test.ts` (4 tests) fail against the old code and pass with the fix
- [x] Full suite passes: 124/124
- [x] End-to-end: rebuilt ESM bundles and loaded a page with 5 components (livestream, like, zap, follow, profile) in a headless browser - one socket set instead of five, zero errors, all components reach `status="ready"`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when connecting to multiple relays concurrently.
  * Prevented active relay connections from being reset during overlapping connection attempts.
  * Reused existing connections and added only new relays.
  * Improved handling of connection failures, including successful retries.
  * Normalized relay addresses to avoid duplicate connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->