### PR TITLE
feat(directory): connect Nostr Atlas to Firestore and add table pagination

### DIFF
--- a/directory-site/.env.example
+++ b/directory-site/.env.example
@@ -1,0 +1,6 @@
+# Use the URL printed by Firebase after deploying listDirectoryProfiles.
+# This matches the gr-prod project used by the browser extension.
+# VITE_DIRECTORY_API_URL=https://us-central1-gr-prod.cloudfunctions.net/listDirectoryProfiles
+
+# To use the local Functions emulator instead:
+# VITE_DIRECTORY_API_URL=http://127.0.0.1:5001/gr-prod/us-central1/listDirectoryProfiles

--- a/directory-site/README.md
+++ b/directory-site/README.md
@@ -1,12 +1,145 @@
 # Nostr Atlas directory site
 
-Nostr Atlas is a self-contained Vite + TypeScript concept for creator account
+Nostr Atlas is a self-contained Vite + TypeScript site for creator account
 claims. It is designed to connect the X and YouTube accounts an audience already
 knows to a creator's Nostr identity, making that identity easier to find and zap
 from compatible Nostr clients. It intentionally lives beside the existing
 component library so the package build and backend jobs remain unchanged.
 
-## Run locally
+## Data connection
+
+The site fetches `listDirectoryProfiles`, an HTTP Firebase Function that reads
+`nostrDirectoryHandles` in Firestore using the Admin SDK. It uses each handle's
+current `activeIdentity`, so pending claims and obsolete identities are excluded.
+The response contains only the handle, verified public key, name, and NIP-05
+metadata; claim evidence and payment details stay on the server. No Firebase
+web API key, browser database credentials, or public Firestore rules are needed.
+
+`VITE_DIRECTORY_API_URL` selects the endpoint. Without an override, the site uses
+`https://us-central1-gr-prod.cloudfunctions.net/listDirectoryProfiles`, matching
+the extension's directory project. **Deploy the new function before using that
+production URL**, or use the local Functions emulator below.
+
+The API reads up to 51 documents per default request (50 records plus one to
+detect another page). `limit` accepts 1–100; `cursor` is the last scanned handle
+document ID. The query uses `activeIdentity.status == verified`, ordered by
+document ID, using Firestore's normal single-field index. If that field has been
+exempted from indexing in your database, restore its ascending single-field index.
+Successful responses may be cached for 60 seconds; errors are not cached.
+
+Search and sorting apply to loaded records. The directory table includes
+pagination controls with page navigation (Previous, Next, and numbered page
+buttons) and customizable page sizes (10, 25, or 50 claims per page, defaulting
+to 10). **Load more creator claims** fetches the next 50-record batch from Firestore,
+expanding the paginated results; **Refresh** returns to the first page. Local previews
+survive a refresh but disappear when the page is reloaded. API failures never display
+sample data as real records.
+
+The current crawler projection contains verified X identities. It does not supply
+audience counts, YouTube claims, or Nostr popularity rankings: those fields show
+`—`, and the Nostr tab explains its empty state. A verified mark means X account
+ownership was verified by the projector; a NIP-05 address is profile metadata,
+not a separate NIP-05 verification. The claim form still creates a **local preview**;
+it does not write to Firestore, publish a claim, or verify ownership.
+
+## Run locally against Firestore
+
+Use Node.js 22 and the Firebase CLI. From the repository root:
+
+```sh
+npm ci
+npm --prefix functions ci
+gcloud auth application-default login
+firebase emulators:start --only functions --project gr-prod
+```
+
+The signed-in Google account needs permission to read the directory database.
+This runs the HTTP function locally and reads the existing Firestore database;
+only the Functions emulator is started. The new endpoint performs no writes.
+If local credentials already exist, the login step is unnecessary.
+
+In a second terminal, from the repository root:
+
+```sh
+VITE_DIRECTORY_API_URL=http://127.0.0.1:5001/gr-prod/us-central1/listDirectoryProfiles npm run dev:directory
+```
+
+Open the URL printed by Vite. For a persistent endpoint override, copy
+`directory-site/.env.example` to `directory-site/.env.local`, set its URL, and
+restart Vite. Never put a service-account key or other credentials in a `VITE_*`
+variable; these values are bundled into the public site.
+
+For another Firebase project, change both `--project` and the project segment in
+the emulator URL. The function reads that project's `(default)` database and
+`nostrDirectoryHandles` collection. Optional server environment variables
+`FIRESTORE_DATABASE` and `FIRESTORE_HANDLES_COLLECTION` select a named database or
+another collection. Set these in `functions/.env.local` for the emulator, or
+`functions/.env.PROJECT_ID` for deployment.
+
+## Manual test checklist (no automated browser test)
+
+1. Start the function and site using the commands above. In DevTools Network,
+   confirm `listDirectoryProfiles?limit=50` returns HTTP 200 with `profiles` and
+   `nextCursor`. The page should show real verified X records, or an honest empty
+   state if the database has none. Loading should never briefly show demo rows.
+2. Compare a returned `twitter:HANDLE` with the same document in Firestore:
+   `activeIdentity.status` must be `verified`, the API `pubkey` must match the active
+   key, and the displayed name/NIP-05 must match available metadata. Missing
+   metadata falls back to the handle and `—`. The response must not contain
+   `claims`, evidence, `lud16`, or retry state.
+3. Search for a loaded handle, name, NIP-05, and copied npub. Check Name A–Z
+   sorting, clear filters, copy a key and paste it, and open its Nostr profile.
+   Audience counts should display `—`, without fabricated rankings.
+4. Check the directory pagination bar: verify previous/next page navigation,
+   direct page selection, and page-size switching (10, 25, 50). If `nextCursor` is
+   non-null, click **Load more creator claims**. Confirm the next request includes
+   that cursor, earlier rows remain, and no handle is duplicated. The pagination
+   page count will update to reflect the newly loaded records. Continue until the
+   button disappears. Search includes each newly loaded page; it does not search
+   pages you have not loaded.
+5. Select **Popular on Nostr** and check the explanatory empty state. Return to
+   the X tab. Add a local claim preview: it should be marked **Local preview**, have
+   no verification check, and cause no write request. Refreshing the directory
+   keeps the preview; reloading the page removes it.
+6. Block the endpoint in DevTools or stop the Functions emulator, then click
+   **Refresh**. Expect an error and **Retry**, with existing rows retained. A page
+   reload while it is blocked should show an error rather than sample data.
+   Restore the endpoint and retry. For a timeout check, throttle or stall the
+   request; it should stop after about 15 seconds.
+7. To check an empty directory, set `FIRESTORE_HANDLES_COLLECTION` to an unused
+   collection name and restart the Functions emulator. Expect
+   `{ "profiles": [], "nextCursor": null }`. Use a separate test Firebase project
+   for invalid-record fixtures: documents without a verified active identity must
+   never become verified rows. The Functions-only emulator still reads real
+   Firestore, so do not modify production claims for this check.
+
+You can also inspect the endpoint without opening a browser:
+
+```sh
+curl --fail-with-body 'http://127.0.0.1:5001/gr-prod/us-central1/listDirectoryProfiles?limit=2'
+# Expect 400 invalid_limit:
+curl -i 'http://127.0.0.1:5001/gr-prod/us-central1/listDirectoryProfiles?limit=101'
+# Expect 405 method_not_allowed:
+curl -i -X POST 'http://127.0.0.1:5001/gr-prod/us-central1/listDirectoryProfiles'
+```
+
+## Deploy the read API
+
+The repository's default Firebase project is for Storybook. Always specify the
+directory project and deploy only the new function:
+
+```sh
+firebase deploy --only functions:listDirectoryProfiles --project gr-prod
+```
+
+The function's runtime service account needs Firestore read access in that
+project/database. It is a public GET API with CORS enabled, following Firebase's
+[HTTP function configuration](https://firebase.google.com/docs/functions/http-events).
+Use the function URL printed by deployment as `VITE_DIRECTORY_API_URL` if it
+differs from the default. The existing extension lookup is not redeployed by this
+command. No hosting target or database rules are changed.
+
+## Run against the deployed API
 
 From the repository root:
 
@@ -24,8 +157,21 @@ npm run build:directory
 
 The deployable static site is written to `directory-site/dist/`.
 
-The current profile list is local demo data. Search, categories, sorting, copy
-feedback, responsive navigation, and the in-browser claim preview are functional.
-The preview does not publish a claim, verify account ownership, or route payments.
-The Firestore-backed relay-directory projection can replace `src/data.ts` when a
-public claim API is available.
+Vite captures `VITE_DIRECTORY_API_URL` at build time. If `.env.local` points to the
+emulator, override it when building for deployment:
+
+```sh
+VITE_DIRECTORY_API_URL=https://us-central1-gr-prod.cloudfunctions.net/listDirectoryProfiles npm run build:directory
+```
+
+## Code checks
+
+```sh
+npm run test:functions
+npx vitest run directory-site/src
+npx tsc --project directory-site/tsconfig.json
+npm run build:directory
+```
+
+These cover the API contract, public field filtering, pagination, error handling,
+frontend mapping, TypeScript, and the static build. They do not launch a browser.

--- a/directory-site/src/api.test.ts
+++ b/directory-site/src/api.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { npubEncode } from "nostr-tools/nip19";
-import { fetchDirectoryPage, parseDirectoryPage } from "./api";
+import {
+  fetchDirectoryPage,
+  fetchNextDirectoryPage,
+  parseDirectoryPage,
+} from "./api";
 
 const profile = {
   id: "twitter:alice",
@@ -103,6 +107,55 @@ describe("directory API", () => {
     await expect(
       fetchDirectoryPage(endpoint, "twitter:alice", fetcher),
     ).rejects.toThrow("page cursor");
+  });
+
+  it("skips empty pages with cursors until profiles are available", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response('{"profiles":[],"nextCursor":"twitter:alice"}'),
+      )
+      .mockResolvedValueOnce(
+        new Response('{"profiles":[],"nextCursor":"twitter:bob"}'),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ profiles: [profile], nextCursor: null })),
+      );
+
+    await expect(
+      fetchNextDirectoryPage(endpoint, null, fetcher),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        profiles: [expect.objectContaining({ id: profile.id })],
+      }),
+    );
+    expect(fetcher).toHaveBeenCalledTimes(3);
+    expect(
+      new URL(String(fetcher.mock.calls[1][0])).searchParams.get("cursor"),
+    ).toBe("twitter:alice");
+    expect(
+      new URL(String(fetcher.mock.calls[2][0])).searchParams.get("cursor"),
+    ).toBe("twitter:bob");
+  });
+
+  it("bounds consecutive empty-page requests and preserves the last cursor", async () => {
+    const cursors = ["alice", "bob", "carol", "dave", "erin"];
+    const fetcher = vi.fn<typeof fetch>();
+    for (const cursor of cursors) {
+      fetcher.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ profiles: [], nextCursor: `twitter:${cursor}` }),
+        ),
+      );
+    }
+
+    await expect(
+      fetchNextDirectoryPage(endpoint, null, fetcher),
+    ).resolves.toEqual({
+      profiles: [],
+      nextCursor: "twitter:erin",
+    });
+    expect(fetcher).toHaveBeenCalledTimes(5);
   });
 
   it("aborts stalled requests and reports a timeout", async () => {

--- a/directory-site/src/api.test.ts
+++ b/directory-site/src/api.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { npubEncode } from "nostr-tools/nip19";
+import { fetchDirectoryPage, parseDirectoryPage } from "./api";
+
+const profile = {
+  id: "twitter:alice",
+  platform: "twitter",
+  handle: "alice",
+  pubkey: "a".repeat(64),
+  verified: true,
+  name: "Alice",
+  nip05: "alice@example.com",
+};
+const endpoint = "https://example.com/listDirectoryProfiles";
+
+afterEach(() => vi.useRealTimers());
+
+describe("directory API", () => {
+  it("maps verified identities to the UI without inventing follower counts or YouTube claims", () => {
+    const page = parseDirectoryPage({ profiles: [profile], nextCursor: null });
+    expect(page.profiles[0]).toMatchObject({
+      id: "twitter:alice",
+      name: "Alice",
+      handle: "@alice",
+      verified: true,
+      npub: npubEncode(profile.pubkey),
+      followers: null,
+      youtube: "",
+      category: "Popular on X.com",
+    });
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it.each([
+    null,
+    { profiles: [], nextCursor: {} },
+    { profiles: [], nextCursor: "twitter:alice/secret" },
+    { profiles: [profile] },
+    { profiles: [{ ...profile, verified: false }], nextCursor: null },
+    { profiles: [{ ...profile, pubkey: "invalid" }], nextCursor: null },
+    { profiles: [{ ...profile, id: "twitter:bob" }], nextCursor: null },
+    { profiles: [{ ...profile, platform: "youtube" }], nextCursor: null },
+    { profiles: Array(51).fill(profile), nextCursor: null },
+  ])("rejects malformed responses: %j", (value) => {
+    expect(() => parseDirectoryPage(value)).toThrow();
+  });
+
+  it("uses GET, a bounded page size and the supplied cursor", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ profiles: [profile], nextCursor: null })),
+      );
+    await fetchDirectoryPage(endpoint, "twitter:aaron", fetcher);
+    const [url, options] = fetcher.mock.calls[0];
+    expect(new URL(String(url)).searchParams.get("limit")).toBe("50");
+    expect(new URL(String(url)).searchParams.get("cursor")).toBe(
+      "twitter:aaron",
+    );
+    expect(options).toMatchObject({
+      method: "GET",
+      credentials: "omit",
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("treats an empty directory as a successful response", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response('{"profiles":[],"nextCursor":null}'));
+    await expect(fetchDirectoryPage(endpoint, null, fetcher)).resolves.toEqual({
+      profiles: [],
+      nextCursor: null,
+    });
+  });
+
+  it("surfaces unavailable APIs and network failures instead of substituting demo data", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response("unavailable", { status: 503 }));
+    await expect(fetchDirectoryPage(endpoint, null, fetcher)).rejects.toThrow(
+      "503",
+    );
+    fetcher.mockRejectedValue(new TypeError("Failed to fetch"));
+    await expect(fetchDirectoryPage(endpoint, null, fetcher)).rejects.toThrow(
+      "Failed to fetch",
+    );
+  });
+
+  it("rejects non-JSON responses, including an incorrect hosting rewrite", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response("<html>Site</html>"));
+    await expect(fetchDirectoryPage(endpoint, null, fetcher)).rejects.toThrow();
+  });
+
+  it("rejects repeated cursors to prevent endless pagination", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        new Response('{"profiles":[],"nextCursor":"twitter:alice"}'),
+      );
+    await expect(
+      fetchDirectoryPage(endpoint, "twitter:alice", fetcher),
+    ).rejects.toThrow("page cursor");
+  });
+
+  it("aborts stalled requests and reports a timeout", async () => {
+    vi.useFakeTimers();
+    const fetcher = vi.fn<typeof fetch>().mockImplementation(
+      (_url, options) =>
+        new Promise((_resolve, reject) => {
+          options?.signal?.addEventListener("abort", () =>
+            reject(new DOMException("Aborted", "AbortError")),
+          );
+        }),
+    );
+    const result = expect(
+      fetchDirectoryPage(endpoint, null, fetcher),
+    ).rejects.toThrow("too long");
+    await vi.advanceTimersByTimeAsync(15_000);
+    await result;
+  });
+});

