### PR TITLE
fix(common): guard formatEventDate against invalid timestamps and unit tests

### DIFF
--- a/src/common/__tests__/date-utils.test.ts
+++ b/src/common/__tests__/date-utils.test.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+import { formatEventDate } from '../date-utils';
+
+describe('formatEventDate', () => {
+  it('formats a valid Unix timestamp in seconds', () => {
+    // 2024-01-15 12:00:00 UTC
+    const timestamp = 1705320000;
+    const expected = new Date(timestamp * 1000).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+    expect(formatEventDate(timestamp)).toBe(expected);
+  });
+
+  it('returns empty string when timestamp is undefined', () => {
+    expect(formatEventDate(undefined)).toBe('');
+    expect(formatEventDate()).toBe('');
+  });
+
+  it('returns empty string when timestamp is null', () => {
+    expect(formatEventDate(null)).toBe('');
+  });
+
+  it('returns empty string when timestamp is 0', () => {
+    expect(formatEventDate(0)).toBe('');
+  });
+
+  it('returns empty string when timestamp is negative', () => {
+    expect(formatEventDate(-1)).toBe('');
+    expect(formatEventDate(-1705320000)).toBe('');
+  });
+
+  it('returns empty string when timestamp is NaN', () => {
+    expect(formatEventDate(NaN)).toBe('');
+  });
+
+  it('returns empty string when timestamp is infinite', () => {
+    expect(formatEventDate(Infinity)).toBe('');
+    expect(formatEventDate(-Infinity)).toBe('');
+  });
+
+  it('returns empty string when timestamp is out of range for valid dates', () => {
+    expect(formatEventDate(1e20)).toBe('');
+  });
+
+  it('returns empty string when input is not a number at runtime', () => {
+    // @ts-expect-error testing invalid runtime argument
+    expect(formatEventDate('1705320000')).toBe('');
+    // @ts-expect-error testing invalid runtime argument
+    expect(formatEventDate({})).toBe('');
+    // @ts-expect-error testing invalid runtime argument
+    expect(formatEventDate([])).toBe('');
+  });
+});

--- a/src/common/date-utils.ts
+++ b/src/common/date-utils.ts
@@ -7,12 +7,19 @@
 /**
  * Formats a Unix timestamp to a readable date string
  * @param createdAt Unix timestamp in seconds
- * @returns Formatted date string (e.g., "Jan 15, 2024")
+ * @returns Formatted date string (e.g., "Jan 15, 2024") or empty string if invalid or non-positive
  */
-export function formatEventDate(createdAt: number | undefined): string {
-  if (createdAt === undefined) return '';
-  
-  return new Date(createdAt * 1000).toLocaleDateString('en-US', {
+export function formatEventDate(createdAt?: number | null): string {
+  if (typeof createdAt !== 'number' || !Number.isFinite(createdAt) || createdAt <= 0) {
+    return '';
+  }
+
+  const date = new Date(createdAt * 1000);
+  if (isNaN(date.getTime())) {
+    return '';
+  }
+
+  return date.toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
     year: 'numeric',


### PR DESCRIPTION
### What This Does

Guards `formatEventDate` against non-finite, negative, zero, or `null` timestamps that cause UI components to render `"Invalid Date"` or Unix epoch dates (`Dec 31, 1969` / `Jan 1, 1970`), and introduces a comprehensive unit test suite.

### Root Cause / Why It Was a Bug

1. `src/common/date-utils.ts` only checked for `createdAt === undefined`. If an event payload contains `null` or `0`, JavaScript evaluates `0 * 1000 = 0`, resulting in `"Dec 31, 1969"` or `"Jan 1, 1970"` in the UI.
2. If `createdAt` is `NaN` or unparseable, `new Date(NaN)` fails and prints `"Invalid Date"` on screen.
3. `date-utils.ts` had no unit tests covering formatting or edge cases.

### Changes

- **`src/common/date-utils.ts`** - Guard against non-number, non-finite, non-positive (`<= 0`), and unparseable dates; permit `null` in parameter type.
- **`src/common/__tests__/date-utils.test.ts`** - New unit test suite covering valid timestamps, `undefined`, `null`, `0`, negative numbers, `NaN`, `Infinity`, out-of-range dates, and non-number runtime types.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event date handling for missing, invalid, or out-of-range timestamps.
  - Prevented incorrect dates from appearing when date values are zero, negative, non-finite, or otherwise invalid.
  - Missing date values now display consistently without causing formatting issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->