### PR TITLE
Schedule daily relay directory projection

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -63,8 +63,10 @@ Relay connections and subscriptions use NDK. The jobs retain explicit event
 validation, pagination, deduplication, Firestore writes, and checkpoint logic.
 
 Run projection after backfill because it consumes the handle documents created
-by backfill. `deploy-relay-directory-projection.sh` creates an unscheduled job;
-execute it manually, or set `RUN_AFTER_DEPLOY=true` to run it once immediately.
+by backfill. `deploy-relay-directory-projection.sh` creates a daily Cloud
+Scheduler job (`relay-directory-projection-daily`, default `0 7 * * *` UTC —
+one hour after backfill). Set `CREATE_SCHEDULER=false` to skip it, or
+`RUN_AFTER_DEPLOY=true` to also execute once immediately after deploy.
 X bio scans, NIP-39 proof-tweet checks, and backfill `@mention` existence
 checks all use FxTwitter's public API (`api.fxtwitter.com`); no X bearer token
 is required. Projection limits and timeouts are passed to Cloud Run as

--- a/backend/deploy-relay-directory-projection.sh
+++ b/backend/deploy-relay-directory-projection.sh
@@ -15,6 +15,15 @@ IMAGE_JOB_NAME="${IMAGE_JOB_NAME:-relay-directory-crawler}"
 IMAGE_TAG="${IMAGE_TAG:-$(git rev-parse --short HEAD 2>/dev/null || date +%Y%m%d%H%M%S)}"
 IMAGE="gcr.io/${PROJECT_ID}/${IMAGE_JOB_NAME}:${IMAGE_TAG}"
 SERVICE_ACCOUNT="${SERVICE_ACCOUNT:-relay-directory-crawler@${PROJECT_ID}.iam.gserviceaccount.com}"
+
+# Cloud Scheduler → Cloud Run Job (daily projection after backfill by default).
+CREATE_SCHEDULER="${CREATE_SCHEDULER:-true}"
+SCHEDULER_JOB_NAME="${SCHEDULER_JOB_NAME:-relay-directory-projection-daily}"
+SCHEDULER_REGION="${SCHEDULER_REGION:-${REGION}}"
+SCHEDULE="${SCHEDULE:-0 7 * * *}"
+SCHEDULE_TIME_ZONE="${SCHEDULE_TIME_ZONE:-Etc/UTC}"
+SCHEDULER_SERVICE_ACCOUNT="${SCHEDULER_SERVICE_ACCOUNT:-relay-directory-scheduler@${PROJECT_ID}.iam.gserviceaccount.com}"
+
 FIRESTORE_DATABASE="${FIRESTORE_DATABASE:-(default)}"
 FIRESTORE_HANDLES_COLLECTION="${FIRESTORE_HANDLES_COLLECTION:-nostrDirectoryHandles}"
 FIRESTORE_ENTRIES_COLLECTION="${FIRESTORE_ENTRIES_COLLECTION:-nostrDirectoryEntries}"
@@ -32,7 +41,11 @@ MAX_REJECTION_TOMBSTONES="${MAX_REJECTION_TOMBSTONES:-100}"
 MAX_RETRY_ATTEMPTS="${MAX_RETRY_ATTEMPTS:-5}"
 
 gcloud config set project "${PROJECT_ID}"
-gcloud services enable run.googleapis.com firestore.googleapis.com cloudbuild.googleapis.com
+gcloud services enable \
+  run.googleapis.com \
+  firestore.googleapis.com \
+  cloudbuild.googleapis.com \
+  cloudscheduler.googleapis.com
 
 if ! gcloud iam service-accounts describe "${SERVICE_ACCOUNT}" >/dev/null 2>&1; then
   SERVICE_ACCOUNT_ID="${SERVICE_ACCOUNT%%@*}"