--- a/directory-site/src/api.ts
+++ b/directory-site/src/api.ts
@@ -5,6 +5,7 @@ export const DEFAULT_DIRECTORY_API_URL =
   "https://us-central1-gr-prod.cloudfunctions.net/listDirectoryProfiles";
 const PAGE_SIZE = 50;
 const REQUEST_TIMEOUT_MS = 15_000;
+const MAX_EMPTY_PAGE_REQUESTS = 5;
 const CURSOR_PATTERN = /^twitter:[a-z0-9_]{1,15}$/;
 
 export interface DirectoryPage {
@@ -110,4 +111,21 @@ export async function fetchDirectoryPage(
   } finally {
     clearTimeout(timeout);
   }
+}
+
+export async function fetchNextDirectoryPage(
+  endpoint: string,
+  cursor: string | null = null,
+  fetcher: typeof fetch = fetch,
+): Promise<DirectoryPage> {
+  let requestCursor = cursor;
+  let page: DirectoryPage = { profiles: [], nextCursor: requestCursor };
+
+  for (let attempt = 0; attempt < MAX_EMPTY_PAGE_REQUESTS; attempt += 1) {
+    page = await fetchDirectoryPage(endpoint, requestCursor, fetcher);
+    if (page.profiles.length > 0 || !page.nextCursor) return page;
+    requestCursor = page.nextCursor;
+  }
+
+  return page;
 }