@@ -43,6 +56,14 @@ if ! gcloud iam service-accounts describe "${SERVICE_ACCOUNT}" >/dev/null 2>&1; 
   fi
   gcloud iam service-accounts create "${SERVICE_ACCOUNT_ID}" \
     --display-name="Relay Directory Crawler"
+fi
+
+if [ "${CREATE_SCHEDULER}" = "true" ]; then
+  SCHEDULER_SA_ID="${SCHEDULER_SERVICE_ACCOUNT%%@*}"
+  if ! gcloud iam service-accounts describe "${SCHEDULER_SERVICE_ACCOUNT}" >/dev/null 2>&1; then
+    gcloud iam service-accounts create "${SCHEDULER_SA_ID}" \
+      --display-name="Relay Directory Scheduler"
+  fi
 fi
 
 if [ "${GRANT_DATASTORE_IAM:-false}" = "true" ]; then
@@ -74,6 +95,37 @@ DEPLOY_ARGS=(
 )
 
 gcloud run jobs deploy "${DEPLOY_ARGS[@]}"
+
+if [ "${CREATE_SCHEDULER}" = "true" ]; then
+  gcloud run jobs add-iam-policy-binding "${JOB_NAME}" \
+    --region "${REGION}" \
+    --member="serviceAccount:${SCHEDULER_SERVICE_ACCOUNT}" \
+    --role="roles/run.invoker" \
+    --quiet >/dev/null
+
+  SCHEDULER_URI="https://run.googleapis.com/v2/projects/${PROJECT_ID}/locations/${REGION}/jobs/${JOB_NAME}:run"
+  SCHEDULER_ARGS=(
+    --location="${SCHEDULER_REGION}"
+    --schedule="${SCHEDULE}"
+    --time-zone="${SCHEDULE_TIME_ZONE}"
+    --uri="${SCHEDULER_URI}"
+    --http-method=POST
+    --oauth-service-account-email="${SCHEDULER_SERVICE_ACCOUNT}"
+    --oauth-token-scope="https://www.googleapis.com/auth/cloud-platform"
+    --description="Triggers ${JOB_NAME} Cloud Run Job on a schedule"
+  )
+
+  if gcloud scheduler jobs describe "${SCHEDULER_JOB_NAME}" \
+    --location="${SCHEDULER_REGION}" >/dev/null 2>&1; then
+    gcloud scheduler jobs update http "${SCHEDULER_JOB_NAME}" "${SCHEDULER_ARGS[@]}"
+    echo "Updated Cloud Scheduler job ${SCHEDULER_JOB_NAME} (${SCHEDULE} ${SCHEDULE_TIME_ZONE})."
+  else
+    gcloud scheduler jobs create http "${SCHEDULER_JOB_NAME}" "${SCHEDULER_ARGS[@]}"
+    echo "Created Cloud Scheduler job ${SCHEDULER_JOB_NAME} (${SCHEDULE} ${SCHEDULE_TIME_ZONE})."
+  fi
+else
+  echo "Skipping Cloud Scheduler (CREATE_SCHEDULER=${CREATE_SCHEDULER})."
+fi
 
 if [ "${RUN_AFTER_DEPLOY:-false}" = "true" ]; then
   gcloud run jobs execute "${JOB_NAME}" --region "${REGION}"


### PR DESCRIPTION
## Summary
- Wire Cloud Scheduler into `deploy-relay-directory-projection.sh` (default `relay-directory-projection-daily` at `0 7 * * *` UTC, one hour after backfill)
- Document the daily projection schedule and `CREATE_SCHEDULER` / `RUN_AFTER_DEPLOY` options in the backend README

## Test plan
- [ ] Confirm `PROJECT_ID=... ./backend/deploy-relay-directory-projection.sh` creates/updates `relay-directory-projection-daily`
- [ ] Confirm `CREATE_SCHEDULER=false` skips scheduler setup
- [ ] Confirm scheduler SA has `roles/run.invoker` on `relay-directory-projector`
- [ ] Optionally trigger once: `gcloud scheduler jobs run relay-directory-projection-daily --location=us-central1`