--- a/directory-site/src/api.ts
+++ b/directory-site/src/api.ts
@@ -1,0 +1,113 @@
+import { npubEncode } from "nostr-tools/nip19";
+import type { DirectoryProfile } from "./data";
+
+export const DEFAULT_DIRECTORY_API_URL =
+  "https://us-central1-gr-prod.cloudfunctions.net/listDirectoryProfiles";
+const PAGE_SIZE = 50;
+const REQUEST_TIMEOUT_MS = 15_000;
+const CURSOR_PATTERN = /^twitter:[a-z0-9_]{1,15}$/;
+
+export interface DirectoryPage {
+  readonly profiles: DirectoryProfile[];
+  readonly nextCursor: string | null;
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function parseDirectoryPage(value: unknown): DirectoryPage {
+  if (
+    !record(value) ||
+    !Array.isArray(value.profiles) ||
+    value.profiles.length > PAGE_SIZE ||
+    !(
+      value.nextCursor === null ||
+      (typeof value.nextCursor === "string" &&
+        CURSOR_PATTERN.test(value.nextCursor))
+    )
+  ) {
+    throw new Error("The directory returned an invalid response.");
+  }
+
+  const profiles = value.profiles.map((profile): DirectoryProfile => {
+    if (
+      !record(profile) ||
+      profile.platform !== "twitter" ||
+      profile.verified !== true ||
+      typeof profile.handle !== "string" ||
+      !/^[a-z0-9_]{1,15}$/.test(profile.handle) ||
+      profile.id !== `twitter:${profile.handle}` ||
+      typeof profile.pubkey !== "string" ||
+      !/^[0-9a-f]{64}$/i.test(profile.pubkey) ||
+      typeof profile.name !== "string" ||
+      profile.name.length > 100 ||
+      typeof profile.nip05 !== "string" ||
+      profile.nip05.length > 255
+    ) {
+      throw new Error("The directory returned an invalid profile.");
+    }
+
+    const name = profile.name.trim() || profile.handle;
+    return {
+      id: profile.id as string,
+      name,
+      handle: `@${profile.handle}`,
+      nip05: profile.nip05,
+      category: "Popular on X.com",
+      followers: null,
+      verified: true,
+      // Encode the verified key; never trust a stored npub that may disagree.
+      npub: npubEncode(profile.pubkey.toLowerCase()),
+      youtube: "",
+      avatar: {
+        initials: name
+          .split(/\s+/)
+          .map((part) => part[0])
+          .join("")
+          .slice(0, 2)
+          .toUpperCase(),
+        foreground: "#ffffff",
+        background: "#7456f6",
+      },
+    };
+  });
+
+  return { profiles, nextCursor: value.nextCursor };
+}
+
+export async function fetchDirectoryPage(
+  endpoint: string,
+  cursor: string | null = null,
+  fetcher: typeof fetch = fetch,
+): Promise<DirectoryPage> {
+  const url = new URL(endpoint);
+  url.searchParams.set("limit", String(PAGE_SIZE));
+  if (cursor) url.searchParams.set("cursor", cursor);
+  else url.searchParams.delete("cursor");
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetcher(url.toString(), {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+      credentials: "omit",
+    });
+    if (!response.ok)
+      throw new Error(`Directory request failed (${response.status}).`);
+    const page = parseDirectoryPage(await response.json());
+    if (cursor && page.nextCursor && page.nextCursor <= cursor) {
+      throw new Error("The directory returned an invalid page cursor.");
+    }
+    return page;
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error("The directory took too long to respond. Please retry.");
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/directory-site/src/data.ts
+++ b/directory-site/src/data.ts
@@ -6,7 +6,7 @@ export interface DirectoryProfile {
   readonly handle: string;
   readonly nip05: string;
   readonly category: DirectoryCategory;
-  readonly followers: number;
+  readonly followers: number | null;
   readonly verified: boolean;
   readonly npub: string;
   readonly youtube: string;
@@ -22,6 +22,7 @@ export const categories: readonly DirectoryCategory[] = [
   "Popular on Nostr",
 ];
 
+// Sample fixtures used by unit tests only. The site loads profiles through api.ts.
 export const directoryProfiles: readonly DirectoryProfile[] = [
   {
     id: "jack",

--- a/directory-site/src/directory.test.ts
+++ b/directory-site/src/directory.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 import { directoryProfiles } from "./data";
 import {
   formatFollowers,
+  getPaginationPageList,
   getVisibleProfiles,
   normalizeSearch,
+  nip05ProfileUrl,
+  paginateProfiles,
   truncateNpub,
 } from "./directory";
 
@@ -55,14 +58,131 @@ describe("directory filtering", () => {
 
 describe("directory formatting", () => {
   it("formats follower counts for compact display", () => {
+    expect(formatFollowers(null)).toBe("—");
     expect(formatFollowers(311_200)).toBe("311.2K");
     expect(formatFollowers(1_000_000)).toBe("1M");
     expect(formatFollowers(820)).toBe("820");
+  });
+
+  it("sorts missing audience counts after known counts without losing profiles", () => {
+    const profiles = directoryProfiles
+      .filter((profile) => profile.category === baseFilters.category)
+      .map((profile, index) => ({
+        ...profile,
+        followers: index === 1 ? 100 : null,
+      }));
+    expect(
+      getVisibleProfiles(profiles, baseFilters).map((profile) => profile.id),
+    ).toEqual(["tbot", "jack", "guy-swann"]);
+  });
+
+  it("preserves original arrival order when audience counts are absent", () => {
+    const profiles = directoryProfiles
+      .filter((profile) => profile.category === baseFilters.category)
+      .map((profile) => ({
+        ...profile,
+        followers: null,
+      }));
+    expect(
+      getVisibleProfiles(profiles, baseFilters).map((profile) => profile.id),
+    ).toEqual(["jack", "tbot", "guy-swann"]);
+  });
+
+  it("only links profile-provided Nostr addresses with valid domains", () => {
+    expect(nip05ProfileUrl("alice@example.com")).toBe("https://example.com");
+    expect(nip05ProfileUrl("example.com")).toBe("https://example.com");
+    for (const value of [
+      "",
+      "javascript:alert(1)",
+      "alice@example.com/path",
+      "alice@localhost",
+      'alice@example.com\" onclick=\"alert(1)',
+    ]) {
+      expect(nip05ProfileUrl(value)).toBeNull();
+    }
   });
 
   it("truncates long public keys without hiding their ends", () => {
     expect(truncateNpub("npub1234567890abcdefghijklmnopqrstuvwxyz")).toBe(
       "npub12345678…tuvwxyz",
     );
+  });
+});
+
+describe("directory pagination", () => {
+  const sampleItems = Array.from({ length: 25 }, (_, i) => `item-${i + 1}`);
+
+  it("paginates items into slices and computes total pages", () => {
+    const page1 = paginateProfiles(sampleItems, 1, 10);
+    expect(page1.page).toBe(1);
+    expect(page1.pageSize).toBe(10);
+    expect(page1.totalItems).toBe(25);
+    expect(page1.totalPages).toBe(3);
+    expect(page1.startIndex).toBe(0);
+    expect(page1.endIndex).toBe(10);
+    expect(page1.items).toEqual(sampleItems.slice(0, 10));
+
+    const page2 = paginateProfiles(sampleItems, 2, 10);
+    expect(page2.page).toBe(2);
+    expect(page2.startIndex).toBe(10);
+    expect(page2.endIndex).toBe(20);
+    expect(page2.items).toEqual(sampleItems.slice(10, 20));
+
+    const page3 = paginateProfiles(sampleItems, 3, 10);
+    expect(page3.page).toBe(3);
+    expect(page3.startIndex).toBe(20);
+    expect(page3.endIndex).toBe(25);
+    expect(page3.items).toEqual(sampleItems.slice(20, 25));
+  });
+
+  it("clamps out-of-bounds page numbers safely", () => {
+    const clampedHigh = paginateProfiles(sampleItems, 99, 10);
+    expect(clampedHigh.page).toBe(3);
+    expect(clampedHigh.items.length).toBe(5);
+
+    const clampedLow = paginateProfiles(sampleItems, 0, 10);
+    expect(clampedLow.page).toBe(1);
+    expect(clampedLow.items.length).toBe(10);
+
+    const clampedNegative = paginateProfiles(sampleItems, -5, 10);
+    expect(clampedNegative.page).toBe(1);
+    expect(clampedNegative.items.length).toBe(10);
+  });
+
+  it("handles empty items array gracefully", () => {
+    const emptyResult = paginateProfiles([], 1, 10);
+    expect(emptyResult.page).toBe(1);
+    expect(emptyResult.totalItems).toBe(0);
+    expect(emptyResult.totalPages).toBe(1);
+    expect(emptyResult.startIndex).toBe(0);
+    expect(emptyResult.endIndex).toBe(0);
+    expect(emptyResult.items).toEqual([]);
+  });
+
+  it("handles invalid or default page size gracefully", () => {
+    const defaultResult = paginateProfiles(sampleItems, 1);
+    expect(defaultResult.pageSize).toBe(10);
+
+    const zeroSizeResult = paginateProfiles(sampleItems, 1, 0);
+    expect(zeroSizeResult.pageSize).toBe(10);
+  });
+
+  it("generates page list without ellipses for 7 or fewer pages", () => {
+    expect(getPaginationPageList(1, 5)).toEqual([1, 2, 3, 4, 5]);
+    expect(getPaginationPageList(3, 7)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  it("generates page list with ellipses for more than 7 pages", () => {
+    // Near start
+    expect(getPaginationPageList(1, 10)).toEqual([1, 2, 3, 4, 5, "…", 10]);
+    expect(getPaginationPageList(4, 10)).toEqual([1, 2, 3, 4, 5, "…", 10]);
+
+    // In middle
+    expect(getPaginationPageList(5, 10)).toEqual([1, "…", 4, 5, 6, "…", 10]);
+    expect(getPaginationPageList(6, 10)).toEqual([1, "…", 5, 6, 7, "…", 10]);
+
+    // Near end
+    expect(getPaginationPageList(7, 10)).toEqual([1, "…", 6, 7, 8, 9, 10]);
+    expect(getPaginationPageList(10, 10)).toEqual([1, "…", 6, 7, 8, 9, 10]);
   });
 });

--- a/directory-site/src/directory.ts
+++ b/directory-site/src/directory.ts
@@ -44,11 +44,12 @@ export function getVisibleProfiles(
 
   return filtered.sort((a, b) => {
     if (filters.sort === "name") return a.name.localeCompare(b.name);
-    return b.followers - a.followers;
+    return (b.followers ?? -1) - (a.followers ?? -1);
   });
 }
 
-export function formatFollowers(value: number): string {
+export function formatFollowers(value: number | null): string {
+  if (value === null) return "—";
   if (value >= 1_000_000) {
     return `${(value / 1_000_000).toFixed(1).replace(".0", "")}M`;
   }
@@ -60,7 +61,86 @@ export function formatFollowers(value: number): string {
   return value.toLocaleString("en-US");
 }
 
+export function nip05ProfileUrl(value: string): string | null {
+  const match =
+    /^(?:[a-zA-Z0-9_.-]+@)?((?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z]{2,})$/.exec(
+      value,
+    );
+  return match ? `https://${match[1]}` : null;
+}
+
 export function truncateNpub(npub: string): string {
   if (npub.length <= 22) return npub;
   return `${npub.slice(0, 12)}…${npub.slice(-7)}`;
+}
+
+export const DEFAULT_PAGE_SIZE = 10;
+export const PAGE_SIZE_OPTIONS = [10, 25, 50] as const;
+
+export interface PaginationResult<T> {
+  readonly items: T[];
+  readonly page: number;
+  readonly pageSize: number;
+  readonly totalItems: number;
+  readonly totalPages: number;
+  readonly startIndex: number;
+  readonly endIndex: number;
+}
+
+export function paginateProfiles<T>(
+  items: readonly T[],
+  page: number,
+  pageSize: number = DEFAULT_PAGE_SIZE,
+): PaginationResult<T> {
+  const safePageSize = Math.max(1, Math.floor(pageSize) || DEFAULT_PAGE_SIZE);
+  const totalItems = items.length;
+  const totalPages = Math.max(1, Math.ceil(totalItems / safePageSize));
+  const safePage = Math.max(1, Math.min(Math.floor(page) || 1, totalPages));
+  const startIndex = totalItems === 0 ? 0 : (safePage - 1) * safePageSize;
+  const endIndex = Math.min(startIndex + safePageSize, totalItems);
+
+  return {
+    items: items.slice(startIndex, endIndex),
+    page: safePage,
+    pageSize: safePageSize,
+    totalItems,
+    totalPages,
+    startIndex,
+    endIndex,
+  };
+}
+
+export function getPaginationPageList(
+  currentPage: number,
+  totalPages: number,
+): (number | "…")[] {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+
+  if (currentPage <= 4) {
+    return [1, 2, 3, 4, 5, "…", totalPages];
+  }
+
+  if (currentPage >= totalPages - 3) {
+    return [
+      1,
+      "…",
+      totalPages - 4,
+      totalPages - 3,
+      totalPages - 2,
+      totalPages - 1,
+      totalPages,
+    ];
+  }
+
+  return [
+    1,
+    "…",
+    currentPage - 1,
+    currentPage,
+    currentPage + 1,
+    "…",
+    totalPages,
+  ];
 }

--- a/directory-site/src/icons.ts
+++ b/directory-site/src/icons.ts
@@ -7,6 +7,14 @@ export const icon = {
     <svg aria-hidden="true" viewBox="0 0 20 20" fill="none">
       <path d="m6 8 4 4 4-4" />
     </svg>`,
+  chevronLeft: () => `
+    <svg aria-hidden="true" viewBox="0 0 20 20" fill="none">
+      <path d="m12 14-4-4 4-4" />
+    </svg>`,
+  chevronRight: () => `
+    <svg aria-hidden="true" viewBox="0 0 20 20" fill="none">
+      <path d="m8 6 4 4-4 4" />
+    </svg>`,
   check: () => `
     <svg aria-hidden="true" viewBox="0 0 20 20" fill="none">
       <path d="m6.5 10.1 2.1 2.2 5-5" />

--- a/directory-site/src/main.ts
+++ b/directory-site/src/main.ts
@@ -16,7 +16,7 @@ import {
   type DirectorySort,
 } from "./directory";
 import { brandMark, icon, networkGraphic } from "./icons";
-import { DEFAULT_DIRECTORY_API_URL, fetchDirectoryPage } from "./api";
+import { DEFAULT_DIRECTORY_API_URL, fetchNextDirectoryPage } from "./api";
 
 const appRoot = document.querySelector<HTMLDivElement>("#app");
 
@@ -156,8 +156,9 @@ function renderProfiles(): void {
 function renderPagination(
   pagination: ReturnType<typeof paginateProfiles<DirectoryProfile>>,
 ): void {
-  const paginationNav =
-    document.querySelector<HTMLElement>("#directory-pagination");
+  const paginationNav = document.querySelector<HTMLElement>(
+    "#directory-pagination",
+  );
   if (!paginationNav) return;
 
   if (pagination.totalItems === 0 || (!loaded && loading)) {
@@ -206,7 +207,7 @@ function renderPagination(
       >
         ${icon.chevronLeft()}<span>Previous</span>
       </button>
-      <div class="pagination-pages" role="navigation" aria-label="Pagination pages">
+      <div class="pagination-pages" role="group" aria-label="Pagination pages">
         ${pagesHtml}
       </div>
       <button
@@ -266,7 +267,7 @@ async function loadProfiles(reset = true): Promise<void> {
   }
   renderProfiles();
   try {
-    const page = await fetchDirectoryPage(
+    const page = await fetchNextDirectoryPage(
       directoryApiUrl,
       reset ? null : nextCursor,
     );

--- a/directory-site/src/main.ts
+++ b/directory-site/src/main.ts
@@ -1,17 +1,22 @@
 import "./styles.css";
 import {
   categories,
-  directoryProfiles,
   type DirectoryCategory,
   type DirectoryProfile,
 } from "./data";
 import {
+  DEFAULT_PAGE_SIZE,
+  PAGE_SIZE_OPTIONS,
   formatFollowers,
+  getPaginationPageList,
   getVisibleProfiles,
+  nip05ProfileUrl,
+  paginateProfiles,
   truncateNpub,
   type DirectorySort,
 } from "./directory";
 import { brandMark, icon, networkGraphic } from "./icons";
+import { DEFAULT_DIRECTORY_API_URL, fetchDirectoryPage } from "./api";
 
 const appRoot = document.querySelector<HTMLDivElement>("#app");
 
@@ -19,10 +24,20 @@ if (!appRoot) throw new Error("Nostr Atlas app root was not found.");
 
 const app = appRoot;
 
-let profiles: DirectoryProfile[] = [...directoryProfiles];
+const directoryApiUrl =
+  import.meta.env.VITE_DIRECTORY_API_URL?.trim() || DEFAULT_DIRECTORY_API_URL;
+let profiles: DirectoryProfile[] = [];
+let previewProfiles: DirectoryProfile[] = [];
+let nextCursor: string | null = null;
+let loading = false;
+let loaded = false;
+let loadFailed = false;
+let lastLoadReset = true;
 let category: DirectoryCategory = "Popular on X.com";
 let query = "";
 let sort: DirectorySort = "followers";
+let currentPage = 1;
+let pageSize = DEFAULT_PAGE_SIZE;
 
 const escapeHtml = (value: string): string =>
   value.replace(
@@ -42,6 +57,10 @@ function profileRow(profile: DirectoryProfile): string {
   const safeHandle = escapeHtml(profile.handle);
   const safeNip05 = escapeHtml(profile.nip05);
   const safeNpub = escapeHtml(profile.npub);
+  const nip05Url = nip05ProfileUrl(profile.nip05);
+  const verificationLabel = profile.verified
+    ? "X account ownership verified"
+    : "Local preview · not verified";
 
   return `
     <article class="profile-row" data-profile-id="${escapeHtml(profile.id)}">
@@ -54,18 +73,18 @@ function profileRow(profile: DirectoryProfile): string {
         <span class="profile-name-wrap">
           <span class="profile-name-line">
             <strong>${safeName}</strong>
-            ${profile.verified ? `<span class="verified-mark" title="Nostr identity verified">${icon.check()}<span class="sr-only">Nostr identity verified</span></span>` : ""}
+            ${profile.verified ? `<span class="verified-mark" title="${verificationLabel}">${icon.check()}<span class="sr-only">${verificationLabel}</span></span>` : ""}
           </span>
-          <span class="profile-handle">${safeHandle}</span>
+          <span class="profile-handle">${safeHandle}${profile.verified ? "" : " · Local preview"}</span>
         </span>
       </div>
-      <a class="nip05-link" href="https://${safeNip05.includes("@") ? safeNip05.split("@")[1] : safeNip05}" target="_blank" rel="noreferrer">${safeNip05}</a>
+      ${nip05Url ? `<a class="nip05-link" href="${escapeHtml(nip05Url)}" target="_blank" rel="noreferrer" title="Profile-provided Nostr address">${safeNip05}</a>` : `<span class="nip05-link">${safeNip05 || "—"}</span>`}
       <button class="npub-copy" type="button" data-copy-npub="${safeNpub}" aria-label="Copy Nostr public key for ${safeName}">
-        <span>${truncateNpub(profile.npub)}</span>
+        <span>${escapeHtml(truncateNpub(profile.npub))}</span>
         ${icon.copy()}
       </button>
-      <span class="followers"><strong>${formatFollowers(profile.followers)}</strong><span class="mobile-only"> audience</span></span>
-      <span class="verified-cell">${profile.verified ? icon.check() : "—"}<span class="sr-only">${profile.verified ? "Nostr identity verified" : "Nostr identity not verified"}</span></span>
+      <span class="followers"${profile.followers === null ? ' title="Audience count unavailable"' : ""}><strong>${formatFollowers(profile.followers)}</strong><span class="mobile-only"> audience</span></span>
+      <span class="verified-cell">${profile.verified ? icon.check() : "—"}<span class="sr-only">${verificationLabel}</span></span>
       <span class="youtube-cell">${profile.youtube ? escapeHtml(profile.youtube) : "—"}</span>
       <a class="profile-link" href="https://njump.me/${safeNpub}" target="_blank" rel="noreferrer">
         <span>Open Nostr profile</span>${icon.external()}
@@ -78,22 +97,196 @@ function renderProfiles(): void {
   const resultCount = document.querySelector<HTMLElement>("#result-count");
   if (!results || !resultCount) return;
 
-  const visibleProfiles = getVisibleProfiles(profiles, {
-    category,
-    query,
-    sort,
-  });
+  const visibleProfiles = getVisibleProfiles(
+    [...previewProfiles, ...profiles],
+    {
+      category,
+      query,
+      sort,
+    },
+  );
 
-  resultCount.textContent = `${visibleProfiles.length} ${visibleProfiles.length === 1 ? "creator claim" : "creator claims"}`;
+  const pagination = paginateProfiles(visibleProfiles, currentPage, pageSize);
+  currentPage = pagination.page;
+
+  const totalLoaded = visibleProfiles.length;
+  if (loading && !loaded) {
+    resultCount.textContent = "Loading creator claims…";
+  } else if (totalLoaded === 0) {
+    resultCount.textContent = "0 creator claims";
+  } else {
+    const claimNoun = totalLoaded === 1 ? "creator claim" : "creator claims";
+    resultCount.textContent = `Showing ${pagination.startIndex + 1}–${pagination.endIndex} of ${totalLoaded} ${claimNoun}${nextCursor ? " in loaded results" : ""}`;
+  }
+
+  results.setAttribute("aria-busy", String(loading));
+  const emptyTitle =
+    loading && !loaded
+      ? "Loading creator claims…"
+      : loadFailed && !loaded
+        ? "Creator claims could not be loaded"
+        : category === "Popular on Nostr"
+          ? "Nostr rankings are not available yet"
+          : "No creator claims found";
+  const emptyDescription =
+    loading && !loaded
+      ? "Fetching verified accounts."
+      : loadFailed && !loaded
+        ? "Please retry using the button below."
+        : category === "Popular on Nostr"
+          ? "The live directory currently lists verified X accounts. Choose Popular on X.com to browse them."
+          : nextCursor
+            ? "Try another search or load more creator claims below."
+            : "Try an X handle, name, Nostr address, or npub. Only verified X accounts appear in the live directory.";
+
   results.innerHTML = visibleProfiles.length
-    ? visibleProfiles.map(profileRow).join("")
+    ? pagination.items.map(profileRow).join("")
     : `
       <div class="empty-state">
         <span>${icon.search()}</span>
-        <h3>No creator claims found</h3>
-        <p>Try an X handle, YouTube channel, NIP-05 address, or npub.</p>
+        <h3>${emptyTitle}</h3>
+        <p>${emptyDescription}</p>
         <button class="text-button" type="button" id="clear-filters">Clear search and filters</button>
       </div>`;
+
+  renderPagination(pagination);
+  renderDirectoryStatus();
+}
+
+function renderPagination(
+  pagination: ReturnType<typeof paginateProfiles<DirectoryProfile>>,
+): void {
+  const paginationNav =
+    document.querySelector<HTMLElement>("#directory-pagination");
+  if (!paginationNav) return;
+
+  if (pagination.totalItems === 0 || (!loaded && loading)) {
+    paginationNav.hidden = true;
+    paginationNav.innerHTML = "";
+    return;
+  }
+
+  paginationNav.hidden = false;
+  const pageList = getPaginationPageList(
+    pagination.page,
+    pagination.totalPages,
+  );
+
+  const pagesHtml = pageList
+    .map((item) => {
+      if (item === "…") {
+        return `<span class="pagination-ellipsis" aria-hidden="true">…</span>`;
+      }
+      const isCurrent = item === pagination.page;
+      return `
+        <button
+          class="pagination-page-btn${isCurrent ? " active" : ""}"
+          type="button"
+          data-page="${item}"
+          aria-label="Page ${item}"
+          ${isCurrent ? 'aria-current="page"' : ""}
+        >${item}</button>`;
+    })
+    .join("");
+
+  const startNumber = pagination.startIndex + 1;
+  const endNumber = pagination.endIndex;
+
+  paginationNav.innerHTML = `
+    <div class="pagination-summary">
+      Showing <strong>${startNumber}–${endNumber}</strong> of <strong>${pagination.totalItems}</strong> claims
+    </div>
+    <div class="pagination-controls">
+      <button
+        class="pagination-nav-btn"
+        id="pagination-prev"
+        type="button"
+        aria-label="Previous page"
+        ${pagination.page <= 1 ? "disabled" : ""}
+      >
+        ${icon.chevronLeft()}<span>Previous</span>
+      </button>
+      <div class="pagination-pages" role="navigation" aria-label="Pagination pages">
+        ${pagesHtml}
+      </div>
+      <button
+        class="pagination-nav-btn"
+        id="pagination-next"
+        type="button"
+        aria-label="Next page"
+        ${pagination.page >= pagination.totalPages ? "disabled" : ""}
+      >
+        <span>Next</span>${icon.chevronRight()}
+      </button>
+    </div>
+    <div class="pagination-size">
+      <label for="page-size-select" class="sr-only">Claims per page</label>
+      <div class="page-size-wrap">
+        <select id="page-size-select" aria-label="Claims per page">
+          ${PAGE_SIZE_OPTIONS.map(
+            (opt) =>
+              `<option value="${opt}"${pageSize === opt ? " selected" : ""}>${opt} per page</option>`,
+          ).join("")}
+        </select>
+        ${icon.chevron()}
+      </div>
+    </div>`;
+}
+
+function renderDirectoryStatus(): void {
+  const status = document.querySelector<HTMLElement>("#directory-status");
+  const refresh =
+    document.querySelector<HTMLButtonElement>("#refresh-directory");
+  const more = document.querySelector<HTMLButtonElement>("#load-more-profiles");
+  if (status) {
+    status.textContent = loadFailed
+      ? "Could not load creator claims. Check your connection and retry. Previously loaded claims and local previews are kept."
+      : loading
+        ? "Loading verified creator claims…"
+        : `${profiles.length} verified X ${profiles.length === 1 ? "account" : "accounts"} loaded. ${nextCursor ? "Search and sorting apply to loaded accounts; load more to expand results. " : ""}Audience counts and YouTube claims are not available yet.`;
+  }
+  if (refresh) {
+    refresh.disabled = loading;
+    refresh.textContent = loadFailed ? "Retry" : "Refresh";
+  }
+  if (more) {
+    more.hidden = !nextCursor || category !== "Popular on X.com";
+    more.disabled = loading || loadFailed;
+    more.textContent = loading ? "Loading…" : "Load more creator claims";
+  }
+}
+
+async function loadProfiles(reset = true): Promise<void> {
+  if (loading) return;
+  loading = true;
+  loadFailed = false;
+  lastLoadReset = reset;
+  if (reset) {
+    currentPage = 1;
+  }
+  renderProfiles();
+  try {
+    const page = await fetchDirectoryPage(
+      directoryApiUrl,
+      reset ? null : nextCursor,
+    );
+    profiles = [
+      ...new Map(
+        [...(reset ? [] : profiles), ...page.profiles].map((profile) => [
+          profile.id,
+          profile,
+        ]),
+      ).values(),
+    ];
+    nextCursor = page.nextCursor;
+    loaded = true;
+  } catch (error) {
+    loadFailed = true;
+    console.error("Failed to load the creator directory", error);
+  } finally {
+    loading = false;
+    renderProfiles();
+  }
 }
 
 function renderApp(): void {
@@ -117,7 +310,7 @@ function renderApp(): void {
           <form class="hero-search" id="hero-search" role="search">
             <label class="sr-only" for="directory-search">Search creator claims</label>
             ${icon.search()}
-            <input id="directory-search" type="search" autocomplete="off" placeholder="Search X, YouTube, NIP-05, or npub" />
+            <input id="directory-search" type="search" autocomplete="off" placeholder="Search X, name, NIP-05, or npub" />
             <button type="submit" aria-label="Search creator claims">${icon.arrow()}</button>
           </form>
         </div>
@@ -154,9 +347,17 @@ function renderApp(): void {
 
         <div class="profile-table" role="region" aria-label="Creator claim directory" tabindex="0">
           <div class="table-header" aria-hidden="true">
-            <span>Creator</span><span>Nostr address</span><span>npub (click to copy)</span><span>Audience</span><span>Nostr verified</span><span>YouTube channel</span><span></span>
+            <span>Creator</span><span>Nostr address</span><span>npub (click to copy)</span><span>Audience</span><span>X verified</span><span>YouTube channel</span><span></span>
           </div>
           <div id="profile-results"></div>
+        </div>
+        <nav class="directory-pagination" id="directory-pagination" aria-label="Directory pagination" hidden></nav>
+        <div class="directory-data-controls">
+          <p id="directory-status" role="status" aria-live="polite"></p>
+          <div class="directory-data-actions">
+            <button class="secondary-button" type="button" id="refresh-directory">Refresh</button>
+            <button class="secondary-button" type="button" id="load-more-profiles" hidden>Load more creator claims</button>
+          </div>
         </div>
       </section>
 
@@ -207,7 +408,82 @@ function renderApp(): void {
   bindEvents();
 }
 
+function scrollToDirectory(): void {
+  const directorySection = document.querySelector("#directory");
+  if (directorySection) {
+    const rect = directorySection.getBoundingClientRect();
+    if (rect.top < 0) {
+      directorySection.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }
+}
+
 function bindEvents(): void {
+  document
+    .querySelector("#refresh-directory")
+    ?.addEventListener("click", () => {
+      void loadProfiles(loadFailed ? lastLoadReset : true);
+    });
+  document
+    .querySelector("#load-more-profiles")
+    ?.addEventListener("click", () => {
+      if (nextCursor) void loadProfiles(false);
+    });
+
+  const paginationNav = document.querySelector("#directory-pagination");
+  paginationNav?.addEventListener("click", (event) => {
+    const target = event.target as HTMLElement;
+    const pageBtn = target.closest<HTMLButtonElement>("[data-page]");
+    if (pageBtn?.dataset.page) {
+      const newPage = parseInt(pageBtn.dataset.page, 10);
+      if (!isNaN(newPage) && newPage !== currentPage) {
+        currentPage = newPage;
+        renderProfiles();
+        scrollToDirectory();
+      }
+      return;
+    }
+
+    const prevBtn = target.closest<HTMLButtonElement>("#pagination-prev");
+    if (prevBtn && currentPage > 1) {
+      currentPage--;
+      renderProfiles();
+      scrollToDirectory();
+      return;
+    }
+
+    const nextBtn = target.closest<HTMLButtonElement>("#pagination-next");
+    if (nextBtn) {
+      const visibleProfiles = getVisibleProfiles(
+        [...previewProfiles, ...profiles],
+        { category, query, sort },
+      );
+      const totalPages = Math.max(
+        1,
+        Math.ceil(visibleProfiles.length / pageSize),
+      );
+      if (currentPage < totalPages) {
+        currentPage++;
+        renderProfiles();
+        scrollToDirectory();
+      }
+    }
+  });
+
+  paginationNav?.addEventListener("change", (event) => {
+    const select = (event.target as HTMLElement).closest<HTMLSelectElement>(
+      "#page-size-select",
+    );
+    if (!select) return;
+    const newSize = parseInt(select.value, 10);
+    if (!isNaN(newSize) && newSize > 0) {
+      pageSize = newSize;
+      currentPage = 1;
+      renderProfiles();
+      scrollToDirectory();
+    }
+  });
+
   const searchForm = document.querySelector<HTMLFormElement>("#hero-search");
   const searchInput =
     document.querySelector<HTMLInputElement>("#directory-search");
@@ -221,6 +497,7 @@ function bindEvents(): void {
   searchForm?.addEventListener("submit", (event) => {
     event.preventDefault();
     query = searchInput?.value ?? "";
+    currentPage = 1;
     renderProfiles();
     document
       .querySelector("#directory")
@@ -229,11 +506,13 @@ function bindEvents(): void {
 
   searchInput?.addEventListener("input", (event) => {
     query = (event.target as HTMLInputElement).value;
+    currentPage = 1;
     renderProfiles();
   });
 
   sortSelect?.addEventListener("change", (event) => {
     sort = (event.target as HTMLSelectElement).value as DirectorySort;
+    currentPage = 1;
     renderProfiles();
   });
 
@@ -243,6 +522,7 @@ function bindEvents(): void {
     );
     if (!button) return;
     category = button.dataset.category as DirectoryCategory;
+    currentPage = 1;
     document
       .querySelectorAll<HTMLButtonElement>("[data-category]")
       .forEach((tab) => {
@@ -269,6 +549,7 @@ function bindEvents(): void {
         query = "";
         category = "Popular on X.com";
         sort = "followers";
+        currentPage = 1;
         if (searchInput) searchInput.value = "";
         if (sortSelect) sortSelect.value = "followers";
         document
@@ -305,14 +586,14 @@ function bindEvents(): void {
     ) as DirectoryProfile["category"];
     const npub = String(formData.get("npub") ?? "").trim();
 
-    profiles = [
+    previewProfiles = [
       {
         id: `preview-${Date.now()}`,
         name,
         handle: handle.startsWith("@") ? handle : `@${handle}`,
         nip05: String(formData.get("nip05") ?? "").trim(),
         category: categoryValue,
-        followers: 0,
+        followers: null,
         verified: false,
         npub,
         youtube: "",
@@ -327,10 +608,11 @@ function bindEvents(): void {
           background: "#7456f6",
         },
       },
-      ...profiles,
+      ...previewProfiles,
     ];
     category = categoryValue;
     query = "";
+    currentPage = 1;
     if (searchInput) searchInput.value = "";
     profileDialog?.close();
     addProfileForm.reset();
@@ -398,3 +680,4 @@ function showToast(message: string): void {
 }
 
 renderApp();
+void loadProfiles();

--- a/directory-site/src/styles.css
+++ b/directory-site/src/styles.css
@@ -58,6 +58,177 @@ button {
   color: inherit;
 }
 
+button:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+.directory-pagination {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding-block: 18px;
+  border-bottom: 1px solid var(--line);
+}
+
+.pagination-summary {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.pagination-summary strong {
+  color: var(--ink);
+  font-weight: 680;
+}
+
+.pagination-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.pagination-pages {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.pagination-nav-btn,
+.pagination-page-btn {
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  background: #ffffff;
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 120ms ease;
+}
+
+.pagination-nav-btn {
+  padding: 0 12px;
+  gap: 6px;
+}
+
+.pagination-nav-btn svg {
+  width: 16px;
+  height: 16px;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.pagination-page-btn {
+  min-width: 36px;
+  padding: 0 8px;
+}
+
+.pagination-nav-btn:hover:not(:disabled),
+.pagination-page-btn:hover:not(.active) {
+  border-color: #aeb6c5;
+  background: #f7f8fa;
+}
+
+.pagination-page-btn.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #ffffff;
+  cursor: default;
+}
+
+.pagination-nav-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.pagination-ellipsis {
+  min-width: 24px;
+  text-align: center;
+  color: var(--muted);
+  font-size: 14px;
+  user-select: none;
+}
+
+.pagination-size {
+  display: flex;
+  align-items: center;
+}
+
+.page-size-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  height: 36px;
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  background: #ffffff;
+}
+
+.page-size-wrap select {
+  height: 100%;
+  appearance: none;
+  border: 0;
+  outline: 0;
+  padding: 0 34px 0 12px;
+  background: transparent;
+  color: var(--ink);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.page-size-wrap svg {
+  position: absolute;
+  right: 10px;
+  width: 16px;
+  pointer-events: none;
+  stroke: currentColor;
+  stroke-width: 1.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.page-size-wrap:focus-within,
+.pagination-nav-btn:focus-visible,
+.pagination-page-btn:focus-visible {
+  outline: 0;
+  box-shadow: var(--focus);
+}
+
+.directory-data-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px;
+  padding-block: 20px;
+}
+
+.directory-data-controls p {
+  flex: 1 1 280px;
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.directory-data-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
 a {
   color: inherit;
   text-decoration: none;
@@ -1242,9 +1413,56 @@ svg {
   .full-field {
     grid-column: auto;
   }
+
+  .directory-pagination {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 14px;
+    padding-block: 14px;
+  }
+
+  .pagination-summary {
+    text-align: center;
+  }
+
+  .pagination-controls {
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .pagination-size {
+    justify-content: center;
+  }
+
+  .page-size-wrap {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .page-size-wrap select {
+    width: 100%;
+    text-align: center;
+  }
 }
 
 @media (max-width: 520px) {
+  .pagination-controls {
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+
+  .pagination-pages {
+    order: -1;
+    width: 100%;
+    justify-content: center;
+    margin-bottom: 8px;
+  }
+
+  .pagination-nav-btn {
+    flex: 1 1 45%;
+  }
+
   .profile-row {
     grid-template-columns: minmax(170px, 1fr) minmax(110px, 138px);
     column-gap: 8px;

--- a/directory-site/src/styles.css
+++ b/directory-site/src/styles.css
@@ -59,7 +59,7 @@ button {
 }
 
 button:disabled {
-  cursor: wait;
+  cursor: not-allowed;
   opacity: 0.6;
 }
 
@@ -150,7 +150,6 @@ button:disabled {
 .pagination-nav-btn:disabled {
   opacity: 0.45;
   cursor: not-allowed;
-  pointer-events: none;
 }
 
 .pagination-ellipsis {

--- a/directory-site/src/vite-env.d.ts
+++ b/directory-site/src/vite-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_DIRECTORY_API_URL?: string;
+}

--- a/directory-site/tsconfig.json
+++ b/directory-site/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "emitDeclarationOnly": false,
+    "types": ["node", "vite/client"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/functions/directory.js
+++ b/functions/directory.js
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+
+import { FieldPath } from 'firebase-admin/firestore';
+import { normalizeTwitterHandle } from './lookup.js';
+
+const DEFAULT_PAGE_SIZE = 50;
+const MAX_PAGE_SIZE = 100;
+const CURSOR_PATTERN = /^twitter:[a-z0-9_]{1,15}$/;
+
+function boundedString(value, length) {
+  return typeof value === 'string' ? value.trim().slice(0, length) : '';
+}
+
+// Read the current identity from handles, not potentially obsolete entry records.
+// Deliberately omit claim evidence, retry state, and payment routing fields.
+export function publicDirectoryProfile(id, data) {
+  const handle = id.startsWith('twitter:') ? id.slice(8) : '';
+  const active = data?.activeIdentity;
+  if (
+    !CURSOR_PATTERN.test(id) ||
+    normalizeTwitterHandle(handle) !== handle ||
+    (data?.platform && data.platform !== 'twitter') ||
+    (data?.handle && data.handle !== handle) ||
+    active?.status !== 'verified' ||
+    typeof active.pubkey !== 'string' ||
+    !/^[0-9a-f]{64}$/i.test(active.pubkey)
+  ) {
+    return null;
+  }
+
+  return {
+    id,
+    platform: 'twitter',
+    handle,
+    pubkey: active.pubkey.toLowerCase(),
+    verified: true,
+    name: boundedString(active.metadata?.name, 100) || handle,
+    nip05: boundedString(active.metadata?.nip05, 255)
+  };
+}
+
+export async function listDirectoryProfiles(db, parameters = {}, options = {}) {
+  const rawLimit = parameters.limit;
+  if (
+    rawLimit !== undefined &&
+    (typeof rawLimit !== 'string' || !/^[1-9][0-9]{0,2}$/.test(rawLimit))
+  ) {
+    return { status: 400, body: { error: 'invalid_limit' } };
+  }
+  const pageSize =
+    rawLimit === undefined ? DEFAULT_PAGE_SIZE : Number(rawLimit);
+  if (pageSize > MAX_PAGE_SIZE) {
+    return { status: 400, body: { error: 'invalid_limit' } };
+  }
+  const cursor = parameters.cursor;
+  if (
+    cursor !== undefined &&
+    (typeof cursor !== 'string' || !CURSOR_PATTERN.test(cursor))
+  ) {
+    return { status: 400, body: { error: 'invalid_cursor' } };
+  }
+
+  let query = db
+    .collection(options.collection || 'nostrDirectoryHandles')
+    .where('activeIdentity.status', '==', 'verified')
+    .orderBy(FieldPath.documentId());
+  if (cursor !== undefined) query = query.startAfter(cursor);
+  const snapshot = await query
+    .select(
+      'platform',
+      'handle',
+      'activeIdentity.status',
+      'activeIdentity.pubkey',
+      'activeIdentity.metadata.name',
+      'activeIdentity.metadata.nip05'
+    )
+    .limit(pageSize + 1)
+    .get();
+  const documents = snapshot.docs.slice(0, pageSize);
+
+  return {
+    status: 200,
+    body: {
+      profiles: documents
+        .map((doc) => publicDirectoryProfile(doc.id, doc.data()))
+        .filter(Boolean),
+      // Advance over scanned documents even when a malformed record was skipped.
+      nextCursor: snapshot.docs.length > pageSize ? documents.at(-1).id : null
+    }
+  };
+}
+
+export function createDirectoryListHandler(db, options = {}) {
+  return async function handleDirectoryList(request, response) {
+    response.set('Cache-Control', 'no-store');
+    if (request.method !== 'GET') {
+      response.set('Allow', 'GET');
+      response.status(405).json({ error: 'method_not_allowed' });
+      return;
+    }
+    try {
+      const result = await listDirectoryProfiles(db, request.query, options);
+      if (result.status === 200) {
+        response.set('Cache-Control', 'public, max-age=60, s-maxage=60');
+      }
+      response.status(result.status).json(result.body);
+    } catch (error) {
+      console.error('Directory listing failed', {
+        message: error instanceof Error ? error.message : String(error)
+      });
+      response.status(503).json({ error: 'directory_unavailable' });
+    }
+  };
+}

--- a/functions/directory.test.js
+++ b/functions/directory.test.js
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: MIT
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createDirectoryListHandler,
+  listDirectoryProfiles,
+  publicDirectoryProfile
+} from './directory.js';
+
+function handleRecord(handle, overrides = {}) {
+  return {
+    platform: 'twitter',
+    handle,
+    claims: [{ evidence: 'private-evidence' }],
+    activeIdentity: {
+      status: 'verified',
+      pubkey: 'A'.repeat(64),
+      npub: 'npub1incorrect',
+      metadata: {
+        name: 'Alice',
+        nip05: 'alice@example.com',
+        about: 'not-public-here'
+      },
+      lud16: 'do-not-expose@example.com'
+    },
+    ...overrides
+  };
+}
+
+function fakeDatabase(records) {
+  const reads = [];
+  return {
+    reads,
+    collection(name) {
+      const operation = { name };
+      reads.push(operation);
+      return {
+        where(field, operator, value) {
+          operation.filter = [field, operator, value];
+          return this;
+        },
+        orderBy(field) {
+          operation.order = field;
+          return this;
+        },
+        startAfter(cursor) {
+          operation.cursor = cursor;
+          return this;
+        },
+        select(...fields) {
+          operation.fields = fields;
+          return this;
+        },
+        limit(limit) {
+          operation.limit = limit;
+          return this;
+        },
+        async get() {
+          return {
+            docs: Object.entries(records)
+              .filter(
+                ([id, data]) =>
+                  data.activeIdentity?.status === 'verified' &&
+                  (!operation.cursor || id > operation.cursor)
+              )
+              .sort(([a], [b]) => a.localeCompare(b))
+              .slice(0, operation.limit)
+              .map(([id, data]) => ({ id, data: () => data }))
+          };
+        }
+      };
+    }
+  };
+}
+
+test('exposes an allowlist of current identity fields, never evidence or payment data', () => {
+  assert.deepEqual(
+    publicDirectoryProfile('twitter:alice', handleRecord('alice')),
+    {
+      id: 'twitter:alice',
+      platform: 'twitter',
+      handle: 'alice',
+      pubkey: 'a'.repeat(64),
+      verified: true,
+      name: 'Alice',
+      nip05: 'alice@example.com'
+    }
+  );
+});
+
+test('rejects unverified, malformed, mismatched, or unsupported records', () => {
+  const valid = handleRecord('alice');
+  for (const data of [
+    { ...valid, activeIdentity: null },
+    {
+      ...valid,
+      activeIdentity: { ...valid.activeIdentity, status: 'pending' }
+    },
+    {
+      ...valid,
+      activeIdentity: { ...valid.activeIdentity, pubkey: 'bad-key' }
+    },
+    { ...valid, platform: 'youtube' },
+    { ...valid, handle: 'bob' }
+  ]) {
+    assert.equal(publicDirectoryProfile('twitter:alice', data), null);
+  }
+  assert.equal(
+    publicDirectoryProfile('twitter:home', handleRecord('home')),
+    null
+  );
+  assert.equal(publicDirectoryProfile('other:alice', valid), null);
+});
+
+test('handles absent metadata and bounds display fields', () => {
+  const data = handleRecord('alice');
+  delete data.activeIdentity.metadata;
+  assert.equal(publicDirectoryProfile('twitter:alice', data).name, 'alice');
+  assert.equal(publicDirectoryProfile('twitter:alice', data).nip05, '');
+  data.activeIdentity.metadata = {
+    name: 'n'.repeat(120),
+    nip05: 'x'.repeat(300)
+  };
+  assert.equal(publicDirectoryProfile('twitter:alice', data).name.length, 100);
+  assert.equal(publicDirectoryProfile('twitter:alice', data).nip05.length, 255);
+});
+
+test('paginates verified handles without duplicates and finishes with a null cursor', async () => {
+  const db = fakeDatabase({
+    'twitter:alice': handleRecord('alice'),
+    'twitter:bob': handleRecord('bob', {
+      activeIdentity: { status: 'pending' }
+    }),
+    'twitter:carol': handleRecord('carol'),
+    'twitter:dave': handleRecord('dave')
+  });
+  const first = await listDirectoryProfiles(db, { limit: '2' });
+  assert.deepEqual(
+    first.body.profiles.map((p) => p.handle),
+    ['alice', 'carol']
+  );
+  assert.equal(first.body.nextCursor, 'twitter:carol');
+  const second = await listDirectoryProfiles(db, {
+    limit: '2',
+    cursor: first.body.nextCursor
+  });
+  assert.deepEqual(
+    second.body.profiles.map((p) => p.handle),
+    ['dave']
+  );
+  assert.equal(second.body.nextCursor, null);
+  assert.equal(db.reads[0].limit, 3);
+  assert.deepEqual(db.reads[0].filter, [
+    'activeIdentity.status',
+    '==',
+    'verified'
+  ]);
+  assert.equal(db.reads[0].name, 'nostrDirectoryHandles');
+  assert.equal(db.reads[0].fields.includes('claims'), false);
+});
+
+test('advances cursors even when every scanned profile is malformed', async () => {
+  const db = fakeDatabase({
+    'twitter:alice': handleRecord('alice', {
+      activeIdentity: { status: 'verified', pubkey: 'invalid' }
+    }),
+    'twitter:bob': handleRecord('bob')
+  });
+  const result = await listDirectoryProfiles(db, { limit: '1' });
+  assert.deepEqual(result.body.profiles, []);
+  assert.equal(result.body.nextCursor, 'twitter:alice');
+});
+
+test('empty collections are successful and collection overrides stay server controlled', async () => {
+  const db = fakeDatabase({});
+  assert.deepEqual(
+    await listDirectoryProfiles(
+      db,
+      { collection: 'ignored' },
+      { collection: 'testHandles' }
+    ),
+    {
+      status: 200,
+      body: { profiles: [], nextCursor: null }
+    }
+  );
+  assert.equal(db.reads[0].name, 'testHandles');
+  assert.equal(db.reads[0].limit, 51);
+});
+
+test('rejects invalid limits and path-like or non-scalar cursors before reading Firestore', async () => {
+  const db = fakeDatabase({});
+  for (const limit of [
+    '0',
+    '101',
+    '-1',
+    '1.5',
+    '1e2',
+    'abc',
+    '',
+    ['2'],
+    {},
+    2
+  ]) {
+    assert.equal((await listDirectoryProfiles(db, { limit })).status, 400);
+  }
+  for (const cursor of [
+    '',
+    'twitter:alice/claims/secret',
+    '../private',
+    ['twitter:alice'],
+    {},
+    2
+  ]) {
+    assert.equal((await listDirectoryProfiles(db, { cursor })).status, 400);
+  }
+  assert.equal(db.reads.length, 0);
+});
+
+function responseRecorder() {
+  return {
+    headers: {},
+    statusCode: null,
+    body: null,
+    set(name, value) {
+      this.headers[name] = value;
+      return this;
+    },
+    status(value) {
+      this.statusCode = value;
+      return this;
+    },
+    json(value) {
+      this.body = value;
+      return this;
+    }
+  };
+}
+
+test('HTTP handler is read only and caches only successful responses', async () => {
+  const db = fakeDatabase({});
+  const handler = createDirectoryListHandler(db);
+  for (const method of ['POST', 'PUT', 'DELETE', 'PATCH']) {
+    const response = responseRecorder();
+    await handler({ method, query: {} }, response);
+    assert.equal(response.statusCode, 405);
+    assert.equal(response.headers.Allow, 'GET');
+    assert.equal(response.headers['Cache-Control'], 'no-store');
+  }
+  assert.equal(db.reads.length, 0);
+  const response = responseRecorder();
+  await handler({ method: 'GET', query: {} }, response);
+  assert.equal(response.statusCode, 200);
+  assert.equal(
+    response.headers['Cache-Control'],
+    'public, max-age=60, s-maxage=60'
+  );
+  const invalid = responseRecorder();
+  await handler({ method: 'GET', query: { limit: '1000' } }, invalid);
+  assert.equal(invalid.statusCode, 400);
+  assert.equal(invalid.headers['Cache-Control'], 'no-store');
+});
+
+test('Firestore failures return a retryable error without internal details', async (context) => {
+  context.mock.method(console, 'error', () => {});
+  const handler = createDirectoryListHandler({
+    collection() {
+      throw new Error('private-project-details');
+    }
+  });
+  const response = responseRecorder();
+  await handler({ method: 'GET', query: {} }, response);
+  assert.equal(response.statusCode, 503);
+  assert.deepEqual(response.body, { error: 'directory_unavailable' });
+  assert.equal(response.headers['Cache-Control'], 'no-store');
+});

--- a/functions/index.js
+++ b/functions/index.js
@@ -4,6 +4,7 @@ import { initializeApp } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 import { onRequest } from 'firebase-functions/v2/https';
 import { lookupDirectoryHandle as lookupDirectoryRecord } from './lookup.js';
+import { createDirectoryListHandler } from './directory.js';
 
 initializeApp();
 const db = getFirestore();
@@ -40,4 +41,21 @@ export const lookupDirectoryHandle = onRequest(
     timeoutSeconds: 10
   },
   handleDirectoryLookup
+);
+
+export const listDirectoryProfiles = onRequest(
+  {
+    region: 'us-central1',
+    cors: true,
+    invoker: 'public',
+    maxInstances: 10,
+    timeoutSeconds: 10
+  },
+  createDirectoryListHandler(
+    getFirestore(process.env.FIRESTORE_DATABASE || '(default)'),
+    {
+      collection:
+        process.env.FIRESTORE_HANDLES_COLLECTION || 'nostrDirectoryHandles'
+    }
+  )
 );

--- a/functions/package.json
+++ b/functions/package.json
@@ -8,7 +8,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "node lookup.test.js"
+    "test": "node --test *.test.js"
   },
   "dependencies": {
     "firebase-admin": "^13.4.0",


### PR DESCRIPTION
- Added pagination functionality to the profile listing, allowing users to navigate through pages of profiles.
- Introduced new utility functions for pagination and page size selection.
- Updated the UI to include pagination controls and improved accessibility features.
- Enhanced profile rendering logic to accommodate new pagination structure.
- Added new icons for pagination navigation.
- Updated styles for pagination components to improve layout and usability.
- Refactored existing code to support dynamic loading of profiles from an API.
- Implemented error handling and loading states for better user experience.
- Added tests for new directory functions and pagination logic.


https://github.com/user-attachments/assets/a7fb5221-b660-43d4-9aaf-6ed9cd4b2943

tested locally with firestore emulator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a public directory powered by verified profile data.
  - Added search, sorting, category filtering, refresh, and “Load more” controls.
  - Added pagination with selectable page sizes and responsive navigation.
  - Added verification indicators, NIP-05 profile links, audience counts, and local preview labels.
  - Added loading, empty, error, and timeout states.

- **Bug Fixes**
  - Improved handling and display of profiles with unavailable follower counts.
  - Added safeguards against invalid or incomplete directory data.

- **Documentation**
  - Added setup instructions for local development, API configuration, testing, and deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->